### PR TITLE
fix: toast popups messages + marketplace counter

### DIFF
--- a/apps/desktop/src/components/ToastContainer.css
+++ b/apps/desktop/src/components/ToastContainer.css
@@ -7,6 +7,9 @@
   flex-direction: column;
   gap: 12px;
   max-width: 400px;
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
+  overflow-x: hidden;
   pointer-events: none;
 }
 

--- a/apps/desktop/src/components/ToastContainer.css
+++ b/apps/desktop/src/components/ToastContainer.css
@@ -3,6 +3,10 @@
   top: 20px;
   right: 20px;
   z-index: 10000;
+  pointer-events: none;
+}
+
+.toast-container-inner {
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -10,7 +14,7 @@
   max-height: calc(100vh - 40px);
   overflow-y: auto;
   overflow-x: hidden;
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .toast {
@@ -127,6 +131,9 @@
     top: 16px;
     right: 16px;
     left: 16px;
+  }
+
+  .toast-container-inner {
     max-width: none;
   }
 

--- a/apps/desktop/src/components/ToastContainer.tsx
+++ b/apps/desktop/src/components/ToastContainer.tsx
@@ -11,6 +11,7 @@ export default function ToastContainer() {
 
   return (
     <div className="toast-container">
+      <div className="toast-container-inner">
       {toasts.map((toast) => (
         <div
           key={toast.id}
@@ -36,6 +37,7 @@ export default function ToastContainer() {
           </button>
         </div>
       ))}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/pages/Contexts.css
+++ b/apps/desktop/src/pages/Contexts.css
@@ -30,6 +30,9 @@
   border-radius: 6px;
   margin-bottom: 16px;
   border: 1px solid var(--error);
+  max-height: 80px;
+  overflow-y: auto;
+  word-break: break-word;
 }
 
 .loading {
@@ -55,6 +58,8 @@
   padding: 24px;
   margin-bottom: 24px;
   box-shadow: var(--shadow-md);
+  max-height: calc(100vh - 120px);
+  overflow-y: auto;
 }
 
 .create-context-form h2 {

--- a/apps/desktop/src/pages/Contexts.tsx
+++ b/apps/desktop/src/pages/Contexts.tsx
@@ -5,6 +5,7 @@ import DataTable from "../components/DataTable";
 import ContextMenu from "../components/ContextMenu";
 import { SkeletonTable } from "../components/Skeleton";
 import { decodeMetadata } from "../utils/appUtils";
+import { truncateText } from "../utils/string";
 import { X } from "lucide-react";
 import "./Contexts.css";
 
@@ -176,7 +177,7 @@ const Contexts: React.FC<ContextsProps> = ({ onAuthRequired, onConfirmDelete, cl
       }
 
       const contextId = response.data?.contextId || 'N/A';
-      toast.success(`Context created! ID: ${contextId.length > 8 ? contextId.substring(0, 8) + '…' : contextId}`);
+      toast.success(`Context created! ID: ${truncateText(contextId, 8)}`);
       setCreateProtocol("near");
       setCreateApplicationId("");
       setCreateInitializationParams("");

--- a/apps/desktop/src/pages/Contexts.tsx
+++ b/apps/desktop/src/pages/Contexts.tsx
@@ -175,7 +175,8 @@ const Contexts: React.FC<ContextsProps> = ({ onAuthRequired, onConfirmDelete, cl
         return;
       }
 
-      toast.success(`Context created successfully! ID: ${response.data?.contextId || 'N/A'}`);
+      const contextId = response.data?.contextId || 'N/A';
+      toast.success(`Context created! ID: ${contextId.length > 8 ? contextId.substring(0, 8) + '…' : contextId}`);
       setCreateProtocol("near");
       setCreateApplicationId("");
       setCreateInitializationParams("");

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -374,7 +374,8 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
 
       if (response.error) {
         console.error("📦 Marketplace: Install error:", response.error);
-        toast.error(`Failed to install: ${response.error.message}`);
+        const msg = response.error.message?.slice(0, 120) ?? 'Unknown error';
+        toast.error(`Failed to install: ${msg}`);
         return;
       }
 
@@ -392,7 +393,8 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
       );
     } catch (err) {
       console.error("📦 Marketplace: Install exception:", err);
-      toast.error(`Failed to install: ${err instanceof Error ? err.message : "Unknown error"}`);
+      const msg = (err instanceof Error ? err.message : "Unknown error").slice(0, 120);
+      toast.error(`Failed to install: ${msg}`);
     } finally {
       setInstallingAppId(null);
     }

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -9,6 +9,7 @@ import {
   touchMarketplaceCache,
   invalidateMarketplaceCache,
 } from "../utils/marketplaceCache";
+import { truncateText } from "../utils/string";
 import { useToast } from "../contexts/ToastContext";
 import Skeleton from "../components/Skeleton";
 import { Search, RefreshCw, Package, Download, CheckCircle2, X } from "lucide-react";
@@ -374,7 +375,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
 
       if (response.error) {
         console.error("📦 Marketplace: Install error:", response.error);
-        const msg = response.error.message?.slice(0, 120) ?? 'Unknown error';
+        const msg = response.error.message ? truncateText(response.error.message, 120) : 'Unknown error';
         toast.error(`Failed to install: ${msg}`);
         return;
       }
@@ -393,7 +394,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
       );
     } catch (err) {
       console.error("📦 Marketplace: Install exception:", err);
-      const msg = (err instanceof Error ? err.message : "Unknown error").slice(0, 120);
+      const msg = truncateText(err instanceof Error ? err.message : "Unknown error", 120);
       toast.error(`Failed to install: ${msg}`);
     } finally {
       setInstallingAppId(null);

--- a/apps/desktop/src/utils/string.ts
+++ b/apps/desktop/src/utils/string.ts
@@ -1,0 +1,7 @@
+/**
+ * Truncates text to maxLength and appends ellipsis when truncated.
+ */
+export function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength) + '…';
+}


### PR DESCRIPTION
# fix: toast popups messages + marketplace counter

## Description
Toast popups for some cases needed truncated message + better error displaying.
Added a marketplace downloader 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes (CSS/layout tweaks and toast message truncation) with no changes to auth, persistence, or backend request logic.
> 
> **Overview**
> **Improves notification and error UX in the desktop app.** Toasts are now rendered inside a new scrollable `toast-container-inner` wrapper, with updated pointer-event handling so the stack can overflow/scroll without blocking the page.
> 
> Long user-facing strings are now truncated via a new `truncateText` utility, used for the context creation success toast (shorter context ID) and Marketplace install error toasts (shorter error messages). Contexts page styling also caps/scrolls long error messages and the create-context form to avoid oversized panels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b61adee2ea7c1bf0531ec5e3c0c43fe3dace53a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->