### PR TITLE
feat: update windows build + merod version

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -248,6 +248,7 @@ jobs:
         working-directory: apps/desktop
         env:
           MEROD_SKIP_IF_EXISTS: "1"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
@@ -267,6 +268,8 @@ jobs:
         working-directory: apps/desktop
         id: build-app-validation
         env:
+          MEROD_SKIP_IF_EXISTS: "1"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -168,7 +168,7 @@ jobs:
             echo "Error: merod.exe not found at $DEST"
             exit 1
           fi
-          echo "merod.exe ready ($(stat --printf='%s' "$DEST" 2>/dev/null || stat -f'%z' "$DEST") bytes)"
+          echo "merod.exe ready ($(wc -c < "$DEST") bytes)"
 
       - name: Prepare merod binary
         working-directory: apps/desktop
@@ -225,6 +225,8 @@ jobs:
           MEROD_SKIP_IF_EXISTS: "1"
           CARGO_PROFILE_RELEASE_LTO: "thin"
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         run: pnpm tauri build
 
       - name: Sign Windows installer (optional)

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -126,15 +126,30 @@ jobs:
         working-directory: apps/desktop
         run: pnpm tauri icon src-tauri/icons/icon.png
 
+      - name: Read merod version
+        id: merod-version
+        shell: bash
+        run: |
+          VERSION="$(node -p "require('./merod-config.json').version")"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Cache merod binary (Windows)
+        id: cache-merod
+        uses: actions/cache@v4
+        with:
+          path: apps/desktop/src-tauri/merod/merod.exe
+          key: windows-merod-${{ steps.merod-version.outputs.version }}
+
       # calimero-network/core does not publish merod_* Windows archives on GitHub Releases (only macOS/Linux).
-      # MEROD_ASSET_FALLBACK cannot fix that. Build merod from the same git tag as merod-config.json.
+      # Build from source only when the cached binary is missing.
       - name: Build merod from source (Windows)
+        if: steps.cache-merod.outputs.cache-hit != 'true'
         shell: bash
         env:
           CARGO_INCREMENTAL: "0"
         run: |
           set -euo pipefail
-          VERSION="$(node -p "require('./merod-config.json').version")"
+          VERSION="${{ steps.merod-version.outputs.version }}"
           DEST="${GITHUB_WORKSPACE}/apps/desktop/src-tauri/merod/merod.exe"
           mkdir -p "$(dirname "$DEST")"
           CORE_TMP="${RUNNER_TEMP}/calimero-core-${VERSION}"
@@ -145,11 +160,20 @@ jobs:
           cp "target/release/merod.exe" "$DEST"
           ls -la "$DEST"
 
+      - name: Verify merod binary exists
+        shell: bash
+        run: |
+          DEST="apps/desktop/src-tauri/merod/merod.exe"
+          if [ ! -f "$DEST" ]; then
+            echo "Error: merod.exe not found at $DEST"
+            exit 1
+          fi
+          echo "merod.exe ready ($(stat --printf='%s' "$DEST" 2>/dev/null || stat -f'%z' "$DEST") bytes)"
+
       - name: Prepare merod binary
         working-directory: apps/desktop
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Binary already built from source above; skip GitHub download (no Windows release asset exists).
           MEROD_SKIP_IF_EXISTS: "1"
         run: pnpm merod:prepare
 
@@ -185,13 +209,22 @@ jobs:
             echo "No TAURI_PUBLIC_KEY provided, using default pubkey"
           fi
 
-      - name: Build Tauri app for Windows
+      - name: Build Tauri app for Windows (release)
+        if: steps.build-mode.outputs.mode == 'release'
         working-directory: apps/desktop
         env:
-          # beforeBuildCommand runs merod:prepare again; keep using the binary built above (no Windows GitHub asset).
           MEROD_SKIP_IF_EXISTS: "1"
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+        run: pnpm tauri build
+
+      - name: Build Tauri app for Windows (validation)
+        if: steps.build-mode.outputs.mode == 'validation'
+        working-directory: apps/desktop
+        env:
+          MEROD_SKIP_IF_EXISTS: "1"
+          CARGO_PROFILE_RELEASE_LTO: "thin"
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
         run: pnpm tauri build
 
       - name: Sign Windows installer (optional)

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.10.1-rc.9"
+    "version": "0.10.1-rc.17"
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes release/validation build workflows for Windows/macOS and the merod version, which can affect CI reliability and the shipped desktop bundle.
> 
> **Overview**
> Updates CI packaging for the desktop app by **bumping `merod` to `0.10.1-rc.17`** and improving how the Windows build obtains that binary.
> 
> On Windows, the workflow now caches `merod.exe` by version, builds it from source only on cache miss, and fails fast if the binary is still missing; it also splits `tauri build` into separate *release* vs *validation* steps with additional Rust profile env tuning for validation.
> 
> On macOS, the validation build step now passes `GITHUB_TOKEN` and sets `MEROD_SKIP_IF_EXISTS` (and release build now explicitly passes `GITHUB_TOKEN`) to make `merod` preparation consistent across modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54a8712e46a1644240ba9028bc5f97a58f2cd7d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->