### PR TITLE
fix: auth skip + desktop redirect

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.22",
+  "version": "0.0.25",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.25",
+  "version": "0.0.27",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1659,6 +1659,12 @@ async fn close_current_window(window: tauri::Window) -> Result<(), String> {
 }
 
 #[tauri::command]
+async fn open_url_in_browser(url: String, app_handle: tauri::AppHandle) -> Result<(), String> {
+    tauri::api::shell::open(&app_handle.shell_scope(), url, None)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 async fn delete_calimero_data_dir(data_dir: String) -> Result<String, String> {
     let expanded = if data_dir.starts_with("~") {
         if let Some(home) = dirs::home_dir() {
@@ -1850,7 +1856,8 @@ fn main() {
             autostart_enable,
             autostart_disable,
             autostart_is_enabled,
-            close_current_window
+            close_current_window,
+            open_url_in_browser
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.22"
+    "version": "0.0.25"
   },
   "tauri": {
     "allowlist": {
@@ -66,7 +66,7 @@
     },
     "bundle": {
       "active": true,
-      "targets": "all",
+      "targets": ["app"],
       "identifier": "network.calimero.desktop",
       "icon": [
         "icons/32x32.png",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -66,7 +66,7 @@
     },
     "bundle": {
       "active": true,
-      "targets": ["app"],
+      "targets": "all",
       "identifier": "network.calimero.desktop",
       "icon": [
         "icons/32x32.png",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.25"
+    "version": "0.0.27"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new Tauri IPC command that opens arbitrary URLs via the OS browser, which can be security-sensitive if called from untrusted web content. Otherwise the change is small and limited to desktop app wiring/version bumps.
> 
> **Overview**
> Bumps the desktop app version to `0.0.27` in both `package.json` and `tauri.conf.json`.
> 
> Adds a new Tauri command, `open_url_in_browser`, and registers it in the `invoke_handler` so the frontend can trigger OS-level browser redirects via `tauri::api::shell::open`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07146df2d519f7eb68183eec99b17ead75838e12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->