### PR TITLE
fix: only check actual Mach-O binaries for signing, not resource files 

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -393,8 +393,11 @@ jobs:
             # Use absolute path for the tar file
             ABS_TAR_PATH="$(cd "$BUNDLE_DIR" && pwd)/$(basename "$TAR_PATH")"
             pnpm tauri signer sign "$ABS_TAR_PATH" || {
-              echo "Warning: Failed to regenerate signature file (this may be expected if signer is not configured)"
+              echo "Error: Failed to regenerate signature file for updater archive"
+              echo "TAURI_PRIVATE_KEY is configured, so signing should succeed. This is a critical error."
+              exit 1
             }
+            echo "Successfully regenerated signature file: ${ABS_TAR_PATH}.sig"
           else
             echo "TAURI_PRIVATE_KEY not available, skipping signature regeneration"
           fi

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -324,8 +324,10 @@ jobs:
           TARGET_DIR=$(dirname "$BUNDLE_DIR")
           DMG_DIR="$BUNDLE_DIR/dmg"
           
-          # Save original working directory for later use
+          # Save original working directory and compute absolute paths
           ORIGINAL_DIR="$(pwd)"
+          ABS_BUNDLE_DIR="$(cd "$BUNDLE_DIR" && pwd)"
+          ABS_APP_BUNDLE="$(cd "$(dirname "$APP_BUNDLE")" && pwd)/$(basename "$APP_BUNDLE")"
 
           echo "Recreating DMG and updater archive from signed app bundle: $APP_BUNDLE"
 
@@ -374,24 +376,23 @@ jobs:
           # Recreate .app.tar.gz for auto-updater
           echo "Creating new .app.tar.gz archive from signed app bundle..."
           TAR_NAME="${APP_NAME}_${VERSION}_universal.app.tar.gz"
-          TAR_PATH="$BUNDLE_DIR/$TAR_NAME"
+          ABS_TAR_PATH="$ABS_BUNDLE_DIR/$TAR_NAME"
           
-          cd "$BUNDLE_DIR"
-          tar -czf "$TAR_PATH" -C "$(dirname "$APP_BUNDLE")" "$(basename "$APP_BUNDLE")" || {
+          # Create tar archive using absolute paths to avoid issues after cd
+          tar -czf "$ABS_TAR_PATH" -C "$(dirname "$ABS_APP_BUNDLE")" "$(basename "$ABS_APP_BUNDLE")" || {
             echo "Failed to create .app.tar.gz"
             exit 1
           }
 
-          echo "Successfully created updater archive: $TAR_PATH"
+          echo "Successfully created updater archive: $ABS_TAR_PATH"
 
           # Regenerate signature file for the updater archive
           # Tauri's build process creates this, but we need to recreate it after rebuilding the archive
           if [ -n "$TAURI_PRIVATE_KEY" ]; then
             echo "Regenerating signature for updater archive..."
-            # Return to original directory before changing to apps/desktop
+            # Change to apps/desktop directory (using absolute path from original dir)
             cd "$ORIGINAL_DIR/apps/desktop"
-            # Use absolute path for the tar file
-            ABS_TAR_PATH="$(cd "$BUNDLE_DIR" && pwd)/$(basename "$TAR_PATH")"
+            # ABS_TAR_PATH is already computed as absolute path above
             pnpm tauri signer sign "$ABS_TAR_PATH" || {
               echo "Error: Failed to regenerate signature file for updater archive"
               echo "TAURI_PRIVATE_KEY is configured, so signing should succeed. This is a critical error."

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -323,6 +323,9 @@ jobs:
           BUNDLE_DIR=$(dirname "$APP_BUNDLE")
           TARGET_DIR=$(dirname "$BUNDLE_DIR")
           DMG_DIR="$BUNDLE_DIR/dmg"
+          
+          # Save original working directory for later use
+          ORIGINAL_DIR="$(pwd)"
 
           echo "Recreating DMG and updater archive from signed app bundle: $APP_BUNDLE"
 
@@ -385,7 +388,8 @@ jobs:
           # Tauri's build process creates this, but we need to recreate it after rebuilding the archive
           if [ -n "$TAURI_PRIVATE_KEY" ]; then
             echo "Regenerating signature for updater archive..."
-            cd apps/desktop
+            # Return to original directory before changing to apps/desktop
+            cd "$ORIGINAL_DIR/apps/desktop"
             # Use absolute path for the tar file
             ABS_TAR_PATH="$(cd "$BUNDLE_DIR" && pwd)/$(basename "$TAR_PATH")"
             pnpm tauri signer sign "$ABS_TAR_PATH" || {

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -323,11 +323,6 @@ jobs:
           BUNDLE_DIR=$(dirname "$APP_BUNDLE")
           TARGET_DIR=$(dirname "$BUNDLE_DIR")
           DMG_DIR="$BUNDLE_DIR/dmg"
-          
-          # Save original working directory and compute absolute paths
-          ORIGINAL_DIR="$(pwd)"
-          ABS_BUNDLE_DIR="$(cd "$BUNDLE_DIR" && pwd)"
-          ABS_APP_BUNDLE="$(cd "$(dirname "$APP_BUNDLE")" && pwd)/$(basename "$APP_BUNDLE")"
 
           echo "Recreating DMG and updater archive from signed app bundle: $APP_BUNDLE"
 
@@ -376,29 +371,26 @@ jobs:
           # Recreate .app.tar.gz for auto-updater
           echo "Creating new .app.tar.gz archive from signed app bundle..."
           TAR_NAME="${APP_NAME}_${VERSION}_universal.app.tar.gz"
-          ABS_TAR_PATH="$ABS_BUNDLE_DIR/$TAR_NAME"
+          TAR_PATH="$BUNDLE_DIR/$TAR_NAME"
           
-          # Create tar archive using absolute paths to avoid issues after cd
-          tar -czf "$ABS_TAR_PATH" -C "$(dirname "$ABS_APP_BUNDLE")" "$(basename "$ABS_APP_BUNDLE")" || {
+          cd "$BUNDLE_DIR"
+          tar -czf "$TAR_PATH" -C "$(dirname "$APP_BUNDLE")" "$(basename "$APP_BUNDLE")" || {
             echo "Failed to create .app.tar.gz"
             exit 1
           }
 
-          echo "Successfully created updater archive: $ABS_TAR_PATH"
+          echo "Successfully created updater archive: $TAR_PATH"
 
           # Regenerate signature file for the updater archive
           # Tauri's build process creates this, but we need to recreate it after rebuilding the archive
           if [ -n "$TAURI_PRIVATE_KEY" ]; then
             echo "Regenerating signature for updater archive..."
-            # Change to apps/desktop directory (using absolute path from original dir)
-            cd "$ORIGINAL_DIR/apps/desktop"
-            # ABS_TAR_PATH is already computed as absolute path above
+            cd apps/desktop
+            # Use absolute path for the tar file
+            ABS_TAR_PATH="$(cd "$BUNDLE_DIR" && pwd)/$(basename "$TAR_PATH")"
             pnpm tauri signer sign "$ABS_TAR_PATH" || {
-              echo "Error: Failed to regenerate signature file for updater archive"
-              echo "TAURI_PRIVATE_KEY is configured, so signing should succeed. This is a critical error."
-              exit 1
+              echo "Warning: Failed to regenerate signature file (this may be expected if signer is not configured)"
             }
-            echo "Successfully regenerated signature file: ${ABS_TAR_PATH}.sig"
           else
             echo "TAURI_PRIVATE_KEY not available, skipping signature regeneration"
           fi

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -287,17 +287,27 @@ jobs:
             exit 1
           }
           
-          # Check for any unsigned binaries
-          echo "Checking for unsigned binaries in app bundle..."
-          UNSIGNED=$(find "$APP_BUNDLE" -type f -exec sh -c 'codesign --verify "$1" 2>&1 | grep -q "code object is not signed" && echo "$1"' _ {} \;)
+          # Check for any unsigned executable binaries
+          # Only check actual executables and libraries, not resource files (icons, plists, etc.)
+          echo "Checking for unsigned executable binaries in app bundle..."
+          # Find all potential binaries (executables, dylibs) excluding known resource files
+          UNSIGNED=$(find "$APP_BUNDLE" -type f \
+            \( -perm +111 -o -name "*.dylib" -o -name "*.so" \) \
+            ! -path "*/_CodeSignature/*" \
+            ! -name "*.icns" \
+            ! -name "*.png" \
+            ! -name "*.plist" \
+            ! -name "*.json" \
+            ! -name "*.txt" \
+            -exec sh -c 'if file "$1" | grep -q "Mach-O"; then codesign --verify "$1" 2>&1 | grep -q "code object is not signed" && echo "$1"; fi' _ {} \;)
           
           if [ -n "$UNSIGNED" ]; then
-            echo "Error: Found unsigned binaries:"
+            echo "Error: Found unsigned executable binaries:"
             echo "$UNSIGNED"
             exit 1
           fi
           
-          echo "All binaries in app bundle are signed"
+          echo "All executable binaries in app bundle are signed"
 
       - name: Recreate DMG and updater archive after signing
         if: steps.build-mode.outputs.mode == 'release' && steps.build-app-release.outputs.is_signed == 'true'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves signing verification in `build-macos.yml` to avoid false positives from resource files.
> 
> - `find` now targets only executable files and libraries (`-perm +111`, `*.dylib`, `*.so`) and confirms they are Mach‑O via `file` before checking `codesign`
> - Excludes common resource types and signature paths (`*.icns`, `*.png`, `*.plist`, `*.json`, `*.txt`, `*/_CodeSignature/*`)
> - Updates log messages to clarify checks are for executable binaries only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e1b70578f0f4b2377b69ca59275d593c6e3b21c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->