### PR TITLE
feat: add debug logs

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -211,11 +211,14 @@ jobs:
 
           MEROD_BINARY="apps/desktop/src-tauri/merod/merod"
           
+          ENTITLEMENTS="apps/desktop/src-tauri/merod.entitlements.plist"
+
           if [ -f "$MEROD_BINARY" ]; then
             echo "Signing merod binary before bundling: $MEROD_BINARY"
             codesign --force --sign "$APPLE_SIGNING_IDENTITY" \
               --options runtime \
               --timestamp \
+              --entitlements "$ENTITLEMENTS" \
               "$MEROD_BINARY"
             
             codesign --verify --verbose "$MEROD_BINARY" || {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/entitlements.plist
+++ b/apps/desktop/src-tauri/entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/merod.entitlements.plist
+++ b/apps/desktop/src-tauri/merod.entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -601,6 +601,7 @@ async fn start_merod(
     swarm_port: Option<u16>,
     data_dir: Option<String>,
     node_name: Option<String>,
+    debug_logs: Option<bool>,
     app_handle: tauri::AppHandle,
     merod_state: tauri::State<'_, MerodState>,
 ) -> Result<String, String> {
@@ -784,6 +785,13 @@ async fn start_merod(
     // Force ANSI colors in output so the log viewer can display them
     cmd.env("CLICOLOR_FORCE", "1");
     cmd.env("FORCE_COLOR", "1");
+    // Set log level based on debug_logs setting
+    if debug_logs.unwrap_or(false) {
+        cmd.env("RUST_LOG", "debug");
+        info!("[Merod] Debug logging enabled");
+    } else {
+        cmd.env("RUST_LOG", "info");
+    }
     
     // Set home directory (global option, before subcommand)
     cmd.arg("--home").arg(&home_dir_path);

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.16"
+    "version": "0.0.17"
   },
   "tauri": {
     "allowlist": {
@@ -80,7 +80,7 @@
         "merod/merod"
       ],
       "macOS": {
-        "entitlements": null,
+        "entitlements": "entitlements.plist",
         "exceptionDomain": "",
         "frameworks": [],
         "providerShortName": null,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -166,7 +166,7 @@ function App() {
           const serverPort = settings.embeddedNodePort ?? 2528;
           const swarmPort = 2428; // default swarm port
           try {
-            await startMerod(serverPort, swarmPort, dataDir, settings.embeddedNodeName);
+            await startMerod(serverPort, swarmPort, dataDir, settings.embeddedNodeName, settings.debugLogs);
             await new Promise((r) => setTimeout(r, 4000)); // give merod time to start (longer when app launches at login)
             runningNodes = await detectRunningMerodNodes();
             setRunningNodes(runningNodes);
@@ -321,7 +321,7 @@ function App() {
       try {
         const dataDir = settings.embeddedNodeDataDir || '~/.calimero';
         const serverPort = settings.embeddedNodePort ?? 2528;
-        await startMerod(serverPort, 2428, dataDir, settings.embeddedNodeName);
+        await startMerod(serverPort, 2428, dataDir, settings.embeddedNodeName, settings.debugLogs);
         toast.success("Starting node...");
         await new Promise((r) => setTimeout(r, 3000));
         await checkConnection();

--- a/apps/desktop/src/pages/NodeManagement.tsx
+++ b/apps/desktop/src/pages/NodeManagement.tsx
@@ -165,7 +165,7 @@ export default function NodeManagement() {
 
     setLoading(true);
     try {
-      await startMerod(portToUse, swarmToUse, homeDir, selectedNode);
+      await startMerod(portToUse, swarmToUse, homeDir, selectedNode, getSettings().debugLogs);
       toast.success(`Node "${selectedNode}" started successfully`);
       await detectRunning();
 

--- a/apps/desktop/src/pages/Nodes.tsx
+++ b/apps/desktop/src/pages/Nodes.tsx
@@ -168,7 +168,7 @@ export default function Nodes({ onBack }: NodesProps) {
     
     setLoading(true);
     try {
-      await startMerod(serverPort, swarmPort, homeDir, selectedNode);
+      await startMerod(serverPort, swarmPort, homeDir, selectedNode, getSettings().debugLogs);
       await checkStatus();
       await detectRunning();
       toast.success(`Node '${selectedNode}' started successfully on server port ${serverPort} and swarm port ${swarmPort}`);

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -339,7 +339,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
                 embeddedNodePort: alreadyRunning.port,
               });
             } else {
-              await startMerod(serverPort, swarmPort, dataDir, nodeToUse);
+              await startMerod(serverPort, swarmPort, dataDir, nodeToUse, getSettings().debugLogs);
               saveSettings({
                 ...getSettings(),
                 nodeUrl: `http://localhost:${serverPort}`,
@@ -460,7 +460,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
         }
         
         // Start the existing node
-        await startMerod(serverPort, swarmPort, dataDir, useExistingNode);
+        await startMerod(serverPort, swarmPort, dataDir, useExistingNode, getSettings().debugLogs);
         setNodeCreated(true);
         setNodeStarted(true);
         const nodeUrl = `http://localhost:${serverPort}`;
@@ -489,7 +489,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
           return;
         }
         
-        await startMerod(serverPort, swarmPort, dataDir, targetNodeName);
+        await startMerod(serverPort, swarmPort, dataDir, targetNodeName, getSettings().debugLogs);
         setNodeCreated(true);
         setNodeStarted(true);
         const nodeUrl = `http://localhost:${serverPort}`;

--- a/apps/desktop/src/pages/Settings.tsx
+++ b/apps/desktop/src/pages/Settings.tsx
@@ -20,6 +20,7 @@ export default function Settings({ onBack }: SettingsProps) {
   // Node management state (removed - now in NodeManagement page)
   const [activeTab, setActiveTab] = useState<'general' | 'registries'>('general');
   const [developerMode, setDeveloperMode] = useState(false);
+  const [debugLogs, setDebugLogs] = useState(false);
   const [showResetConfirm, setShowResetConfirm] = useState(false);
   const [resetConfirmed, setResetConfirmed] = useState(false);
   const [resetting, setResetting] = useState(false);
@@ -34,6 +35,7 @@ export default function Settings({ onBack }: SettingsProps) {
     const settings = getSettings();
     setRegistries(settings.registries || []);
     setDeveloperMode(settings.developerMode ?? false);
+    setDebugLogs(settings.debugLogs ?? false);
   }, []);
 
   useEffect(() => {
@@ -76,6 +78,16 @@ export default function Settings({ onBack }: SettingsProps) {
     toast.success(`Developer mode ${newValue ? 'enabled' : 'disabled'}`);
   };
 
+  const handleDebugLogsToggle = () => {
+    const newValue = !debugLogs;
+    setDebugLogs(newValue);
+    const settings = getSettings();
+    saveSettings({
+      ...settings,
+      debugLogs: newValue,
+    });
+    toast.success(`Debug logs ${newValue ? 'enabled' : 'disabled'}. Restart the node for changes to take effect.`);
+  };
 
   const handleAddRegistry = () => {
     const url = newRegistryUrl.trim();
@@ -197,6 +209,27 @@ export default function Settings({ onBack }: SettingsProps) {
             <p className="field-hint">
                   Enable to show advanced features like multiple node management and contexts tab.
                   When disabled, the app uses a simplified single-node mode.
+            </p>
+          </div>
+          <div className="settings-field">
+                <span className="settings-field-label">Debug Logs</span>
+                <div className="toggle-switch">
+            <input
+                    id="debug-logs"
+                    type="checkbox"
+                    checked={debugLogs}
+                    onChange={handleDebugLogsToggle}
+                  />
+                  <label htmlFor="debug-logs" className="toggle-label">
+                    <span className="toggle-slider"></span>
+                    <span className="toggle-text">
+                      {debugLogs ? 'Enabled' : 'Disabled'}
+                    </span>
+                  </label>
+                </div>
+            <p className="field-hint">
+                  Enable debug-level logging for the merod node. Produces more verbose logs useful for troubleshooting.
+                  Restart the node for changes to take effect.
             </p>
           </div>
               <div className="settings-field" style={{ marginTop: '16px', paddingTop: '16px', borderTop: '1px solid var(--border-color, #333)' }}>

--- a/apps/desktop/src/utils/merod.ts
+++ b/apps/desktop/src/utils/merod.ts
@@ -28,8 +28,8 @@ export async function listMerodNodes(homeDir?: string): Promise<string[]> {
 /**
  * Start the embedded merod node
  */
-export async function startMerod(serverPort?: number, swarmPort?: number, dataDir?: string, nodeName?: string): Promise<string> {
-  return await invoke('start_merod', { serverPort, swarmPort, dataDir, nodeName });
+export async function startMerod(serverPort?: number, swarmPort?: number, dataDir?: string, nodeName?: string, debugLogs?: boolean): Promise<string> {
+  return await invoke('start_merod', { serverPort, swarmPort, dataDir, nodeName, debugLogs });
 }
 
 /**

--- a/apps/desktop/src/utils/settings.ts
+++ b/apps/desktop/src/utils/settings.ts
@@ -7,6 +7,7 @@ export interface AppSettings {
   embeddedNodeDataDir?: string; // Data directory for embedded node (default: ~/.calimero)
   embeddedNodeName?: string; // Node name for embedded node
   developerMode?: boolean; // Developer mode - shows advanced features like multiple nodes and contexts
+  debugLogs?: boolean; // Enable debug-level logging for the merod node
   onboardingCompleted?: boolean; // True once user has completed first-time setup - never show onboarding again
 }
 
@@ -77,6 +78,7 @@ export function getSettings(): AppSettings {
         embeddedNodeDataDir: rawSettings.embeddedNodeDataDir,
         embeddedNodeName: rawSettings.embeddedNodeName,
         developerMode: rawSettings.developerMode ?? false, // Default to false
+        debugLogs: rawSettings.debugLogs ?? false,
         onboardingCompleted: rawSettings.onboardingCompleted ?? false,
       };
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk due to changes in process spawning/runtime environment (log level) and macOS code-signing entitlements, which can affect node startup behavior and release notarization/signing outcomes.
> 
> **Overview**
> Adds a new **Debug Logs** setting that persists in app settings and is passed through all node-start flows to the Tauri `start_merod` command.
> 
> Updates the Tauri backend to honor this flag by setting `RUST_LOG` (`debug` vs `info`) when spawning `merod`, and bumps the desktop app version to `0.0.17`.
> 
> Adjusts macOS release packaging by introducing entitlements plists, enabling app entitlements in `tauri.conf.json`, and applying entitlements when codesigning the bundled `merod` binary in the macOS GitHub Actions workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ea20f7ff9f2b7959db08f7fc5956479d1de4da2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->