### PR TITLE
feat: add automatic url passing

### DIFF
--- a/apps/desktop/src/utils/appUtils.ts
+++ b/apps/desktop/src/utils/appUtils.ts
@@ -2,6 +2,25 @@ import { invoke } from "@tauri-apps/api/tauri";
 import { getSettings } from "./settings";
 
 /**
+ * Appends the current node_url as a query parameter to a frontend URL.
+ * Encodes the node URL so the full string is valid (?, #, &, =, %, :, / etc. don't break the query).
+ * The opened app can read it via URLSearchParams.get('node_url') (decoded automatically).
+ */
+function appendNodeUrlParam(frontendUrl: string, nodeUrl: string): string {
+  if (!nodeUrl) return frontendUrl;
+  const encoded = encodeURIComponent(nodeUrl);
+  try {
+    const url = new URL(frontendUrl);
+    url.searchParams.set("node_url", nodeUrl); // URLSearchParams encodes when setting
+    return url.toString();
+  } catch {
+    // If URL parsing fails, append with ? or &
+    const separator = frontendUrl.includes("?") ? "&" : "?";
+    return `${frontendUrl}${separator}node_url=${encoded}`;
+  }
+}
+
+/**
  * Decodes app metadata from various formats (base64 string, byte array, or already decoded object)
  * @param metadata - The metadata to decode (can be string, number[], or already decoded object)
  * @returns The decoded metadata object, or null if decoding fails
@@ -49,6 +68,7 @@ export async function openAppFrontend(
 ): Promise<string | void> {
   try {
     const settings = getSettings();
+    const urlToOpen = appendNodeUrlParam(frontendUrl, settings.nodeUrl ?? '');
     
     // Generate unique window label based on domain + timestamp to avoid conflicts
     const urlObj = new URL(frontendUrl);
@@ -57,7 +77,7 @@ export async function openAppFrontend(
     
     await invoke('create_app_window', {
       windowLabel,
-      url: frontendUrl,
+      url: urlToOpen,
       title: appName || 'Application',
       openDevtools: false,
       nodeUrl: settings.nodeUrl,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized URL-construction change; main risk is inadvertent URL/parameter formatting issues affecting app launch.
> 
> **Overview**
> When opening an app frontend in a new Tauri window, the desktop app now automatically appends the current `settings.nodeUrl` as a `node_url` query parameter.
> 
> This adds `appendNodeUrlParam` to safely encode/attach the parameter (with a fallback for non-parseable URLs) and switches `openAppFrontend` to open the modified URL instead of the raw `frontendUrl`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f54c90550b8b9186ca44e5ae03bdfbf43091bd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->