### PR TITLE
WIP feat: update image creation for linux

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -185,30 +185,23 @@ jobs:
           MEROD_SKIP_IF_EXISTS: "1"
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-        run: pnpm tauri build
+        run: pnpm tauri build -- --bundles deb,rpm
 
       - name: Verify build outputs
         if: steps.build-mode.outputs.mode == 'validation'
         run: |
           echo "Checking for expected build outputs..."
 
-          APPIMAGE_FILE=$(find apps/desktop/src-tauri/target/release/bundle -name "*.AppImage" 2>/dev/null | head -1)
           DEB_FILE=$(find apps/desktop/src-tauri/target/release/bundle -name "*.deb" 2>/dev/null | head -1)
           RPM_FILE=$(find apps/desktop/src-tauri/target/release/bundle -name "*.rpm" 2>/dev/null | head -1)
 
-          if [ -z "$APPIMAGE_FILE" ]; then
-            echo "Error: AppImage not found"
+          if [ -z "$DEB_FILE" ] && [ -z "$RPM_FILE" ]; then
+            echo "Error: Neither .deb nor .rpm package found"
             exit 1
           fi
-          echo "AppImage: $APPIMAGE_FILE"
 
-          if [ -n "$DEB_FILE" ]; then
-            echo "DEB: $DEB_FILE"
-          fi
-
-          if [ -n "$RPM_FILE" ]; then
-            echo "RPM: $RPM_FILE"
-          fi
+          [ -n "$DEB_FILE" ] && echo "DEB: $DEB_FILE"
+          [ -n "$RPM_FILE" ] && echo "RPM: $RPM_FILE"
 
           echo "Build validation passed"
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -185,7 +185,7 @@ jobs:
           MEROD_SKIP_IF_EXISTS: "1"
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-        run: pnpm tauri build -- --bundles deb,rpm
+        run: pnpm exec tauri build --bundles deb,rpm
 
       - name: Verify build outputs
         if: steps.build-mode.outputs.mode == 'validation'

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -200,8 +200,8 @@ jobs:
             exit 1
           fi
 
-          [ -n "$DEB_FILE" ] && echo "DEB: $DEB_FILE"
-          [ -n "$RPM_FILE" ] && echo "RPM: $RPM_FILE"
+          [ -n "$DEB_FILE" ] && echo "DEB: $DEB_FILE ($(du -sh "$DEB_FILE" | cut -f1))"
+          [ -n "$RPM_FILE" ] && echo "RPM: $RPM_FILE ($(du -sh "$RPM_FILE" | cut -f1))"
 
           echo "Build validation passed"
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.5", features = [ "system-tray", "updater", "process-relaunch", "shell-open", "http-all", "window-all", "devtools", "dialog-all", "icon-png"] }
+tauri = { version = "1.5", features = [ "system-tray", "updater", "process-relaunch", "shell-open", "http-all", "window-all", "dialog-all", "icon-png"] }
 tauri-plugin-autostart = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -24,8 +24,15 @@ dirs = "5.0"
 toml = "0.8"
 regex = "1.10"
 
+[profile.release]
+strip = "symbols"
+lto = true
+opt-level = "s"
+codegen-units = 1
+
 [features]
 default = ["custom-protocol", "autostart"]
 custom-protocol = ["tauri/custom-protocol"]
 autostart = ["dep:tauri-plugin-autostart"]
+devtools = ["tauri/devtools"]
 

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -527,6 +527,7 @@ async fn create_app_window(
     if should_open_devtools {
         // Wait a bit for window to be ready, then open devtools
         tokio::time::sleep(tokio::time::Duration::from_millis(800)).await;
+        #[cfg(feature = "devtools")]
         window.open_devtools();
     }
     
@@ -534,15 +535,18 @@ async fn create_app_window(
 }
 
 #[tauri::command]
-async fn open_devtools(window_label: String, app_handle: tauri::AppHandle) {
-    // Try multiple times with delays in case window isn't ready yet
-    for _i in 0..5 {
-        if let Some(window) = app_handle.get_window(&window_label) {
-            window.open_devtools();
-            return;
+async fn open_devtools(_window_label: String, _app_handle: tauri::AppHandle) {
+    #[cfg(feature = "devtools")]
+    {
+        // Try multiple times with delays in case window isn't ready yet
+        for _i in 0..5 {
+            if let Some(window) = _app_handle.get_window(&_window_label) {
+                window.open_devtools();
+                return;
+            }
+            // Wait a bit before retrying (use async sleep to avoid blocking runtime)
+            tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
         }
-        // Wait a bit before retrying (use async sleep to avoid blocking runtime)
-        tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
     }
 }
 
@@ -1831,6 +1835,7 @@ fn main() {
             if should_open_main_devtools {
                 use tauri::Manager;
                 if let Some(window) = app.get_window("main") {
+                    #[cfg(feature = "devtools")]
                     window.open_devtools();
                 }
             }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -524,10 +524,9 @@ async fn create_app_window(
         }
     };
     
+    #[cfg(feature = "devtools")]
     if should_open_devtools {
-        // Wait a bit for window to be ready, then open devtools
         tokio::time::sleep(tokio::time::Duration::from_millis(800)).await;
-        #[cfg(feature = "devtools")]
         window.open_devtools();
     }
     
@@ -1832,10 +1831,10 @@ fn main() {
                 }
             };
             
+            #[cfg(feature = "devtools")]
             if should_open_main_devtools {
                 use tauri::Manager;
                 if let Some(window) = app.get_window("main") {
-                    #[cfg(feature = "devtools")]
                     window.open_devtools();
                 }
             }

--- a/scripts/release/collect-assets.cjs
+++ b/scripts/release/collect-assets.cjs
@@ -61,21 +61,6 @@ const PLATFORM_CONFIG = {
   linux: {
     searchPaths: ["apps/desktop/src-tauri/target/release/bundle"],
     artifacts: [
-      {
-        pattern: /\.AppImage$/,
-        suffix: "_linux_x64.AppImage",
-        type: "installer",
-      },
-      {
-        pattern: /\.AppImage\.tar\.gz$/,
-        suffix: "_linux_x64.AppImage.tar.gz",
-        type: "updater",
-      },
-      {
-        pattern: /\.AppImage\.tar\.gz\.sig$/,
-        suffix: "_linux_x64.AppImage.tar.gz.sig",
-        type: "signature",
-      },
       { pattern: /\.deb$/, suffix: "_linux_x64.deb", type: "installer" },
       { pattern: /\.rpm$/, suffix: "_linux_x64.rpm", type: "installer" },
     ],

--- a/scripts/release/generate-latest-json.cjs
+++ b/scripts/release/generate-latest-json.cjs
@@ -13,17 +13,17 @@ const fs = require("fs");
 const path = require("path");
 
 // Tauri v1 platform identifiers
+// Note: Linux is excluded — .deb/.rpm don't support Tauri's built-in updater.
+// Linux users update via their package manager.
 const TAURI_PLATFORMS = {
   macos: ["darwin-universal", "darwin-x86_64", "darwin-aarch64"],
   windows: ["windows-x86_64"],
-  linux: ["linux-x86_64"],
 };
 
 // Map our artifact types to Tauri updater expectations
 const UPDATER_ASSET_SUFFIX = {
   macos: "_macos_universal.app.tar.gz",
   windows: "_windows_x64.nsis.zip",
-  linux: "_linux_x64.AppImage.tar.gz",
 };
 
 function parseArgs() {

--- a/scripts/release/generate-release-json.cjs
+++ b/scripts/release/generate-release-json.cjs
@@ -26,7 +26,7 @@ const DOWNLOAD_META = {
 const PRIMARY_FORMAT = {
   macos: "dmg",
   windows: "exe",
-  linux: "appimage",
+  linux: "deb",
 };
 
 function parseArgs() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Linux release artifacts and updater/feed generation, which could break packaging or downloads if expectations differ. Runtime changes are limited to devtools compilation flags and release build settings.
> 
> **Overview**
> Linux desktop CI now builds **only** `.deb`/`.rpm` bundles (no AppImage) and validates/collects those artifacts for releases.
> 
> Release tooling is updated accordingly: `collect-assets.cjs` stops looking for AppImage (+ updater/signature), `generate-latest-json.cjs` no longer emits Linux entries because `.deb`/`.rpm` aren’t compatible with Tauri’s built-in updater, and `generate-release-json.cjs` makes `.deb` the primary Linux download.
> 
> Desktop app build config is tightened by adding a size-optimized release profile and gating all devtools-opening code behind a new `devtools` feature (and removing always-on `tauri` devtools in default deps).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d78fccf2f74df2e5d52878197b359f357e4c12b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->