### PR TITLE
fix: download binary versions

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -125,6 +125,8 @@ jobs:
 
       - name: Prepare merod binary
         working-directory: apps/desktop
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm merod:prepare
 
       - name: Update version in tauri.conf.json

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -181,6 +181,8 @@ jobs:
       - name: Build Tauri app for Linux
         working-directory: apps/desktop
         env:
+          # beforeBuildCommand runs merod:prepare again; reuse binary from "Prepare merod binary" (no GITHUB_TOKEN here).
+          MEROD_SKIP_IF_EXISTS: "1"
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         run: pnpm tauri build

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -123,6 +123,10 @@ jobs:
         working-directory: apps/desktop
         run: pnpm tauri icon src-tauri/icons/icon.png
 
+      - name: Prepare merod binary
+        working-directory: apps/desktop
+        run: pnpm merod:prepare
+
       - name: Update version in tauri.conf.json
         if: steps.build-mode.outputs.mode == 'release'
         run: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -141,6 +141,8 @@ jobs:
 
       - name: Prepare merod binary
         working-directory: apps/desktop
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm merod:prepare
 
       - name: Update version in tauri.conf.json

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -139,6 +139,10 @@ jobs:
         working-directory: apps/desktop
         run: pnpm tauri icon src-tauri/icons/icon.png
 
+      - name: Prepare merod binary
+        working-directory: apps/desktop
+        run: pnpm merod:prepare
+
       - name: Update version in tauri.conf.json
         if: steps.build-mode.outputs.mode == 'release'
         run: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -245,6 +245,7 @@ jobs:
         if: steps.build-mode.outputs.mode == 'release'
         working-directory: apps/desktop
         env:
+          MEROD_SKIP_IF_EXISTS: "1"
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -126,6 +126,10 @@ jobs:
         working-directory: apps/desktop
         run: pnpm tauri icon src-tauri/icons/icon.png
 
+      - name: Prepare merod binary
+        working-directory: apps/desktop
+        run: pnpm merod:prepare
+
       - name: Update version in tauri.conf.json
         if: steps.build-mode.outputs.mode == 'release'
         shell: bash

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -126,12 +126,31 @@ jobs:
         working-directory: apps/desktop
         run: pnpm tauri icon src-tauri/icons/icon.png
 
+      # calimero-network/core does not publish merod_* Windows archives on GitHub Releases (only macOS/Linux).
+      # MEROD_ASSET_FALLBACK cannot fix that. Build merod from the same git tag as merod-config.json.
+      - name: Build merod from source (Windows)
+        shell: bash
+        env:
+          CARGO_INCREMENTAL: "0"
+        run: |
+          set -euo pipefail
+          VERSION="$(node -p "require('./merod-config.json').version")"
+          DEST="${GITHUB_WORKSPACE}/apps/desktop/src-tauri/merod/merod.exe"
+          mkdir -p "$(dirname "$DEST")"
+          CORE_TMP="${RUNNER_TEMP}/calimero-core-${VERSION}"
+          rm -rf "$CORE_TMP"
+          git clone --depth 1 --branch "${VERSION}" "https://github.com/calimero-network/core.git" "$CORE_TMP"
+          cd "$CORE_TMP"
+          cargo build --release -p merod
+          cp "target/release/merod.exe" "$DEST"
+          ls -la "$DEST"
+
       - name: Prepare merod binary
         working-directory: apps/desktop
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Pinned core release may omit Windows zips; use newest release that ships merod for this OS.
-          MEROD_ASSET_FALLBACK: "1"
+          # Binary already built from source above; skip GitHub download (no Windows release asset exists).
+          MEROD_SKIP_IF_EXISTS: "1"
         run: pnpm merod:prepare
 
       - name: Update version in tauri.conf.json
@@ -169,6 +188,8 @@ jobs:
       - name: Build Tauri app for Windows
         working-directory: apps/desktop
         env:
+          # beforeBuildCommand runs merod:prepare again; keep using the binary built above (no Windows GitHub asset).
+          MEROD_SKIP_IF_EXISTS: "1"
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         run: pnpm tauri build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -128,6 +128,10 @@ jobs:
 
       - name: Prepare merod binary
         working-directory: apps/desktop
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pinned core release may omit Windows zips; use newest release that ships merod for this OS.
+          MEROD_ASSET_FALLBACK: "1"
         run: pnpm merod:prepare
 
       - name: Update version in tauri.conf.json

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ target/
 # Tauri
 **/src-tauri/target
 **/src-tauri/gen
+**/src-tauri/merod/merod
+**/src-tauri/merod/merod.exe
 
 # Environment variables
 .env

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,12 +7,13 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "merod:prepare": "node scripts/prepare-merod.mjs",
     "tauri": "tauri",
-    "tauri:dev": "tauri dev",
-    "tauri:dev:devtools": "TAURI_OPEN_DEVTOOLS=true tauri dev",
-    "tauri:dev:no-devtools": "TAURI_OPEN_DEVTOOLS=false tauri dev",
-    "tauri:build": "tauri build",
-    "tauri:build:app": "tauri build --bundles app",
+    "tauri:dev": "pnpm merod:prepare && tauri dev",
+    "tauri:dev:devtools": "pnpm merod:prepare && TAURI_OPEN_DEVTOOLS=true tauri dev",
+    "tauri:dev:no-devtools": "pnpm merod:prepare && TAURI_OPEN_DEVTOOLS=false tauri dev",
+    "tauri:build": "pnpm merod:prepare && tauri build",
+    "tauri:build:app": "pnpm merod:prepare && tauri build --bundles app",
     "icon": "node scripts/svg-to-icon.js && pnpm tauri icon src-tauri/icons/icon-1024.png",
     "clean": "rm -rf dist src-tauri/target"
   },
@@ -33,6 +34,7 @@
     "@types/react-dom": "^19.2.2",
     "@vitejs/plugin-react": "^3.1.0",
     "sharp": "^0.34.5",
+    "tar": "^7.5.13",
     "typescript": "^5.8.3",
     "vite": "^4.1.0"
   }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,8 +12,9 @@
     "tauri:dev": "pnpm merod:prepare && tauri dev",
     "tauri:dev:devtools": "pnpm merod:prepare && TAURI_OPEN_DEVTOOLS=true tauri dev",
     "tauri:dev:no-devtools": "pnpm merod:prepare && TAURI_OPEN_DEVTOOLS=false tauri dev",
-    "tauri:build": "pnpm merod:prepare && tauri build",
+    "tauri:build": "pnpm merod:prepare && tauri build --bundles app",
     "tauri:build:app": "pnpm merod:prepare && tauri build --bundles app",
+    "tauri:build:full": "pnpm merod:prepare && tauri build",
     "icon": "node scripts/svg-to-icon.js && pnpm tauri icon src-tauri/icons/icon-1024.png",
     "clean": "rm -rf dist src-tauri/target"
   },

--- a/apps/desktop/scripts/prepare-merod.mjs
+++ b/apps/desktop/scripts/prepare-merod.mjs
@@ -247,20 +247,25 @@ async function findBinary(startDir) {
 }
 
 async function extractBinary(assetPath, assetName) {
+  const lower = assetName.toLowerCase();
+  if (
+    !lower.endsWith(".tar.gz") &&
+    !lower.endsWith(".tgz") &&
+    !lower.endsWith(".zip")
+  ) {
+    return assetPath;
+  }
+
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "merod-extract-"));
 
   try {
-    const lower = assetName.toLowerCase();
-
     if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz")) {
       await tar.x({
         file: assetPath,
         cwd: tempDir,
       });
-    } else if (lower.endsWith(".zip")) {
-      shellExtractZip(assetPath, tempDir);
     } else {
-      return assetPath;
+      shellExtractZip(assetPath, tempDir);
     }
 
     const binaryPath = await findBinary(tempDir);
@@ -276,6 +281,16 @@ async function extractBinary(assetPath, assetName) {
 }
 
 async function main() {
+  await fs.mkdir(merodDir, { recursive: true });
+
+  if (
+    process.env.MEROD_SKIP_IF_EXISTS === "1" &&
+    existsSync(merodBinaryPath)
+  ) {
+    console.log(`[merod] ready: ${merodBinaryPath} (existing binary in CI)`);
+    return;
+  }
+
   const config = await readConfig();
   const target = resolveTarget();
   const { release, source } = await resolveRelease(config);
@@ -285,7 +300,6 @@ async function main() {
   console.log(`[merod] release: ${release.tag_name} (${source})`);
   console.log(`[merod] asset: ${asset.name}`);
 
-  await fs.mkdir(merodDir, { recursive: true });
   await fs.rm(merodBinaryPath, { force: true });
   if (process.platform === "win32") {
     await fs.rm(path.join(merodDir, "merod"), { force: true });

--- a/apps/desktop/scripts/prepare-merod.mjs
+++ b/apps/desktop/scripts/prepare-merod.mjs
@@ -1,0 +1,326 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { createWriteStream, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
+import * as tar from "tar";
+
+const CORE_REPO = "calimero-network/core";
+const rootDir = path.resolve(import.meta.dirname, "../../..");
+const desktopDir = path.resolve(import.meta.dirname, "..");
+const configPath = path.join(rootDir, "merod-config.json");
+const merodDir = path.join(desktopDir, "src-tauri", "merod");
+const merodBinaryName = process.platform === "win32" ? "merod.exe" : "merod";
+const merodBinaryPath = path.join(merodDir, merodBinaryName);
+
+function githubHeaders() {
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "calimero-desktop-merod-prep",
+  };
+
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  return headers;
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url, { headers: githubHeaders() });
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed (${response.status}) for ${url}`);
+  }
+
+  return response.json();
+}
+
+async function readConfig() {
+  if (!existsSync(configPath)) {
+    return {};
+  }
+
+  const raw = await fs.readFile(configPath, "utf8");
+  return JSON.parse(raw);
+}
+
+function resolveTarget() {
+  const platform = process.platform;
+  const arch = process.arch;
+
+  if (platform === "darwin" && arch === "arm64") {
+    return {
+      label: "macOS arm64",
+      candidates: ["aarch64-apple-darwin", "arm64-apple-darwin"],
+    };
+  }
+
+  if (platform === "darwin" && arch === "x64") {
+    return {
+      label: "macOS x64",
+      candidates: ["x86_64-apple-darwin"],
+    };
+  }
+
+  if (platform === "linux" && arch === "x64") {
+    return {
+      label: "Linux x64",
+      candidates: ["x86_64-unknown-linux-gnu"],
+    };
+  }
+
+  if (platform === "linux" && arch === "arm64") {
+    return {
+      label: "Linux arm64",
+      candidates: ["aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl"],
+    };
+  }
+
+  if (platform === "win32" && arch === "x64") {
+    return {
+      label: "Windows x64",
+      candidates: [
+        "x86_64-pc-windows-msvc",
+        "x86_64-pc-windows-gnu",
+        "x86_64-windows",
+      ],
+    };
+  }
+
+  if (platform === "win32" && arch === "arm64") {
+    return {
+      label: "Windows arm64",
+      candidates: ["aarch64-pc-windows-msvc", "arm64-pc-windows-msvc"],
+    };
+  }
+
+  throw new Error(`Unsupported platform/architecture: ${platform}/${arch}`);
+}
+
+async function resolveRelease(config) {
+  if (process.env.MEROD_VERSION) {
+    return {
+      release: await fetchJson(
+        `https://api.github.com/repos/${CORE_REPO}/releases/tags/${encodeURIComponent(
+          process.env.MEROD_VERSION,
+        )}`,
+      ),
+      source: `MEROD_VERSION=${process.env.MEROD_VERSION}`,
+    };
+  }
+
+  if (process.env.MEROD_CHANNEL) {
+    const channel = process.env.MEROD_CHANNEL.trim().toLowerCase();
+    const releases = await fetchJson(
+      `https://api.github.com/repos/${CORE_REPO}/releases?per_page=20`,
+    );
+
+    const release =
+      channel === "prerelease"
+        ? releases.find((item) => item.prerelease)
+        : releases.find((item) => !item.prerelease);
+
+    if (!release) {
+      throw new Error(`No ${channel} release found in ${CORE_REPO}`);
+    }
+
+    return {
+      release,
+      source: `MEROD_CHANNEL=${channel}`,
+    };
+  }
+
+  if (config.version) {
+    return {
+      release: await fetchJson(
+        `https://api.github.com/repos/${CORE_REPO}/releases/tags/${encodeURIComponent(
+          config.version,
+        )}`,
+      ),
+      source: `merod-config.json version=${config.version}`,
+    };
+  }
+
+  const release = await fetchJson(
+    `https://api.github.com/repos/${CORE_REPO}/releases/latest`,
+  );
+  return {
+    release,
+    source: "latest stable release",
+  };
+}
+
+function scoreAsset(name, target) {
+  const lower = name.toLowerCase();
+  const targetIndex = target.candidates.findIndex((candidate) =>
+    lower.includes(candidate.toLowerCase()),
+  );
+
+  if (targetIndex === -1 || !lower.startsWith("merod")) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  let score = targetIndex * 100;
+
+  if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz")) {
+    score += 1;
+  } else if (lower.endsWith(".zip")) {
+    score += 2;
+  } else if (lower.endsWith(".exe")) {
+    score += 3;
+  } else {
+    score += 4;
+  }
+
+  return score;
+}
+
+function pickAsset(release, target) {
+  const ranked = release.assets
+    .map((asset) => ({ asset, score: scoreAsset(asset.name, target) }))
+    .filter((item) => Number.isFinite(item.score))
+    .sort((a, b) => a.score - b.score);
+
+  if (ranked.length > 0) {
+    return ranked[0].asset;
+  }
+
+  const assetNames = release.assets.map((asset) => asset.name).join(", ");
+  throw new Error(
+    `No merod asset found for ${target.label} in ${release.tag_name}. Available assets: ${
+      assetNames || "none"
+    }`,
+  );
+}
+
+async function downloadToFile(url, destination) {
+  const response = await fetch(url, { headers: githubHeaders() });
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download ${url} (${response.status})`);
+  }
+
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(destination));
+}
+
+function shellExtractZip(archivePath, destinationDir) {
+  if (process.platform === "win32") {
+    execFileSync(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-Command",
+        `Expand-Archive -Path '${archivePath.replace(/'/g, "''")}' -DestinationPath '${destinationDir.replace(/'/g, "''")}' -Force`,
+      ],
+      { stdio: "inherit" },
+    );
+    return;
+  }
+
+  execFileSync("unzip", ["-o", archivePath, "-d", destinationDir], {
+    stdio: "inherit",
+  });
+}
+
+async function findBinary(startDir) {
+  const entries = await fs.readdir(startDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(startDir, entry.name);
+
+    if (entry.isDirectory()) {
+      const nested = await findBinary(fullPath);
+      if (nested) {
+        return nested;
+      }
+      continue;
+    }
+
+    const lower = entry.name.toLowerCase();
+    if (lower === "merod" || lower === "merod.exe") {
+      return fullPath;
+    }
+  }
+
+  return null;
+}
+
+async function extractBinary(assetPath, assetName) {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "merod-extract-"));
+
+  try {
+    const lower = assetName.toLowerCase();
+
+    if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz")) {
+      await tar.x({
+        file: assetPath,
+        cwd: tempDir,
+      });
+    } else if (lower.endsWith(".zip")) {
+      shellExtractZip(assetPath, tempDir);
+    } else {
+      return assetPath;
+    }
+
+    const binaryPath = await findBinary(tempDir);
+    if (!binaryPath) {
+      throw new Error(`Could not find extracted merod binary inside ${assetName}`);
+    }
+
+    return { binaryPath, tempDir };
+  } catch (error) {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function main() {
+  const config = await readConfig();
+  const target = resolveTarget();
+  const { release, source } = await resolveRelease(config);
+  const asset = pickAsset(release, target);
+
+  console.log(`[merod] target: ${target.label}`);
+  console.log(`[merod] release: ${release.tag_name} (${source})`);
+  console.log(`[merod] asset: ${asset.name}`);
+
+  await fs.mkdir(merodDir, { recursive: true });
+  await fs.rm(merodBinaryPath, { force: true });
+  if (process.platform === "win32") {
+    await fs.rm(path.join(merodDir, "merod"), { force: true });
+  } else {
+    await fs.rm(path.join(merodDir, "merod.exe"), { force: true });
+  }
+
+  const tempDownloadDir = await fs.mkdtemp(path.join(os.tmpdir(), "merod-download-"));
+  const assetPath = path.join(tempDownloadDir, asset.name);
+
+  try {
+    await downloadToFile(asset.browser_download_url, assetPath);
+    const extracted = await extractBinary(assetPath, asset.name);
+    try {
+      const extractedBinaryPath =
+        typeof extracted === "string" ? extracted : extracted.binaryPath;
+
+      await fs.copyFile(extractedBinaryPath, merodBinaryPath);
+
+      if (process.platform !== "win32") {
+        await fs.chmod(merodBinaryPath, 0o755);
+      }
+    } finally {
+      if (typeof extracted !== "string") {
+        await fs.rm(extracted.tempDir, { recursive: true, force: true });
+      }
+    }
+  } finally {
+    await fs.rm(tempDownloadDir, { recursive: true, force: true });
+  }
+
+  console.log(`[merod] ready: ${merodBinaryPath}`);
+}
+
+main().catch((error) => {
+  console.error(`[merod] ${error.message}`);
+  process.exit(1);
+});

--- a/apps/desktop/scripts/prepare-merod.mjs
+++ b/apps/desktop/scripts/prepare-merod.mjs
@@ -15,6 +15,26 @@ const merodDir = path.join(desktopDir, "src-tauri", "merod");
 const merodBinaryName = process.platform === "win32" ? "merod.exe" : "merod";
 const merodBinaryPath = path.join(merodDir, merodBinaryName);
 
+function envTruthy(name) {
+  const v = String(process.env[name] ?? "").trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
+function shouldUseExistingMerodBinary() {
+  if (!existsSync(merodBinaryPath)) {
+    return false;
+  }
+  if (envTruthy("MEROD_SKIP_IF_EXISTS")) {
+    return true;
+  }
+  // calimero-network/core does not ship Windows merod archives; CI builds from source first.
+  // If MEROD_SKIP_IF_EXISTS is missing (org env, old workflow), still skip when the binary is already there.
+  if (process.env.CI === "true" && process.platform === "win32") {
+    return true;
+  }
+  return false;
+}
+
 function githubHeaders() {
   const headers = {
     Accept: "application/vnd.github+json",
@@ -327,11 +347,10 @@ async function extractBinary(assetPath, assetName) {
 async function main() {
   await fs.mkdir(merodDir, { recursive: true });
 
-  if (
-    process.env.MEROD_SKIP_IF_EXISTS === "1" &&
-    existsSync(merodBinaryPath)
-  ) {
-    console.log(`[merod] ready: ${merodBinaryPath} (existing binary in CI)`);
+  if (shouldUseExistingMerodBinary()) {
+    console.log(
+      `[merod] ready: ${merodBinaryPath} (existing binary; skip GitHub download)`,
+    );
     return;
   }
 
@@ -343,7 +362,7 @@ async function main() {
   try {
     asset = pickAsset(release, target);
   } catch (primaryError) {
-    const allowFallback = process.env.MEROD_ASSET_FALLBACK === "1";
+    const allowFallback = envTruthy("MEROD_ASSET_FALLBACK");
     const isMissingAsset =
       primaryError instanceof Error &&
       primaryError.message.includes("No merod asset found");

--- a/apps/desktop/scripts/prepare-merod.mjs
+++ b/apps/desktop/scripts/prepare-merod.mjs
@@ -28,10 +28,27 @@ function githubHeaders() {
   return headers;
 }
 
+async function readErrorBody(response) {
+  try {
+    const text = await response.text();
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return "";
+    }
+    return trimmed.length > 800 ? `${trimmed.slice(0, 800)}…` : trimmed;
+  } catch {
+    return "";
+  }
+}
+
 async function fetchJson(url) {
   const response = await fetch(url, { headers: githubHeaders() });
   if (!response.ok) {
-    throw new Error(`GitHub API request failed (${response.status}) for ${url}`);
+    const body = await readErrorBody(response);
+    const detail = body ? ` — ${body}` : "";
+    throw new Error(
+      `GitHub API request failed (${response.status}) for ${url}${detail}`,
+    );
   }
 
   return response.json();
@@ -195,10 +212,33 @@ function pickAsset(release, target) {
   );
 }
 
+/**
+ * When the pinned release omits a platform (e.g. no Windows zip yet), find a newer
+ * release that ships merod for this target. Newest-first.
+ */
+async function findReleaseWithMerodForTarget(target) {
+  const releases = await fetchJson(
+    `https://api.github.com/repos/${CORE_REPO}/releases?per_page=40`,
+  );
+
+  for (const candidate of releases) {
+    try {
+      const asset = pickAsset(candidate, target);
+      return { release: candidate, asset };
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
 async function downloadToFile(url, destination) {
   const response = await fetch(url, { headers: githubHeaders() });
   if (!response.ok || !response.body) {
-    throw new Error(`Failed to download ${url} (${response.status})`);
+    const body = await readErrorBody(response);
+    const detail = body ? ` — ${body}` : "";
+    throw new Error(`Failed to download ${url} (${response.status})${detail}`);
   }
 
   await pipeline(Readable.fromWeb(response.body), createWriteStream(destination));
@@ -227,6 +267,10 @@ async function findBinary(startDir) {
   const entries = await fs.readdir(startDir, { withFileTypes: true });
 
   for (const entry of entries) {
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+
     const fullPath = path.join(startDir, entry.name);
 
     if (entry.isDirectory()) {
@@ -293,8 +337,33 @@ async function main() {
 
   const config = await readConfig();
   const target = resolveTarget();
-  const { release, source } = await resolveRelease(config);
-  const asset = pickAsset(release, target);
+  let { release, source } = await resolveRelease(config);
+  let asset;
+
+  try {
+    asset = pickAsset(release, target);
+  } catch (primaryError) {
+    const allowFallback = process.env.MEROD_ASSET_FALLBACK === "1";
+    const isMissingAsset =
+      primaryError instanceof Error &&
+      primaryError.message.includes("No merod asset found");
+
+    if (!allowFallback || !isMissingAsset) {
+      throw primaryError;
+    }
+
+    const found = await findReleaseWithMerodForTarget(target);
+    if (!found) {
+      throw primaryError;
+    }
+
+    console.warn(
+      `[merod] ${release.tag_name} has no ${target.label} asset; using fallback ${found.release.tag_name}`,
+    );
+    release = found.release;
+    source = `${source} → fallback ${found.release.tag_name}`;
+    asset = found.asset;
+  }
 
   console.log(`[merod] target: ${target.label}`);
   console.log(`[merod] release: ${release.tag_name} (${source})`);

--- a/apps/desktop/src-tauri/scripts/download-merod.sh
+++ b/apps/desktop/src-tauri/scripts/download-merod.sh
@@ -1,72 +1,8 @@
 #!/bin/bash
 
-# Download merod binary at build time
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TAURI_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-MEROD_DIR="$TAURI_DIR/merod"
-MEROD_BINARY="$MEROD_DIR/merod"
+DESKTOP_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-# Detect architecture
-ARCH=$(uname -m)
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-
-echo "Detected architecture: $ARCH on $OS"
-
-# Map architecture to GitHub release asset name
-case "$ARCH" in
-  arm64|aarch64)
-    if [ "$OS" = "darwin" ]; then
-      ASSET_NAME="merod_aarch64-apple-darwin.tar.gz"
-    else
-      echo "Unsupported OS for ARM64: $OS"
-      exit 1
-    fi
-    ;;
-  x86_64|amd64)
-    if [ "$OS" = "darwin" ]; then
-      ASSET_NAME="merod_x86_64-apple-darwin.tar.gz"
-    elif [ "$OS" = "linux" ]; then
-      ASSET_NAME="merod_x86_64-unknown-linux-gnu.tar.gz"
-    else
-      echo "Unsupported OS for x86_64: $OS"
-      exit 1
-    fi
-    ;;
-  *)
-    echo "Unsupported architecture: $ARCH"
-    exit 1
-    ;;
-esac
-
-# Fetch latest release tag from GitHub (includes pre-releases)
-VERSION=$(curl -sL "https://api.github.com/repos/calimero-network/core/releases?per_page=1" | grep -o '"tag_name": *"[^"]*"' | head -1 | cut -d'"' -f4)
-if [ -z "$VERSION" ]; then
-  echo "Failed to fetch latest release version from GitHub"
-  exit 1
-fi
-
-URL="https://github.com/calimero-network/core/releases/download/$VERSION/$ASSET_NAME"
-
-echo "Downloading merod $VERSION from: $URL"
-
-# Create merod directory if it doesn't exist
-mkdir -p "$MEROD_DIR"
-
-# Remove old binary so we always get the configured VERSION
-rm -f "$MEROD_BINARY"
-
-# Download and extract
-TEMP_TAR="$MEROD_DIR/temp.tar.gz"
-curl -L -o "$TEMP_TAR" "$URL"
-
-# Extract tar.gz
-cd "$MEROD_DIR"
-tar -xzf "$TEMP_TAR" merod
-rm "$TEMP_TAR"
-
-# Make executable
-chmod +x "$MEROD_BINARY"
-
-echo "Successfully downloaded merod to $MEROD_BINARY"
+node "$DESKTOP_DIR/scripts/prepare-merod.mjs"

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -561,17 +561,24 @@ type MerodState = Arc<Mutex<Vec<MerodProcess>>>;
 
 /// Get the path to the bundled merod binary
 fn get_merod_binary_path(app_handle: &tauri::AppHandle) -> Result<std::path::PathBuf, String> {
-    // Access the bundled resource
-    let resource_path = app_handle
-        .path_resolver()
-        .resolve_resource("merod/merod")
-        .ok_or("Failed to resolve merod resource")?;
-    
-    if !resource_path.exists() {
-        return Err(format!("Merod resource not found at {:?}", resource_path));
+    let resource_candidates = if cfg!(target_os = "windows") {
+        vec!["merod/merod.exe", "merod/merod"]
+    } else {
+        vec!["merod/merod", "merod/merod.exe"]
+    };
+
+    for candidate in &resource_candidates {
+        if let Some(resource_path) = app_handle.path_resolver().resolve_resource(candidate) {
+            if resource_path.exists() {
+                return Ok(resource_path);
+            }
+        }
     }
-    
-    Ok(resource_path)
+
+    Err(format!(
+        "Merod resource not found. Checked: {:?}",
+        resource_candidates
+    ))
 }
 
 /// Get the app data directory for storing merod data

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "build": {
-    "beforeDevCommand": "pnpm dev",
-    "beforeBuildCommand": "pnpm build",
+    "beforeDevCommand": "pnpm merod:prepare && pnpm dev",
+    "beforeBuildCommand": "pnpm merod:prepare && pnpm build",
     "devPath": "http://localhost:1420",
     "distDir": "../dist",
     "withGlobalTauri": false
@@ -77,7 +77,7 @@
         "icons/icon.png"
       ],
       "resources": [
-        "merod/merod"
+        "merod"
       ],
       "macOS": {
         "entitlements": "entitlements.plist",

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.10.1-rc.3"
+    "version": "0.10.1-rc.9"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+      tar:
+        specifier: ^7.5.13
+        version: 7.5.13
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -636,6 +639,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1171,6 +1178,10 @@ packages:
   caniuse-lite@1.0.30001760:
     resolution: {integrity: sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==}
 
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
   commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
@@ -1361,6 +1372,14 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1547,6 +1566,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tar@7.5.13:
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+    engines: {node: '>=18'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1674,6 +1697,10 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   z-schema@5.0.5:
     resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
@@ -2068,6 +2095,10 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2633,6 +2664,8 @@ snapshots:
 
   caniuse-lite@1.0.30001760: {}
 
+  chownr@3.0.0: {}
+
   commander@9.5.0:
     optional: true
 
@@ -2818,6 +2851,12 @@ snapshots:
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
+
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
 
   ms@2.1.3: {}
 
@@ -3063,6 +3102,14 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tar@7.5.13:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   tslib@2.8.1:
     optional: true
 
@@ -3145,6 +3192,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
 
   z-schema@5.0.5:
     dependencies:


### PR DESCRIPTION
# fix: download binary versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release/build pipeline and how an external binary is fetched/extracted/bundled across all platforms, which can break packaging or ship the wrong binary if asset selection logic is wrong.
> 
> **Overview**
> Ensures the Tauri desktop app always bundles the intended `merod` version by replacing the ad-hoc shell downloader with a new `scripts/prepare-merod.mjs` that selects the correct GitHub Release asset for the current OS/arch (with env overrides/fallback) and extracts/copies it into `src-tauri/merod`.
> 
> Build flows are updated to run `pnpm merod:prepare` in local `tauri:*` scripts, `tauri.conf.json` `before*Command`, and CI workflows; CI also reuses an existing binary via `MEROD_SKIP_IF_EXISTS`, and Windows CI now builds `merod.exe` from the matching `core` git tag since Windows release assets aren’t published. Bundling/resource resolution is adjusted to include the `merod` directory and to locate either `merod` or `merod.exe`, and `merod-config.json` is bumped to `0.10.1-rc.9`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48bf5df2f6b8a4af9122eab5e67334b20ade3447. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->