### PR TITLE
fix: Sign embedded merod binary for macOS notarization

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -393,8 +393,11 @@ jobs:
             # Use absolute path for the tar file
             ABS_TAR_PATH="$(cd "$BUNDLE_DIR" && pwd)/$(basename "$TAR_PATH")"
             pnpm tauri signer sign "$ABS_TAR_PATH" || {
-              echo "Warning: Failed to regenerate signature file (this may be expected if signer is not configured)"
+              echo "Error: Failed to regenerate signature file for updater archive"
+              echo "TAURI_PRIVATE_KEY is configured, so signing should succeed. This is a critical error."
+              exit 1
             }
+            echo "Successfully regenerated signature file: ${ABS_TAR_PATH}.sig"
           else
             echo "TAURI_PRIVATE_KEY not available, skipping signature regeneration"
           fi

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -324,8 +324,10 @@ jobs:
           TARGET_DIR=$(dirname "$BUNDLE_DIR")
           DMG_DIR="$BUNDLE_DIR/dmg"
           
-          # Save original working directory for later use
+          # Save original working directory and compute absolute paths
           ORIGINAL_DIR="$(pwd)"
+          ABS_BUNDLE_DIR="$(cd "$BUNDLE_DIR" && pwd)"
+          ABS_APP_BUNDLE="$(cd "$(dirname "$APP_BUNDLE")" && pwd)/$(basename "$APP_BUNDLE")"
 
           echo "Recreating DMG and updater archive from signed app bundle: $APP_BUNDLE"
 
@@ -374,24 +376,23 @@ jobs:
           # Recreate .app.tar.gz for auto-updater
           echo "Creating new .app.tar.gz archive from signed app bundle..."
           TAR_NAME="${APP_NAME}_${VERSION}_universal.app.tar.gz"
-          TAR_PATH="$BUNDLE_DIR/$TAR_NAME"
+          ABS_TAR_PATH="$ABS_BUNDLE_DIR/$TAR_NAME"
           
-          cd "$BUNDLE_DIR"
-          tar -czf "$TAR_PATH" -C "$(dirname "$APP_BUNDLE")" "$(basename "$APP_BUNDLE")" || {
+          # Create tar archive using absolute paths to avoid issues after cd
+          tar -czf "$ABS_TAR_PATH" -C "$(dirname "$ABS_APP_BUNDLE")" "$(basename "$ABS_APP_BUNDLE")" || {
             echo "Failed to create .app.tar.gz"
             exit 1
           }
 
-          echo "Successfully created updater archive: $TAR_PATH"
+          echo "Successfully created updater archive: $ABS_TAR_PATH"
 
           # Regenerate signature file for the updater archive
           # Tauri's build process creates this, but we need to recreate it after rebuilding the archive
           if [ -n "$TAURI_PRIVATE_KEY" ]; then
             echo "Regenerating signature for updater archive..."
-            # Return to original directory before changing to apps/desktop
+            # Change to apps/desktop directory (using absolute path from original dir)
             cd "$ORIGINAL_DIR/apps/desktop"
-            # Use absolute path for the tar file
-            ABS_TAR_PATH="$(cd "$BUNDLE_DIR" && pwd)/$(basename "$TAR_PATH")"
+            # ABS_TAR_PATH is already computed as absolute path above
             pnpm tauri signer sign "$ABS_TAR_PATH" || {
               echo "Error: Failed to regenerate signature file for updater archive"
               echo "TAURI_PRIVATE_KEY is configured, so signing should succeed. This is a critical error."

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -299,6 +299,102 @@ jobs:
           
           echo "All binaries in app bundle are signed"
 
+      - name: Recreate DMG and updater archive after signing
+        if: steps.build-mode.outputs.mode == 'release' && steps.build-app-release.outputs.is_signed == 'true'
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+        run: |
+          if [ -z "$APPLE_SIGNING_IDENTITY" ]; then
+            echo "No signing identity provided, skipping archive recreation"
+            exit 0
+          fi
+
+          # Find the signed .app bundle
+          APP_BUNDLE=$(find apps/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos -name "*.app" -type d | head -1)
+          
+          if [ -z "$APP_BUNDLE" ]; then
+            echo "No .app bundle found"
+            exit 1
+          fi
+
+          APP_NAME=$(basename "$APP_BUNDLE" .app)
+          BUNDLE_DIR=$(dirname "$APP_BUNDLE")
+          TARGET_DIR=$(dirname "$BUNDLE_DIR")
+          DMG_DIR="$BUNDLE_DIR/dmg"
+
+          echo "Recreating DMG and updater archive from signed app bundle: $APP_BUNDLE"
+
+          # Find and remove old DMG and .app.tar.gz files
+          echo "Removing old DMG and archive files..."
+          find "$TARGET_DIR" -name "*.dmg" -delete
+          find "$TARGET_DIR" -name "*.app.tar.gz" -delete
+          find "$TARGET_DIR" -name "*.app.tar.gz.sig" -delete
+
+          # Recreate DMG from signed .app bundle
+          # Tauri creates DMG with format: "Product Name_version_universal.dmg"
+          # We'll use the same format but need to get the version
+          VERSION="${{ steps.build-mode.outputs.version }}"
+          DMG_NAME="${APP_NAME}_${VERSION}_universal.dmg"
+          DMG_PATH="$DMG_DIR/$DMG_NAME"
+          
+          mkdir -p "$DMG_DIR"
+          
+          # Create DMG using hdiutil
+          hdiutil create -volname "$APP_NAME" \
+            -srcfolder "$APP_BUNDLE" \
+            -ov -format UDZO \
+            "$DMG_PATH" || {
+            echo "Failed to create DMG"
+            exit 1
+          }
+
+          # Sign the DMG
+          echo "Signing DMG..."
+          codesign --force --sign "$APPLE_SIGNING_IDENTITY" \
+            --options runtime \
+            --timestamp \
+            "$DMG_PATH" || {
+            echo "Failed to sign DMG"
+            exit 1
+          }
+
+          # Verify DMG signature
+          codesign --verify --verbose "$DMG_PATH" || {
+            echo "Failed to verify DMG signature"
+            exit 1
+          }
+
+          echo "Successfully created and signed DMG: $DMG_PATH"
+
+          # Recreate .app.tar.gz for auto-updater
+          echo "Creating new .app.tar.gz archive from signed app bundle..."
+          TAR_NAME="${APP_NAME}_${VERSION}_universal.app.tar.gz"
+          TAR_PATH="$BUNDLE_DIR/$TAR_NAME"
+          
+          cd "$BUNDLE_DIR"
+          tar -czf "$TAR_PATH" -C "$(dirname "$APP_BUNDLE")" "$(basename "$APP_BUNDLE")" || {
+            echo "Failed to create .app.tar.gz"
+            exit 1
+          }
+
+          echo "Successfully created updater archive: $TAR_PATH"
+
+          # Regenerate signature file for the updater archive
+          # Tauri's build process creates this, but we need to recreate it after rebuilding the archive
+          if [ -n "$TAURI_PRIVATE_KEY" ]; then
+            echo "Regenerating signature for updater archive..."
+            cd apps/desktop
+            # Use absolute path for the tar file
+            ABS_TAR_PATH="$(cd "$BUNDLE_DIR" && pwd)/$(basename "$TAR_PATH")"
+            pnpm tauri signer sign "$ABS_TAR_PATH" || {
+              echo "Warning: Failed to regenerate signature file (this may be expected if signer is not configured)"
+            }
+          else
+            echo "TAURI_PRIVATE_KEY not available, skipping signature regeneration"
+          fi
+
       - name: Cleanup keychain
         if: always() && steps.build-mode.outputs.mode == 'release'
         run: security delete-keychain build.keychain 2>/dev/null || true

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -323,6 +323,9 @@ jobs:
           BUNDLE_DIR=$(dirname "$APP_BUNDLE")
           TARGET_DIR=$(dirname "$BUNDLE_DIR")
           DMG_DIR="$BUNDLE_DIR/dmg"
+          
+          # Save original working directory for later use
+          ORIGINAL_DIR="$(pwd)"
 
           echo "Recreating DMG and updater archive from signed app bundle: $APP_BUNDLE"
 
@@ -385,7 +388,8 @@ jobs:
           # Tauri's build process creates this, but we need to recreate it after rebuilding the archive
           if [ -n "$TAURI_PRIVATE_KEY" ]; then
             echo "Regenerating signature for updater archive..."
-            cd apps/desktop
+            # Return to original directory before changing to apps/desktop
+            cd "$ORIGINAL_DIR/apps/desktop"
             # Use absolute path for the tar file
             ABS_TAR_PATH="$(cd "$BUNDLE_DIR" && pwd)/$(basename "$TAR_PATH")"
             pnpm tauri signer sign "$ABS_TAR_PATH" || {

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -228,6 +228,77 @@ jobs:
           echo "is_signed=false" >> $GITHUB_OUTPUT
           pnpm tauri build --target universal-apple-darwin
 
+      - name: Sign embedded binaries
+        if: steps.build-mode.outputs.mode == 'release' && steps.build-app-release.outputs.is_signed == 'true'
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          if [ -z "$APPLE_SIGNING_IDENTITY" ]; then
+            echo "No signing identity provided, skipping embedded binary signing"
+            exit 0
+          fi
+
+          # Find the .app bundle
+          APP_BUNDLE=$(find apps/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos -name "*.app" -type d | head -1)
+          
+          if [ -z "$APP_BUNDLE" ]; then
+            echo "No .app bundle found"
+            exit 1
+          fi
+
+          echo "Found app bundle: $APP_BUNDLE"
+
+          # Sign the merod binary if it exists
+          MEROD_BINARY="$APP_BUNDLE/Contents/Resources/merod/merod"
+          
+          if [ -f "$MEROD_BINARY" ]; then
+            echo "Signing merod binary: $MEROD_BINARY"
+            codesign --force --deep --sign "$APPLE_SIGNING_IDENTITY" \
+              --options runtime \
+              --timestamp \
+              "$MEROD_BINARY"
+            
+            # Verify the signature
+            codesign --verify --verbose "$MEROD_BINARY" || {
+              echo "Failed to verify merod binary signature"
+              exit 1
+            }
+            echo "Successfully signed merod binary"
+          else
+            echo "Warning: merod binary not found at $MEROD_BINARY"
+          fi
+
+          # Re-sign the entire app bundle to update the code signature
+          # This is necessary because signing embedded binaries invalidates the app's signature
+          echo "Re-signing app bundle..."
+          codesign --force --deep --sign "$APPLE_SIGNING_IDENTITY" \
+            --options runtime \
+            --timestamp \
+            --entitlements "$APP_BUNDLE/Contents/Resources/entitlements.plist" \
+            "$APP_BUNDLE" 2>/dev/null || \
+          codesign --force --deep --sign "$APPLE_SIGNING_IDENTITY" \
+            --options runtime \
+            --timestamp \
+            "$APP_BUNDLE"
+
+          # Verify the app bundle signature
+          codesign --verify --verbose "$APP_BUNDLE" || {
+            echo "Failed to verify app bundle signature"
+            exit 1
+          }
+          
+          # Check for any unsigned binaries
+          echo "Checking for unsigned binaries in app bundle..."
+          UNSIGNED=$(find "$APP_BUNDLE" -type f -exec sh -c 'codesign --verify "$1" 2>&1 | grep -q "code object is not signed" && echo "$1"' _ {} \;)
+          
+          if [ -n "$UNSIGNED" ]; then
+            echo "Error: Found unsigned binaries:"
+            echo "$UNSIGNED"
+            exit 1
+          fi
+          
+          echo "All binaries in app bundle are signed"
+
       - name: Cleanup keychain
         if: always() && steps.build-mode.outputs.mode == 'release'
         run: security delete-keychain build.keychain 2>/dev/null || true


### PR DESCRIPTION
## Problem

The macOS notarization was failing with status "Invalid" because the embedded `merod` binary in the app bundle was not signed. Apple requires all binaries in a notarized app to be signed.

## Solution

Added a new step in the build workflow that:
1. Signs the `merod` binary located at `Contents/Resources/merod/merod` in the app bundle
2. Re-signs the entire app bundle (required after signing embedded binaries)
3. Verifies all signatures and checks for any unsigned binaries before notarization

## Changes

- Added "Sign embedded binaries" step after build and before notarization
- Signs merod binary with the same signing identity as the app
- Re-signs app bundle to ensure signature is valid
- Verifies all binaries are signed before proceeding to notarization

## Testing

This should fix the notarization failure. The workflow will now ensure all binaries are properly signed before submitting for notarization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens macOS release workflow to ensure all binaries and artifacts are signed and notarizable.
> 
> - Adds `Sign embedded binaries` step to sign `Contents/Resources/merod/merod`, then re-signs the app bundle (with entitlements fallback) and verifies signatures; fails on any unsigned binaries
> - Adds `Recreate DMG and updater archive after signing` to rebuild DMG via `hdiutil`, sign and verify it, recreate `.app.tar.gz`, and regenerate its `.sig` with Tauri signer; removes stale DMGs/archives first
> - Steps run only for signed release builds; preserves existing notarization and artifact upload flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fd46ff1480c9a148fd5688feb5751b4d53a3ab4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->