### PR TITLE
feat: bump merod version to 10.1.rc1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.21"
+    "version": "0.0.22"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
<img width="732" height="48" alt="Screenshot 2026-03-04 at 12 14 26" src="https://github.com/user-attachments/assets/455277b6-d1f7-4022-b601-0089128244ab" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no functional or security-impacting code modifications.
> 
> **Overview**
> Bumps the Calimero Desktop app version from `0.0.21` to `0.0.22` in both `apps/desktop/package.json` and the Tauri `tauri.conf.json` package metadata, keeping the desktop build and bundle versions in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49309075036e55df0cef31547773e853564ab345. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->