### PR TITLE
feat: download api endpoint

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.27"
+    "version": "0.0.28"
   },
   "tauri": {
     "allowlist": {

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -382,6 +382,10 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
 
       toast.success(`${app.alias || app.name} installed successfully!`);
 
+      // Record download with registry (fire-and-forget)
+      const { recordDownload } = await import("../utils/registry");
+      recordDownload(app.registry, app.id, app.latest_version);
+
       // Reload installed apps and refetch marketplace so download count updates
       const installed = await loadInstalledApps();
       await loadMarketplaceApps(installed, true);

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { getSettings } from "../utils/settings";
-import { fetchAppsFromAllRegistries, type AppSummary } from "../utils/registry";
+import { fetchAppsFromAllRegistries, recordDownload, type AppSummary } from "../utils/registry";
 import { apiClient } from "@calimero-network/mero-react";
 import { decodeMetadata } from "../utils/appUtils";
 import {
@@ -383,7 +383,6 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
       toast.success(`${app.alias || app.name} installed successfully!`);
 
       // Record download with registry (fire-and-forget)
-      const { recordDownload } = await import("../utils/registry");
       recordDownload(app.registry, app.id, app.latest_version);
 
       // Reload installed apps and refetch marketplace so download count updates

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -5,7 +5,7 @@ import { initMerodNode, startMerod, listMerodNodes, detectRunningMerodNodes, wai
 import { invoke } from "@tauri-apps/api/tauri";
 import { saveSettings, getSettings } from "../utils/settings";
 import { saveOnboardingProgress, loadOnboardingProgress } from "../utils/onboardingProgress";
-import { fetchAppsFromAllRegistries, fetchAppManifest, type AppSummary } from "../utils/registry";
+import { fetchAppsFromAllRegistries, fetchAppManifest, recordDownload, type AppSummary } from "../utils/registry";
 import { useToast } from "../contexts/ToastContext";
 import { useTheme } from "../contexts/ThemeContext";
 import { ArrowLeft, ArrowRight, Check, Package, Download, CheckCircle2, ChevronDown, ChevronUp, Search, AlertTriangle } from "lucide-react";
@@ -434,7 +434,6 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
       setInstalledAppIds(new Set([...installedAppIds, app.id]));
 
       // Record download with registry (fire-and-forget)
-      const { recordDownload } = await import("../utils/registry");
       recordDownload(registry, app.id, app.latest_version);
 
       // Ensure dark mode is saved before completing onboarding

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -432,7 +432,11 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
 
       toast.success(`Successfully installed ${app.name}!`);
       setInstalledAppIds(new Set([...installedAppIds, app.id]));
-      
+
+      // Record download with registry (fire-and-forget)
+      const { recordDownload } = await import("../utils/registry");
+      recordDownload(registry, app.id, app.latest_version);
+
       // Ensure dark mode is saved before completing onboarding
       setTheme('dark');
       

--- a/apps/desktop/src/utils/registry.ts
+++ b/apps/desktop/src/utils/registry.ts
@@ -255,20 +255,28 @@ export async function fetchAppManifest(
 /**
  * Record a download with the registry (fire-and-forget).
  * Call after a successful app install so download counts stay accurate.
+ * Never throws; logs warnings on invalid URL or fetch failure.
  */
 export function recordDownload(
   registryBaseUrl: string,
   packageId: string,
   version: string
 ): void {
-  const recordUrl = new URL('/api/v2/downloads/record', registryBaseUrl).toString();
-  fetch(recordUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ package: packageId, version }),
-  }).catch((err) => {
-    console.warn('Failed to record download:', err);
-  });
+  try {
+    if (!registryBaseUrl?.startsWith('https://')) {
+      console.warn('recordDownload: registry URL should use HTTPS', registryBaseUrl);
+    }
+    const recordUrl = new URL('/api/v2/downloads/record', registryBaseUrl).toString();
+    fetch(recordUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ package: packageId, version }),
+    }).catch((err) => {
+      console.warn('Failed to record download:', err);
+    });
+  } catch (err) {
+    console.warn('Failed to record download (invalid URL or serialization):', err);
+  }
 }
 
 /**

--- a/apps/desktop/src/utils/registry.ts
+++ b/apps/desktop/src/utils/registry.ts
@@ -253,6 +253,25 @@ export async function fetchAppManifest(
 }
 
 /**
+ * Record a download with the registry (fire-and-forget).
+ * Call after a successful app install so download counts stay accurate.
+ */
+export function recordDownload(
+  registryBaseUrl: string,
+  packageId: string,
+  version: string
+): void {
+  const recordUrl = new URL('/api/v2/downloads/record', registryBaseUrl).toString();
+  fetch(recordUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ package: packageId, version }),
+  }).catch((err) => {
+    console.warn('Failed to record download:', err);
+  });
+}
+
+/**
  * Fetch applications from all configured registries
  */
 export async function fetchAppsFromAllRegistries(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new outbound POST request to registry servers after successful installs, which could affect install flows or privacy expectations if registries are misconfigured/unreachable (though failures are swallowed). Version bumps are low risk.
> 
> **Overview**
> After a successful app install, the desktop app now **records the download with the app registry** by POSTing to `POST /api/v2/downloads/record` (fire-and-forget, non-blocking, never throws).
> 
> This behavior is wired into both the Marketplace install flow and the onboarding “install first app” step, and the desktop/Tauri package versions are bumped to `0.0.28`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5b6f81f7a6149ae08c979470f1aac1a6a5fab40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->