### PR TITLE
feat: add downloads

### DIFF
--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -382,8 +382,9 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
 
       toast.success(`${app.alias || app.name} installed successfully!`);
 
-      // Reload installed apps (this updates installedAppIds which triggers sync useEffect)
-      await loadInstalledApps();
+      // Reload installed apps and refetch marketplace so download count updates
+      const installed = await loadInstalledApps();
+      await loadMarketplaceApps(installed, true);
       // Also explicitly mark this app as installed immediately for instant UI feedback
       setApps((prevApps) =>
         prevApps.map((a) =>
@@ -535,6 +536,10 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
                         <span className="app-meta-value">
                           {app.author || (shortPubkey && shortPubkey !== 'unknown' ? shortPubkey : '—')}
                         </span>
+                      </div>
+                      <div className="app-meta-row">
+                        <span className="app-meta-label">Downloads:</span>
+                        <span className="app-meta-value">{(app.downloads ?? 0).toLocaleString()}</span>
                       </div>
                     </div>
                   </div>

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -1013,6 +1013,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
                           {(app as any).description && (
                             <p className="app-description">{(app as any).description}</p>
                           )}
+                          <p className="app-downloads">{(app as any).downloads ?? 0} downloads</p>
                           <button
                             onClick={() => handleInstallApp(app, registry)}
                             className="app-install-button"

--- a/apps/desktop/src/utils/registry.ts
+++ b/apps/desktop/src/utils/registry.ts
@@ -11,6 +11,7 @@ export interface AppSummary {
   alias?: string;
   description?: string;
   author?: string;
+  downloads?: number;
 }
 
 export interface VersionInfo {
@@ -109,6 +110,7 @@ export async function fetchAppsFromRegistry(
       description: bundle.metadata?.description,
       author: bundle.metadata?.author,
       minRuntimeVersion: bundle.minRuntimeVersion,
+      downloads: bundle.downloads ?? 0,
     }));
   } catch (error) {
     console.error(`Failed to fetch apps from registry ${registryUrl}:`, error);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/data-model change that adds a new optional `downloads` field from the registry API and triggers an extra marketplace refresh after install to keep counts current.
> 
> **Overview**
> Adds registry support for per-app download counts by extending `AppSummary` with `downloads` and mapping it from the v2 bundles response.
> 
> Surfaces the download count in both the Marketplace app cards and the onboarding “install your first app” list, and updates the Marketplace install flow to reload installed apps *and* force-refresh the marketplace list after a successful install so the displayed count can update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e852a031c47d8e8c071cea367036ea4f0bcc92bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->