### PR TITLE
fix: auth proxy + multiple node support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ target/
 **/src-tauri/target
 **/src-tauri/Cargo.lock
 **/src-tauri/gen
-**/src-tauri/merod
 
 # Environment variables
 .env

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.15"
+    "version": "0.0.16"
   },
   "tauri": {
     "allowlist": {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { createClient, apiClient, LoginView, getAccessToken } from "@calimero-network/mero-react";
+import { createClient, apiClient, LoginView, getAccessToken, clearAccessToken, clearRefreshToken } from "@calimero-network/mero-react";
 import { getSettings, getAuthUrl, saveSettings } from "./utils/settings";
 import { clearOnboardingProgress } from "./utils/onboardingProgress";
 import { startMerod, detectRunningMerodNodes, type RunningMerodNode } from "./utils/merod";
@@ -50,6 +50,12 @@ function App() {
 
   const handleSelectNode = useCallback((nodeUrl: string) => {
     const settings = getSettings();
+    if (settings.nodeUrl !== nodeUrl) {
+      // Clear auth tokens — old tokens are invalid for the new node
+      clearAccessToken();
+      clearRefreshToken();
+      localStorage.removeItem('calimero-auth-tokens');
+    }
     saveSettings({ ...settings, nodeUrl });
     window.location.reload();
   }, []);

--- a/apps/desktop/src/pages/Nodes.tsx
+++ b/apps/desktop/src/pages/Nodes.tsx
@@ -12,6 +12,7 @@ import {
 } from "../utils/merod";
 import { invoke } from "@tauri-apps/api/tauri";
 import { getSettings, saveSettings } from "../utils/settings";
+import { clearAccessToken, clearRefreshToken } from "@calimero-network/mero-react";
 import { useToast } from "../contexts/ToastContext";
 import "./Nodes.css";
 
@@ -206,6 +207,14 @@ export default function Nodes({ onBack }: NodesProps) {
     try {
       const nodeUrl = `http://localhost:${node.port}`;
       const settings = getSettings();
+
+      // Clear auth tokens when switching nodes — old tokens are invalid
+      if (settings.nodeUrl !== nodeUrl) {
+        clearAccessToken();
+        clearRefreshToken();
+        localStorage.removeItem('calimero-auth-tokens');
+      }
+
       saveSettings({
         ...settings,
         nodeUrl,

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,0 +1,4 @@
+{
+    "name": "merod binary",
+    "version": "430df052"
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build:mero-react": "pnpm --filter @calimero-network/mero-react build",
     "dev": "pnpm build:mero-js && pnpm build:mero-react && pnpm dev:desktop",
     "build": "pnpm build:mero-js && pnpm build:mero-react && pnpm build:desktop",
-    "clean": "pnpm -r clean && rm -rf node_modules"
+    "clean": "pnpm -r clean && rm -rf node_modules",
+    "check-runners": "ps aux | grep merod"
   },
   "devDependencies": {
     "typescript": "^5.8.3"

--- a/uninstall-mac.sh
+++ b/uninstall-mac.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Uninstall script for Calimero Desktop (Tauri app) on macOS
+# Removes the installed app and all associated data/caches
+
+set -e
+
+APP_NAME="Calimero Desktop"
+BUNDLE_ID="network.calimero.desktop"
+
+echo "=== Uninstalling $APP_NAME ==="
+
+# Kill the app if running
+if pgrep -f "$APP_NAME" > /dev/null 2>&1; then
+    echo "Stopping $APP_NAME..."
+    pkill -f "$APP_NAME" || true
+    sleep 1
+fi
+
+REMOVED=0
+
+# Remove from /Applications
+if [ -d "/Applications/${APP_NAME}.app" ]; then
+    echo "Removing /Applications/${APP_NAME}.app"
+    rm -rf "/Applications/${APP_NAME}.app"
+    REMOVED=1
+fi
+
+# Remove from ~/Applications
+if [ -d "$HOME/Applications/${APP_NAME}.app" ]; then
+    echo "Removing ~/Applications/${APP_NAME}.app"
+    rm -rf "$HOME/Applications/${APP_NAME}.app"
+    REMOVED=1
+fi
+
+# Tauri app data & config directories
+DIRS_TO_REMOVE=(
+    "$HOME/Library/Application Support/${BUNDLE_ID}"
+    "$HOME/Library/Application Support/${APP_NAME}"
+    "$HOME/Library/Caches/${BUNDLE_ID}"
+    "$HOME/Library/Caches/${APP_NAME}"
+    "$HOME/Library/Preferences/${BUNDLE_ID}.plist"
+    "$HOME/Library/Saved Application State/${BUNDLE_ID}.savedState"
+    "$HOME/Library/WebKit/${BUNDLE_ID}"
+    "$HOME/Library/Logs/${BUNDLE_ID}"
+)
+
+for dir in "${DIRS_TO_REMOVE[@]}"; do
+    if [ -e "$dir" ]; then
+        echo "Removing $dir"
+        rm -rf "$dir"
+        REMOVED=1
+    fi
+done
+
+# Clean build artifacts in this repo
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUILD_DIRS=(
+    "$SCRIPT_DIR/apps/desktop/src-tauri/target"
+    "$SCRIPT_DIR/apps/desktop/dist"
+)
+
+for dir in "${BUILD_DIRS[@]}"; do
+    if [ -d "$dir" ]; then
+        echo "Removing build artifacts: $dir"
+        rm -rf "$dir"
+        REMOVED=1
+    fi
+done
+
+if [ "$REMOVED" -eq 0 ]; then
+    echo "Nothing found to remove."
+else
+    echo ""
+    echo "=== $APP_NAME has been uninstalled ==="
+fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Expands what localhost traffic is eligible for proxying and changes node-selection behavior (auto port selection + forced reloads), which could affect connectivity and security assumptions if URL validation has gaps.
> 
> **Overview**
> Updates the desktop app’s Tauri proxying so **any** `http://localhost:*` / `127.0.0.1:*` request can be proxied (instead of only `:2528`), with simplified validation messaging and updated tests to reflect the broader allowance.
> 
> Improves multi-node UX by auto-bumping ports to avoid conflicts when starting nodes, auto-switching the app’s configured `nodeUrl` to the newly started node, and **clearing access/refresh tokens** (plus local storage token cache) whenever the node URL changes to avoid invalid auth.
> 
> Includes a desktop version bump to `0.0.16`, adds a `check-runners` script, introduces `merod-config.json`, and adds a macOS uninstaller script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f92ea67eb9a49b93e36086b0a1cc314d2a30668e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->