### PR TITLE
fix: use -k flag to pass TAURI_PRIVATE_KEY directly to tauri signer

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -396,21 +396,30 @@ jobs:
 
           echo "Successfully created updater archive: $ABS_TAR_PATH"
 
-          # Regenerate signature file for the updater archive
-          # Tauri's build process creates this, but we need to recreate it after rebuilding the archive
+          # Sign the archive using Tauri signer
+          # Tauri's build process normally signs during build, but since we recreated the archive
+          # after signing embedded binaries, we need to sign it manually
           if [ -n "$TAURI_PRIVATE_KEY" ]; then
-            echo "Regenerating signature for updater archive..."
+            echo "Signing updater archive..."
             # Change to apps/desktop directory (using absolute path from original dir)
             cd "$ORIGINAL_DIR/apps/desktop"
-            # ABS_TAR_PATH is already computed as absolute path above
-            pnpm tauri signer sign "$ABS_TAR_PATH" || {
-              echo "Error: Failed to regenerate signature file for updater archive"
-              echo "TAURI_PRIVATE_KEY is configured, so signing should succeed. This is a critical error."
-              exit 1
-            }
-            echo "Successfully regenerated signature file: ${ABS_TAR_PATH}.sig"
+            # Use -k flag to pass private key directly as string
+            if [ -n "$TAURI_KEY_PASSWORD" ]; then
+              pnpm tauri signer sign "$ABS_TAR_PATH" -k "$TAURI_PRIVATE_KEY" -p "$TAURI_KEY_PASSWORD" || {
+                echo "Error: Failed to sign updater archive"
+                echo "TAURI_PRIVATE_KEY is configured, so signing should succeed. This is a critical error."
+                exit 1
+              }
+            else
+              pnpm tauri signer sign "$ABS_TAR_PATH" -k "$TAURI_PRIVATE_KEY" || {
+                echo "Error: Failed to sign updater archive"
+                echo "TAURI_PRIVATE_KEY is configured, so signing should succeed. This is a critical error."
+                exit 1
+              }
+            fi
+            echo "Successfully signed updater archive: ${ABS_TAR_PATH}.sig"
           else
-            echo "TAURI_PRIVATE_KEY not available, skipping signature regeneration"
+            echo "TAURI_PRIVATE_KEY not available, skipping archive signing"
           fi
 
       - name: Cleanup keychain


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures the updater archive is correctly signed after re-signing embedded binaries in the macOS build.
> 
> - In `.github/workflows/build-macos.yml`, replace signature regeneration with explicit signing of the recreated `.app.tar.gz` via `pnpm tauri signer sign "$ABS_TAR_PATH" -k "$TAURI_PRIVATE_KEY"` and optional `-p "$TAURI_KEY_PASSWORD"`
> - Adjusts logging and skip message when `TAURI_PRIVATE_KEY` is missing; no other workflow steps changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7546d521586d5ecd24e07be94407037ad4078d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->