### PR TITLE
fix: linux build v2

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -129,6 +129,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm merod:prepare
 
+      - name: Strip merod binary
+        run: |
+          MEROD_BINARY="apps/desktop/src-tauri/merod/merod"
+          if [ -f "$MEROD_BINARY" ]; then
+            BEFORE=$(stat --printf="%s" "$MEROD_BINARY")
+            strip "$MEROD_BINARY"
+            AFTER=$(stat --printf="%s" "$MEROD_BINARY")
+            echo "Stripped merod: $(( BEFORE / 1024 / 1024 ))MB → $(( AFTER / 1024 / 1024 ))MB"
+          else
+            echo "Warning: merod binary not found at $MEROD_BINARY"
+          fi
+
       - name: Update version in tauri.conf.json
         if: steps.build-mode.outputs.mode == 'release'
         run: |
@@ -185,20 +197,22 @@ jobs:
           MEROD_SKIP_IF_EXISTS: "1"
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-        run: pnpm exec tauri build --bundles deb,rpm
+        run: pnpm exec tauri build --bundles appimage,deb,rpm
 
       - name: Verify build outputs
         if: steps.build-mode.outputs.mode == 'validation'
         run: |
           echo "Checking for expected build outputs..."
 
+          APPIMAGE_FILE=$(find apps/desktop/src-tauri/target/release/bundle -name "*.AppImage" 2>/dev/null | head -1)
           DEB_FILE=$(find apps/desktop/src-tauri/target/release/bundle -name "*.deb" 2>/dev/null | head -1)
           RPM_FILE=$(find apps/desktop/src-tauri/target/release/bundle -name "*.rpm" 2>/dev/null | head -1)
 
-          if [ -z "$DEB_FILE" ] && [ -z "$RPM_FILE" ]; then
-            echo "Error: Neither .deb nor .rpm package found"
+          if [ -z "$APPIMAGE_FILE" ]; then
+            echo "Error: AppImage not found"
             exit 1
           fi
+          echo "AppImage: $APPIMAGE_FILE ($(du -sh "$APPIMAGE_FILE" | cut -f1))"
 
           [ -n "$DEB_FILE" ] && echo "DEB: $DEB_FILE ($(du -sh "$DEB_FILE" | cut -f1))"
           [ -n "$RPM_FILE" ] && echo "RPM: $RPM_FILE ($(du -sh "$RPM_FILE" | cut -f1))"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.31"
+    "version": "0.0.32"
   },
   "tauri": {
     "allowlist": {

--- a/scripts/release/collect-assets.cjs
+++ b/scripts/release/collect-assets.cjs
@@ -61,6 +61,17 @@ const PLATFORM_CONFIG = {
   linux: {
     searchPaths: ["apps/desktop/src-tauri/target/release/bundle"],
     artifacts: [
+      { pattern: /\.AppImage$/, suffix: "_linux_x64.AppImage", type: "installer" },
+      {
+        pattern: /\.AppImage\.tar\.gz$/,
+        suffix: "_linux_x64.AppImage.tar.gz",
+        type: "updater",
+      },
+      {
+        pattern: /\.AppImage\.tar\.gz\.sig$/,
+        suffix: "_linux_x64.AppImage.tar.gz.sig",
+        type: "signature",
+      },
       { pattern: /\.deb$/, suffix: "_linux_x64.deb", type: "installer" },
       { pattern: /\.rpm$/, suffix: "_linux_x64.rpm", type: "installer" },
     ],

--- a/scripts/release/generate-latest-json.cjs
+++ b/scripts/release/generate-latest-json.cjs
@@ -13,17 +13,17 @@ const fs = require("fs");
 const path = require("path");
 
 // Tauri v1 platform identifiers
-// Note: Linux is excluded — .deb/.rpm don't support Tauri's built-in updater.
-// Linux users update via their package manager.
 const TAURI_PLATFORMS = {
   macos: ["darwin-universal", "darwin-x86_64", "darwin-aarch64"],
   windows: ["windows-x86_64"],
+  linux: ["linux-x86_64"],
 };
 
 // Map our artifact types to Tauri updater expectations
 const UPDATER_ASSET_SUFFIX = {
   macos: "_macos_universal.app.tar.gz",
   windows: "_windows_x64.nsis.zip",
+  linux: "_linux_x64.AppImage.tar.gz",
 };
 
 function parseArgs() {

--- a/scripts/release/generate-release-json.cjs
+++ b/scripts/release/generate-release-json.cjs
@@ -26,7 +26,7 @@ const DOWNLOAD_META = {
 const PRIMARY_FORMAT = {
   macos: "dmg",
   windows: "exe",
-  linux: "deb",
+  linux: "appimage",
 };
 
 function parseArgs() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the Linux build/release artifact set and updater manifests, which can break packaging or auto-update behavior if artifact naming/output differs from expectations. No runtime application logic changes beyond a version bump.
> 
> **Overview**
> **Linux releases now produce and validate AppImage bundles.** The Linux GitHub Actions workflow strips the bundled `merod` binary, builds `appimage,deb,rpm`, and updates validation to require an `.AppImage` output.
> 
> **Release asset generation and updater metadata now include Linux.** `collect-assets.cjs` collects AppImage installer/updater/signature artifacts, `generate-latest-json.cjs` adds `linux-x86_64` updater entries keyed off the AppImage `.tar.gz`, and `generate-release-json.cjs` switches Linux primary download format from `.deb` to AppImage.
> 
> Bumps the desktop app version to `0.0.32` in `package.json` and `tauri.conf.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c0fc22ae36ca610746c48409b3c4cce7b313c48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->