### PR TITLE
feat: integrate Calimero Cloud login into desktop app

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -488,6 +488,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-deep-link",
  "thiserror",
  "tokio",
  "toml 0.8.23",
@@ -2029,6 +2030,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "interprocess"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f2533f3be42fffe3b5e63b71aeca416c1c3bc33e4e27be018521e76b1f38fb"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustc_version",
+ "to_method",
+ "winapi",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,6 +2624,28 @@ dependencies = [
  "objc",
  "objc_id",
 ]
+
+[[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
 name = "objc_exception"
@@ -3378,7 +3414,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4170,6 +4206,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4536f5f6602e8fdfaa7b3b185076c2a0704f8eb7015f4e58461eb483ec3ed1f8"
+dependencies = [
+ "dirs 5.0.1",
+ "interprocess",
+ "log",
+ "objc2",
+ "once_cell",
+ "tauri-utils",
+ "windows-sys 0.48.0",
+ "winreg 0.50.0",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4349,6 +4401,12 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "to_method"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
 
 [[package]]
 name = "tokio"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ toml = "0.8"
 regex = "1.10"
 thiserror = "1.0"
 keyring = "2"
+tauri-plugin-deep-link = "0.1"
 
 [profile.release]
 strip = "symbols"

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>network.calimero.desktop</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>calimero</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -2197,32 +2197,8 @@ fn main() {
             get_pending_cloud_auth,
             clear_pending_cloud_auth
         ])
-        .build(tauri::generate_context!())
-        .expect("error while building tauri application")
-        .run(|app_handle, event| {
-            // Handle calimero:// deep link URLs when app is already running (macOS Apple Events)
-            #[allow(unused_variables)]
-            if let tauri::RunEvent::Opened { urls } = &event {
-                for url in urls {
-                    let url_str = url.to_string();
-                    if url_str.starts_with("calimero://") {
-                        info!("Received deep link: {}", url_str);
-                        if let Some(state) = app_handle.try_state::<PendingCloudAuth>() {
-                            if let Ok(mut g) = state.0.lock() {
-                                *g = Some(url_str.clone());
-                            }
-                        }
-                        // Emit event to frontend so it can react immediately
-                        let _ = app_handle.emit_all("cloud-auth-callback", url_str);
-                        // Focus the main window
-                        if let Some(window) = app_handle.get_window("main") {
-                            let _ = window.show();
-                            let _ = window.set_focus();
-                        }
-                    }
-                }
-            }
-        });
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -2034,6 +2034,12 @@ fn secure_delete_token(key: String) -> Result<(), String> {
 }
 
 fn main() {
+    // Register the calimero:// URL scheme handler before Tauri builds.
+    // Required for tauri-plugin-deep-link to intercept OS-level scheme
+    // events (e.g. NSAppleEventManager on macOS) so a running app
+    // receives the deep link instead of a second instance launching.
+    tauri_plugin_deep_link::prepare("network.calimero.desktop");
+
     // Initialize logger - reads from RUST_LOG environment variable
     // Default: info level in release, debug level in debug builds
     env_logger::Builder::from_default_env()
@@ -2111,9 +2117,32 @@ fn main() {
             let pending = parse_open_app_args();
             app.manage(PendingOpenApp(std::sync::Mutex::new(pending.clone())));
 
-            // Check CLI args for calimero:// deep link URL (used by OS URL scheme handler)
+            // Check CLI args for calimero:// deep link URL (cold-launch case,
+            // e.g. macOS routes the URL via argv when the app was not running).
             let cloud_auth = parse_deep_link_arg();
             app.manage(PendingCloudAuth(std::sync::Mutex::new(cloud_auth)));
+
+            // Hot-launch case: the app is already running when the browser
+            // redirects to calimero://…. The plugin hooks NSAppleEventManager
+            // (macOS) / the registered scheme handler (Windows/Linux) and
+            // delivers the URL to the running process. We stash it in
+            // PendingCloudAuth and emit an event so the frontend can react
+            // without polling.
+            let deep_link_handle = app.handle();
+            if let Err(e) = tauri_plugin_deep_link::register("calimero", move |request| {
+                if let Some(state) = deep_link_handle.try_state::<PendingCloudAuth>() {
+                    if let Ok(mut g) = state.0.lock() {
+                        *g = Some(request.clone());
+                    }
+                }
+                let _ = deep_link_handle.emit_all("cloud-auth-callback", request);
+                if let Some(window) = deep_link_handle.get_window("main") {
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                }
+            }) {
+                log::warn!("deep-link register failed: {e}");
+            }
             // When launched from a desktop shortcut, hide the main window so only the app window is shown
             if pending.is_some() {
                 if let Some(window) = app.get_window("main") {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -139,8 +139,21 @@ fn parse_open_app_args() -> Option<(String, String)> {
     url.map(|u| (u, name.unwrap_or_else(|| "Application".to_string())))
 }
 
+/// Check CLI args for a calimero:// deep link URL (passed by OS when app is launched via URL scheme).
+fn parse_deep_link_arg() -> Option<String> {
+    for arg in std::env::args() {
+        if arg.starts_with("calimero://") {
+            return Some(arg);
+        }
+    }
+    None
+}
+
 /// State for app to open when launched from a desktop shortcut (read by frontend on load).
 pub struct PendingOpenApp(pub std::sync::Mutex<Option<(String, String)>>);
+
+/// State for pending Calimero Cloud auth callback (set by deep link handler, read by frontend).
+pub struct PendingCloudAuth(pub std::sync::Mutex<Option<String>>);
 
 const MAX_NODE_NAME_LENGTH: usize = 64;
 
@@ -431,6 +444,18 @@ fn get_pending_open_app(state: tauri::State<'_, PendingOpenApp>) -> Option<(Stri
 
 #[tauri::command]
 fn clear_pending_open_app(state: tauri::State<'_, PendingOpenApp>) {
+    if let Ok(mut g) = state.0.lock() {
+        *g = None;
+    }
+}
+
+#[tauri::command]
+fn get_pending_cloud_auth(state: tauri::State<'_, PendingCloudAuth>) -> Option<String> {
+    state.0.lock().ok().and_then(|g| g.clone())
+}
+
+#[tauri::command]
+fn clear_pending_cloud_auth(state: tauri::State<'_, PendingCloudAuth>) {
     if let Ok(mut g) = state.0.lock() {
         *g = None;
     }
@@ -2085,6 +2110,10 @@ fn main() {
         .setup(|app| {
             let pending = parse_open_app_args();
             app.manage(PendingOpenApp(std::sync::Mutex::new(pending.clone())));
+
+            // Check CLI args for calimero:// deep link URL (used by OS URL scheme handler)
+            let cloud_auth = parse_deep_link_arg();
+            app.manage(PendingCloudAuth(std::sync::Mutex::new(cloud_auth)));
             // When launched from a desktop shortcut, hide the main window so only the app window is shown
             if pending.is_some() {
                 if let Some(window) = app.get_window("main") {
@@ -2164,10 +2193,36 @@ fn main() {
             open_url_in_browser,
             secure_store_token,
             secure_get_token,
-            secure_delete_token
+            secure_delete_token,
+            get_pending_cloud_auth,
+            clear_pending_cloud_auth
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            // Handle calimero:// deep link URLs when app is already running (macOS Apple Events)
+            #[allow(unused_variables)]
+            if let tauri::RunEvent::Opened { urls } = &event {
+                for url in urls {
+                    let url_str = url.to_string();
+                    if url_str.starts_with("calimero://") {
+                        info!("Received deep link: {}", url_str);
+                        if let Some(state) = app_handle.try_state::<PendingCloudAuth>() {
+                            if let Ok(mut g) = state.0.lock() {
+                                *g = Some(url_str.clone());
+                            }
+                        }
+                        // Emit event to frontend so it can react immediately
+                        let _ = app_handle.emit_all("cloud-auth-callback", url_str);
+                        // Focus the main window
+                        if let Some(window) = app_handle.get_window("main") {
+                            let _ = window.show();
+                            let _ = window.set_focus();
+                        }
+                    }
+                }
+            }
+        });
 }
 
 #[cfg(test)]

--- a/apps/desktop/src/pages/Namespaces.css
+++ b/apps/desktop/src/pages/Namespaces.css
@@ -596,3 +596,59 @@
   margin-bottom: 16px;
   border: 1px solid rgba(239, 68, 68, 0.2);
 }
+
+/* ─── HA Section ─── */
+.ha-description {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+  line-height: 1.5;
+}
+
+.ha-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: var(--bg-secondary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+}
+
+.ha-status {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.ha-toggle-btn {
+  padding: 6px 16px;
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: white;
+  transition: all 0.2s;
+}
+
+.ha-toggle-btn:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.ha-toggle-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ha-toggle-btn.ha-enabled {
+  background: transparent;
+  color: var(--text-muted);
+  border-color: var(--border);
+}
+
+.ha-toggle-btn.ha-enabled:hover:not(:disabled) {
+  border-color: var(--error);
+  color: var(--error);
+}

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -62,6 +62,55 @@ type View =
   | { type: "namespace"; ns: Namespace }
   | { type: "group"; ns: Namespace; groupId: string };
 
+/**
+ * Find any {group_id, context_id} pair owned by the user under this
+ * namespace. The manager only stores one HaRequest + HaContextStatus
+ * per namespace regardless of how many groups the client sends, so
+ * there is no reason to enumerate them all — we just need one entry
+ * to attach billing + fleet-join bookkeeping to.
+ *
+ * Fast path: most namespaces have a context in the root group
+ * (group_id === namespace_id), so one admin-API call usually suffices.
+ * Fallback: probe every subgroup in parallel and return the first with
+ * a context. Parallel not sequential — the old code did O(N) round
+ * trips serially, which scaled badly with subgroup count.
+ */
+async function findRepresentativeHaGroup(
+  mero: NonNullable<ReturnType<typeof useMero>["mero"]>,
+  namespaceId: string,
+): Promise<NamespaceHaGroup> {
+  const rootCtxs = await mero.admin
+    .listGroupContexts(namespaceId)
+    .catch(() => [] as { contextId: string }[]);
+  if (rootCtxs.length) {
+    return { group_id: namespaceId, context_id: rootCtxs[0].contextId };
+  }
+
+  const subgroups = await mero.admin.listNamespaceGroups(namespaceId);
+  if (!subgroups.length) {
+    throw new Error("This namespace has no groups");
+  }
+
+  const probes = await Promise.all(
+    subgroups.map((g) =>
+      mero.admin
+        .listGroupContexts(g.groupId)
+        .then(
+          (ctxs) =>
+            ctxs[0]
+              ? ({ group_id: g.groupId, context_id: ctxs[0].contextId } as NamespaceHaGroup)
+              : null,
+          () => null,
+        ),
+    ),
+  );
+  const found = probes.find((p): p is NamespaceHaGroup => p !== null);
+  if (!found) {
+    throw new Error("No group in this namespace has a context yet");
+  }
+  return found;
+}
+
 export default function Namespaces() {
   const toast = useToast();
   const { mero } = useMero();
@@ -223,24 +272,15 @@ export default function Namespaces() {
         setHaEnabled((prev) => ({ ...prev, [nsId]: false }));
         toast.success('HA disabled — TEE nodes will stop replicating');
       } else {
-        // Enumerate groups + representative context from the local node so
-        // the cloud can register HA on each group.
-        const groupsInNs = await mero.admin.listNamespaceGroups(nsId);
-        if (!groupsInNs.length) {
-          throw new Error('This namespace has no groups');
-        }
-        const haGroups: NamespaceHaGroup[] = [];
-        for (const g of groupsInNs) {
-          const ctxs = await mero.admin.listGroupContexts(g.groupId);
-          if (!ctxs.length) continue; // skip groups with no contexts
-          haGroups.push({ group_id: g.groupId, context_id: ctxs[0].contextId });
-        }
-        if (!haGroups.length) {
-          throw new Error('No group in this namespace has a context yet');
-        }
-        await enableHaForNamespace(token, settings.nodeUrl, nsId, haGroups);
+        // The cloud only needs ONE representative {group_id, context_id}
+        // per namespace (post mdma#30 / core rc.29 — one HaRequest row
+        // per namespace, auto-follow propagates fleet membership into
+        // subgroups). Find one quickly instead of enumerating every
+        // subgroup sequentially.
+        const haGroup = await findRepresentativeHaGroup(mero, nsId);
+        await enableHaForNamespace(token, settings.nodeUrl, nsId, [haGroup]);
         setHaEnabled((prev) => ({ ...prev, [nsId]: true }));
-        toast.success(`HA enabled on ${haGroups.length} group${haGroups.length === 1 ? '' : 's'} — TEE fleet nodes will join`);
+        toast.success('HA enabled — TEE fleet nodes will join');
       }
     } catch (err: any) {
       if (err instanceof CloudSessionExpiredError) {

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -168,8 +168,9 @@ export default function Namespaces() {
 
   // HA state — keyed by namespaceId (not groupId). A namespace is
   // considered HA-enabled if at least one of its groups has HA enabled
-  // on the cloud side.
-  const [haEnabling, setHaEnabling] = useState(false);
+  // on the cloud side. `haEnabling` is a per-namespace map (not a single
+  // boolean) so toggling one namespace doesn't lock every other toggle.
+  const [haEnabling, setHaEnabling] = useState<Record<string, boolean>>({});
   const [haEnabled, setHaEnabled] = useState<Record<string, boolean>>({});
 
   // Hydrate HA state from the cloud so toggles reflect server truth on mount.
@@ -214,7 +215,7 @@ export default function Namespaces() {
 
     const nsId = ns.namespaceId;
     const isEnabled = !!haEnabled[nsId];
-    setHaEnabling(true);
+    setHaEnabling((prev) => ({ ...prev, [nsId]: true }));
 
     try {
       if (isEnabled) {
@@ -248,7 +249,11 @@ export default function Namespaces() {
         toast.error(err.message || 'Failed to toggle HA');
       }
     } finally {
-      setHaEnabling(false);
+      setHaEnabling((prev) => {
+        const next = { ...prev };
+        delete next[nsId];
+        return next;
+      });
     }
   }, [haEnabled, mero, toast]);
 
@@ -495,9 +500,9 @@ export default function Namespaces() {
               <button
                 className={`ha-toggle-btn ${haEnabled[ns.namespaceId] ? 'ha-enabled' : ''}`}
                 onClick={() => toggleHa(ns)}
-                disabled={haEnabling}
+                disabled={!!haEnabling[ns.namespaceId]}
               >
-                {haEnabling ? 'Working...' : haEnabled[ns.namespaceId] ? 'Disable HA' : 'Enable HA'}
+                {haEnabling[ns.namespaceId] ? 'Working...' : haEnabled[ns.namespaceId] ? 'Disable HA' : 'Enable HA'}
               </button>
             </div>
           </div>

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   useNamespaces,
   useNamespaceGroups,
@@ -16,6 +16,9 @@ import { ArrowLeft, Users, Box, Layers, Copy, ChevronRight, Shield, Globe, Plus,
 import { apiClient } from "../lib/mero-client";
 import { saveContextKey, getContextKey } from "../utils/contextKeys";
 import { decodeMetadata, openAppFrontend } from "../utils/appUtils";
+import { getSettings } from "../utils/settings";
+import { enableHaForNamespace, disableHa, CloudSessionExpiredError } from "../utils/cloudApi";
+import { getCloudIdToken } from "../utils/cloudAuth";
 import "./Namespaces.css";
 
 // Same default as battleships: CAN_CREATE_CONTEXT (1) | CAN_INVITE_MEMBERS (2) | MANAGE_MEMBERS (8).
@@ -156,6 +159,51 @@ export default function Namespaces() {
       executorPublicKey: key?.publicKey,
     });
   };
+
+  // HA state
+  const [haEnabling, setHaEnabling] = useState(false);
+  const [haEnabled, setHaEnabled] = useState<Record<string, boolean>>({});
+
+  const toggleHa = useCallback(async (ns: Namespace) => {
+    const token = getCloudIdToken();
+    if (!token) {
+      toast.error('Connect to Calimero Cloud first (Settings → Cloud)');
+      return;
+    }
+    const settings = getSettings();
+    if (!settings.nodeUrl) {
+      toast.error('Node URL not configured');
+      return;
+    }
+
+    const nsId = ns.namespaceId;
+    const isEnabled = haEnabled[nsId];
+    setHaEnabling(true);
+
+    try {
+      if (isEnabled) {
+        // Find a context in this namespace to disable HA
+        // Use the namespace ID as a proxy context ID for now
+        await disableHa(token, nsId);
+        setHaEnabled((prev) => ({ ...prev, [nsId]: false }));
+        toast.success('HA disabled — TEE nodes will stop replicating');
+      } else {
+        await enableHaForNamespace(token, settings.nodeUrl, nsId, nsId, {
+          acceptMock: true, // Allow mock attestations during development
+        });
+        setHaEnabled((prev) => ({ ...prev, [nsId]: true }));
+        toast.success('HA enabled — TEE fleet nodes will join this namespace');
+      }
+    } catch (err: any) {
+      if (err instanceof CloudSessionExpiredError) {
+        toast.error('Cloud session expired — reconnect in Settings');
+      } else {
+        toast.error(err.message || 'Failed to toggle HA');
+      }
+    } finally {
+      setHaEnabling(false);
+    }
+  }, [haEnabled, toast]);
 
   // View transitions
   const openNamespace = (ns: Namespace) => {
@@ -355,7 +403,6 @@ export default function Namespaces() {
             </div>
           </div>
 
-          <div className="ns-detail-section">
             <h2><Box size={16} /> Contexts ({nsRootContexts.length})</h2>
             {nsRootContexts.length === 0 ? (
               <p className="empty-hint">No contexts in this namespace yet. Click "Create Context" to add one.</p>
@@ -386,6 +433,26 @@ export default function Namespaces() {
                 })}
               </div>
             )}
+          </div>
+
+          <div className="ns-detail-section">
+            <h2><Shield size={16} style={{ marginRight: 6, verticalAlign: -2 }} />High Availability</h2>
+            <p className="ha-description">
+              Enable TEE replication to have fleet nodes automatically join and replicate
+              your namespace data. Requires a Calimero Cloud account with a paid plan.
+            </p>
+            <div className="ha-toggle-row">
+              <span className="ha-status">
+                {haEnabled[ns.namespaceId] ? '✓ HA Enabled' : 'HA Disabled'}
+              </span>
+              <button
+                className={`ha-toggle-btn ${haEnabled[ns.namespaceId] ? 'ha-enabled' : ''}`}
+                onClick={() => toggleHa(ns)}
+                disabled={haEnabling}
+              >
+                {haEnabling ? 'Working...' : haEnabled[ns.namespaceId] ? 'Disable HA' : 'Enable HA'}
+              </button>
+            </div>
           </div>
 
           <div className="ns-detail-section">

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import {
+  useMero,
   useNamespaces,
   useNamespaceGroups,
   useGroupInfo,
@@ -8,7 +9,6 @@ import {
   useSubgroups,
   useCreateNamespace,
   useCreateContext,
-  useMero,
   type Namespace,
 } from "@calimero-network/mero-react";
 import { useToast } from "../contexts/ToastContext";
@@ -17,7 +17,13 @@ import { apiClient } from "../lib/mero-client";
 import { saveContextKey, getContextKey } from "../utils/contextKeys";
 import { decodeMetadata, openAppFrontend } from "../utils/appUtils";
 import { getSettings } from "../utils/settings";
-import { enableHaForNamespace, disableHa, getCloudGroups, CloudSessionExpiredError } from "../utils/cloudApi";
+import {
+  enableHaForNamespace,
+  disableHaNamespace,
+  getCloudGroups,
+  CloudSessionExpiredError,
+  type NamespaceHaGroup,
+} from "../utils/cloudApi";
 import { getCloudIdToken } from "../utils/cloudAuth";
 import "./Namespaces.css";
 
@@ -160,7 +166,9 @@ export default function Namespaces() {
     });
   };
 
-  // HA state
+  // HA state — keyed by namespaceId (not groupId). A namespace is
+  // considered HA-enabled if at least one of its groups has HA enabled
+  // on the cloud side.
   const [haEnabling, setHaEnabling] = useState(false);
   const [haEnabled, setHaEnabled] = useState<Record<string, boolean>>({});
 
@@ -172,11 +180,13 @@ export default function Namespaces() {
     getCloudGroups(token)
       .then((groups) => {
         if (cancelled) return;
-        const next: Record<string, boolean> = {};
+        const byNamespace: Record<string, boolean> = {};
         for (const g of groups) {
-          next[g.group_id] = g.ha_status === "enabled";
+          if (!g.namespace_id) continue;
+          if (g.ha_status === "enabled") byNamespace[g.namespace_id] = true;
+          else if (byNamespace[g.namespace_id] === undefined) byNamespace[g.namespace_id] = false;
         }
-        setHaEnabled(next);
+        setHaEnabled(byNamespace);
       })
       .catch(() => {
         // Silent — HA toggles will stay in local state until next refresh.
@@ -197,22 +207,39 @@ export default function Namespaces() {
       toast.error('Node URL not configured');
       return;
     }
+    if (!mero) {
+      toast.error('Local node client is not ready yet');
+      return;
+    }
 
     const nsId = ns.namespaceId;
-    const isEnabled = haEnabled[nsId];
+    const isEnabled = !!haEnabled[nsId];
     setHaEnabling(true);
 
     try {
       if (isEnabled) {
-        // Find a context in this namespace to disable HA
-        // Use the namespace ID as a proxy context ID for now
-        await disableHa(token, nsId);
+        await disableHaNamespace(token, nsId);
         setHaEnabled((prev) => ({ ...prev, [nsId]: false }));
         toast.success('HA disabled — TEE nodes will stop replicating');
       } else {
-        await enableHaForNamespace(token, settings.nodeUrl, nsId, nsId);
+        // Enumerate groups + representative context from the local node so
+        // the cloud can register HA on each group.
+        const groupsInNs = await mero.admin.listNamespaceGroups(nsId);
+        if (!groupsInNs.length) {
+          throw new Error('This namespace has no groups');
+        }
+        const haGroups: NamespaceHaGroup[] = [];
+        for (const g of groupsInNs) {
+          const ctxs = await mero.admin.listGroupContexts(g.groupId);
+          if (!ctxs.length) continue; // skip groups with no contexts
+          haGroups.push({ group_id: g.groupId, context_id: ctxs[0].contextId });
+        }
+        if (!haGroups.length) {
+          throw new Error('No group in this namespace has a context yet');
+        }
+        await enableHaForNamespace(token, settings.nodeUrl, nsId, haGroups);
         setHaEnabled((prev) => ({ ...prev, [nsId]: true }));
-        toast.success('HA enabled — TEE fleet nodes will join this namespace');
+        toast.success(`HA enabled on ${haGroups.length} group${haGroups.length === 1 ? '' : 's'} — TEE fleet nodes will join`);
       }
     } catch (err: any) {
       if (err instanceof CloudSessionExpiredError) {
@@ -223,7 +250,7 @@ export default function Namespaces() {
     } finally {
       setHaEnabling(false);
     }
-  }, [haEnabled, toast]);
+  }, [haEnabled, mero, toast]);
 
   // View transitions
   const openNamespace = (ns: Namespace) => {

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -71,44 +71,72 @@ type View =
  *
  * Fast path: most namespaces have a context in the root group
  * (group_id === namespace_id), so one admin-API call usually suffices.
- * Fallback: probe every subgroup in parallel and return the first with
- * a context. Parallel not sequential — the old code did O(N) round
- * trips serially, which scaled badly with subgroup count.
+ * Fallback: probe subgroups in bounded-concurrency batches and
+ * early-exit as soon as one batch returns a match. The old code did
+ * O(N) sequential round-trips; bounded batches keep the local admin
+ * API from seeing a burst of parallel requests on large namespaces
+ * while still amortising latency.
  */
+const PROBE_BATCH_SIZE = 6;
+
 async function findRepresentativeHaGroup(
   mero: NonNullable<ReturnType<typeof useMero>["mero"]>,
   namespaceId: string,
 ): Promise<NamespaceHaGroup> {
+  // Fast path failure is tolerated but logged — if it's a real
+  // connectivity issue the fallback path's listNamespaceGroups call
+  // will surface the same error with proper context. We don't
+  // distinguish "404 / no contexts" from other errors here because
+  // mero-js doesn't expose a stable error shape to switch on; the
+  // warning in dev console is what surfaces the cause.
   const rootCtxs = await mero.admin
     .listGroupContexts(namespaceId)
-    .catch(() => [] as { contextId: string }[]);
+    .catch((err: unknown) => {
+      console.warn(
+        `listGroupContexts(${namespaceId}) failed on fast path, falling through to subgroup probe:`,
+        err,
+      );
+      return [] as { contextId: string }[];
+    });
   if (rootCtxs.length) {
     return { group_id: namespaceId, context_id: rootCtxs[0].contextId };
   }
 
-  const subgroups = await mero.admin.listNamespaceGroups(namespaceId);
+  const allGroups = await mero.admin.listNamespaceGroups(namespaceId);
+  // Root already proven empty on the fast path — drop it so we don't
+  // re-probe it in the fallback.
+  const subgroups = allGroups.filter((g) => g.groupId !== namespaceId);
   if (!subgroups.length) {
     throw new Error("This namespace has no groups");
   }
 
-  const probes = await Promise.all(
-    subgroups.map((g) =>
-      mero.admin
-        .listGroupContexts(g.groupId)
-        .then(
-          (ctxs) =>
-            ctxs[0]
-              ? ({ group_id: g.groupId, context_id: ctxs[0].contextId } as NamespaceHaGroup)
-              : null,
-          () => null,
-        ),
-    ),
-  );
-  const found = probes.find((p): p is NamespaceHaGroup => p !== null);
-  if (!found) {
-    throw new Error("No group in this namespace has a context yet");
+  for (let i = 0; i < subgroups.length; i += PROBE_BATCH_SIZE) {
+    const batch = subgroups.slice(i, i + PROBE_BATCH_SIZE);
+    const probes = await Promise.all(
+      batch.map((g) =>
+        mero.admin
+          .listGroupContexts(g.groupId)
+          .then(
+            (ctxs) =>
+              ctxs[0]
+                ? ({ group_id: g.groupId, context_id: ctxs[0].contextId } as NamespaceHaGroup)
+                : null,
+            (err: unknown) => {
+              // Per-probe failure logged but non-fatal — another
+              // subgroup may still resolve. If every probe fails the
+              // caller sees the "no context yet" error below, and the
+              // dev console has the underlying reason.
+              console.warn(`listGroupContexts(${g.groupId}) failed:`, err);
+              return null;
+            },
+          ),
+      ),
+    );
+    const found = probes.find((p): p is NamespaceHaGroup => p !== null);
+    if (found) return found;
   }
-  return found;
+
+  throw new Error("No group in this namespace has a context yet");
 }
 
 export default function Namespaces() {

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -17,7 +17,7 @@ import { apiClient } from "../lib/mero-client";
 import { saveContextKey, getContextKey } from "../utils/contextKeys";
 import { decodeMetadata, openAppFrontend } from "../utils/appUtils";
 import { getSettings } from "../utils/settings";
-import { enableHaForNamespace, disableHa, CloudSessionExpiredError } from "../utils/cloudApi";
+import { enableHaForNamespace, disableHa, getCloudGroups, CloudSessionExpiredError } from "../utils/cloudApi";
 import { getCloudIdToken } from "../utils/cloudAuth";
 import "./Namespaces.css";
 
@@ -163,6 +163,28 @@ export default function Namespaces() {
   // HA state
   const [haEnabling, setHaEnabling] = useState(false);
   const [haEnabled, setHaEnabled] = useState<Record<string, boolean>>({});
+
+  // Hydrate HA state from the cloud so toggles reflect server truth on mount.
+  useEffect(() => {
+    const token = getCloudIdToken();
+    if (!token) return;
+    let cancelled = false;
+    getCloudGroups(token)
+      .then((groups) => {
+        if (cancelled) return;
+        const next: Record<string, boolean> = {};
+        for (const g of groups) {
+          next[g.group_id] = g.ha_status === "enabled";
+        }
+        setHaEnabled(next);
+      })
+      .catch(() => {
+        // Silent — HA toggles will stay in local state until next refresh.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const toggleHa = useCallback(async (ns: Namespace) => {
     const token = getCloudIdToken();

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -188,9 +188,7 @@ export default function Namespaces() {
         setHaEnabled((prev) => ({ ...prev, [nsId]: false }));
         toast.success('HA disabled — TEE nodes will stop replicating');
       } else {
-        await enableHaForNamespace(token, settings.nodeUrl, nsId, nsId, {
-          acceptMock: true, // Allow mock attestations during development
-        });
+        await enableHaForNamespace(token, settings.nodeUrl, nsId, nsId);
         setHaEnabled((prev) => ({ ...prev, [nsId]: true }));
         toast.success('HA enabled — TEE fleet nodes will join this namespace');
       }

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -25,6 +25,7 @@ import {
   type NamespaceHaGroup,
 } from "../utils/cloudApi";
 import { getCloudIdToken } from "../utils/cloudAuth";
+import { isCloudEnabled } from "../utils/featureFlags";
 import "./Namespaces.css";
 
 // Same default as battleships: CAN_CREATE_CONTEXT (1) | CAN_INVITE_MEMBERS (2) | MANAGE_MEMBERS (8).
@@ -523,6 +524,7 @@ export default function Namespaces() {
             </div>
           </div>
 
+          <div className="ns-detail-section">
             <h2><Box size={16} /> Contexts ({nsRootContexts.length})</h2>
             {nsRootContexts.length === 0 ? (
               <p className="empty-hint">No contexts in this namespace yet. Click "Create Context" to add one.</p>
@@ -555,25 +557,27 @@ export default function Namespaces() {
             )}
           </div>
 
-          <div className="ns-detail-section">
-            <h2><Shield size={16} style={{ marginRight: 6, verticalAlign: -2 }} />High Availability</h2>
-            <p className="ha-description">
-              Enable TEE replication to have fleet nodes automatically join and replicate
-              your namespace data. Requires a Calimero Cloud account with a paid plan.
-            </p>
-            <div className="ha-toggle-row">
-              <span className="ha-status">
-                {haEnabled[ns.namespaceId] ? '✓ HA Enabled' : 'HA Disabled'}
-              </span>
-              <button
-                className={`ha-toggle-btn ${haEnabled[ns.namespaceId] ? 'ha-enabled' : ''}`}
-                onClick={() => toggleHa(ns)}
-                disabled={!!haEnabling[ns.namespaceId]}
-              >
-                {haEnabling[ns.namespaceId] ? 'Working...' : haEnabled[ns.namespaceId] ? 'Disable HA' : 'Enable HA'}
-              </button>
+          {isCloudEnabled() && (
+            <div className="ns-detail-section">
+              <h2><Shield size={16} style={{ marginRight: 6, verticalAlign: -2 }} />High Availability</h2>
+              <p className="ha-description">
+                Enable TEE replication to have fleet nodes automatically join and replicate
+                your namespace data. Requires a Calimero Cloud account with a paid plan.
+              </p>
+              <div className="ha-toggle-row">
+                <span className="ha-status">
+                  {haEnabled[ns.namespaceId] ? '✓ HA Enabled' : 'HA Disabled'}
+                </span>
+                <button
+                  className={`ha-toggle-btn ${haEnabled[ns.namespaceId] ? 'ha-enabled' : ''}`}
+                  onClick={() => toggleHa(ns)}
+                  disabled={!!haEnabling[ns.namespaceId]}
+                >
+                  {haEnabling[ns.namespaceId] ? 'Working...' : haEnabled[ns.namespaceId] ? 'Disable HA' : 'Enable HA'}
+                </button>
+              </div>
             </div>
-          </div>
+          )}
 
           <div className="ns-detail-section">
             <h2>Groups</h2>

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -6,6 +6,7 @@ import { initMerodNode, startMerod, listMerodNodes, detectRunningMerodNodes, wai
 import { invoke } from "@tauri-apps/api/tauri";
 import { saveSettings, getSettings } from "../utils/settings";
 import { saveOnboardingProgress, loadOnboardingProgress } from "../utils/onboardingProgress";
+import { startCloudLogin } from "../utils/cloudAuth";
 import { fetchAppsFromAllRegistries, fetchAppManifest, recordDownload, type AppSummary } from "../utils/registry";
 import { useToast } from "../contexts/ToastContext";
 import { useTheme } from "../contexts/ThemeContext";
@@ -20,9 +21,9 @@ interface OnboardingProps {
   onSettings?: () => void;
 }
 
-type OnboardingStep = 'welcome' | 'what-is' | 'node-setup' | 'login' | 'install-app';
+type OnboardingStep = 'welcome' | 'what-is' | 'node-setup' | 'cloud-connect' | 'login' | 'install-app';
 
-const ONBOARDING_STEPS: OnboardingStep[] = ['welcome', 'what-is', 'node-setup', 'login', 'install-app'];
+const ONBOARDING_STEPS: OnboardingStep[] = ['welcome', 'what-is', 'node-setup', 'cloud-connect', 'login', 'install-app'];
 
 
 export default function Onboarding({ onComplete, onSettings }: OnboardingProps) {
@@ -88,6 +89,8 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
       const [nodeStarted, setNodeStarted] = useState(false);
       const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const [loginTransitioning, setLoginTransitioning] = useState(false);
+  const [cloudConnecting, setCloudConnecting] = useState(false);
+  const [cloudConnected, setCloudConnected] = useState(() => getSettings().cloudConnected ?? false);
   const [existingNodes, setExistingNodes] = useState<string[]>([]);
   const [useExistingNode, setUseExistingNode] = useState<string | null>(() => loadOnboardingProgress()?.useExistingNode ?? null);
   const [loadingExistingNodes, setLoadingExistingNodes] = useState(false);
@@ -176,7 +179,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
             }
             setTheme('dark');
             setCreatingNode(false);
-            setCurrentStep('login');
+            setCurrentStep('cloud-connect');
             return;
           } catch (err) {
             console.error('Failed to use existing node:', err);
@@ -225,15 +228,15 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
     setNodeError(null);
     
     try {
-      const advanceToLogin = () => {
+      const advanceToCloudConnect = () => {
         setTimeout(async () => {
           try {
             const onboardingState = await checkOnboardingState();
             setState(onboardingState);
-            setCurrentStep('login');
+            setCurrentStep('cloud-connect');
           } catch (err) {
             console.error("Failed to check onboarding state:", err);
-            setCurrentStep('login');
+            setCurrentStep('cloud-connect');
           }
         }, 2000);
       };
@@ -257,7 +260,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
           });
           // check_merod_health appends /health — use /auth so it hits /auth/health
           await waitForNodeHealthy(`${nodeUrl}/auth`, 5000);
-          advanceToLogin();
+          advanceToCloudConnect();
           return;
         }
 
@@ -276,7 +279,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
         });
         // check_merod_health appends /health — use /auth so it hits /auth/health
         await waitForNodeHealthy(`${nodeUrl}/auth`, 20000);
-        advanceToLogin();
+        advanceToCloudConnect();
       } else {
         // Create new node
         try {
@@ -306,7 +309,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
         });
         // check_merod_health appends /health — use /auth so it hits /auth/health
         await waitForNodeHealthy(`${nodeUrl}/auth`, 20000);
-        advanceToLogin();
+        advanceToCloudConnect();
       }
     } catch (error: any) {
       console.error("Failed to create/start node:", error);
@@ -888,6 +891,87 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
               </div>
             </div>
             )}
+          </div>
+          <ScrollHint containerRef={stepContainerRef} />
+        </div>
+      </div>
+    );
+  }
+
+  // Cloud connect step - optional, skippable
+  if (currentStep === 'cloud-connect') {
+    return (
+      <div className="onboarding-page" data-testid="onboarding-page">
+        <ProgressIndicator />
+        <div ref={stepContainerRef} className="onboarding-step-container">
+          <div className="step-content">
+            <h1 className="step-title">Connect to Calimero Cloud</h1>
+            <p className="step-description">
+              Sign in with Google to enable cloud features like High Availability,
+              cloud-hosted contexts, and managed infrastructure. This is optional &mdash;
+              your local node works fully without it.
+            </p>
+            <div className="onboarding-card" style={{ textAlign: 'center', padding: '32px' }}>
+              {cloudConnecting ? (
+                <div className="loading-spinner">
+                  <div className="spinner" />
+                  <p>Waiting for sign-in in your browser...</p>
+                </div>
+              ) : cloudConnected ? (
+                <div>
+                  <CheckCircle2 size={48} style={{ color: 'var(--accent-color, #4ade80)', marginBottom: '12px' }} />
+                  <p style={{ fontWeight: 600, fontSize: '1.1rem' }}>Connected to Calimero Cloud</p>
+                  <p style={{ opacity: 0.7, marginTop: '4px' }}>{getSettings().cloudUserEmail}</p>
+                </div>
+              ) : (
+                <button
+                  className="button button-primary"
+                  style={{ fontSize: '1rem', padding: '12px 32px' }}
+                  onClick={async () => {
+                    setCloudConnecting(true);
+                    try {
+                      const userInfo = await startCloudLogin();
+                      if (userInfo) {
+                        setCloudConnected(true);
+                        toast.success('Connected to Calimero Cloud');
+                      } else {
+                        toast.error('Cloud login timed out or was cancelled');
+                      }
+                    } catch (err: unknown) {
+                      toast.error(`Cloud login failed: ${String(err)}`);
+                    } finally {
+                      setCloudConnecting(false);
+                    }
+                  }}
+                >
+                  Sign in with Google
+                </button>
+              )}
+            </div>
+            <div className="step-actions" style={{ marginTop: '24px' }}>
+              <button
+                className="button button-secondary"
+                onClick={() => setCurrentStep('node-setup')}
+              >
+                <ArrowLeft size={16} style={{ marginRight: '4px', verticalAlign: 'middle' }} />
+                Back
+              </button>
+              <button
+                className="button button-primary"
+                onClick={async () => {
+                  try {
+                    const onboardingState = await checkOnboardingState();
+                    setState(onboardingState);
+                  } catch {
+                    // continue anyway
+                  }
+                  setCurrentStep('login');
+                }}
+              >
+                {cloudConnected ? 'Continue' : 'Skip for now'}
+                <ArrowRight size={16} style={{ marginLeft: '4px', verticalAlign: 'middle' }} />
+              </button>
+            </div>
           </div>
           <ScrollHint containerRef={stepContainerRef} />
         </div>

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -132,10 +132,11 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
   const prevDataDirRef = useRef(dataDir);
   useEffect(() => {
     if (currentStep !== 'node-setup') {
-      hasAttemptedAutoContinue.current = false;
       return;
     }
-    // Reset when dataDir changes so we retry for the new directory
+    // Reset only when dataDir changes so we retry for the new directory.
+    // Do NOT reset on step change — otherwise pressing Back from cloud-connect
+    // re-triggers auto-advance and the user is bounced forward again.
     if (prevDataDirRef.current !== dataDir) {
       prevDataDirRef.current = dataDir;
       hasAttemptedAutoContinue.current = false;

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -7,6 +7,7 @@ import { invoke } from "@tauri-apps/api/tauri";
 import { saveSettings, getSettings } from "../utils/settings";
 import { saveOnboardingProgress, loadOnboardingProgress } from "../utils/onboardingProgress";
 import { startCloudLogin } from "../utils/cloudAuth";
+import { isCloudEnabled } from "../utils/featureFlags";
 import { fetchAppsFromAllRegistries, fetchAppManifest, recordDownload, type AppSummary } from "../utils/registry";
 import { useToast } from "../contexts/ToastContext";
 import { useTheme } from "../contexts/ThemeContext";
@@ -23,7 +24,11 @@ interface OnboardingProps {
 
 type OnboardingStep = 'welcome' | 'what-is' | 'node-setup' | 'cloud-connect' | 'login' | 'install-app';
 
-const ONBOARDING_STEPS: OnboardingStep[] = ['welcome', 'what-is', 'node-setup', 'cloud-connect', 'login', 'install-app'];
+const ONBOARDING_STEPS: OnboardingStep[] = isCloudEnabled()
+  ? ['welcome', 'what-is', 'node-setup', 'cloud-connect', 'login', 'install-app']
+  : ['welcome', 'what-is', 'node-setup', 'login', 'install-app'];
+
+const STEP_AFTER_NODE_SETUP: OnboardingStep = isCloudEnabled() ? 'cloud-connect' : 'login';
 
 
 export default function Onboarding({ onComplete, onSettings }: OnboardingProps) {
@@ -180,7 +185,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
             }
             setTheme('dark');
             setCreatingNode(false);
-            setCurrentStep('cloud-connect');
+            setCurrentStep(STEP_AFTER_NODE_SETUP);
             return;
           } catch (err) {
             console.error('Failed to use existing node:', err);
@@ -234,10 +239,10 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
           try {
             const onboardingState = await checkOnboardingState();
             setState(onboardingState);
-            setCurrentStep('cloud-connect');
+            setCurrentStep(STEP_AFTER_NODE_SETUP);
           } catch (err) {
             console.error("Failed to check onboarding state:", err);
-            setCurrentStep('cloud-connect');
+            setCurrentStep(STEP_AFTER_NODE_SETUP);
           }
         }, 2000);
       };

--- a/apps/desktop/src/pages/Settings.tsx
+++ b/apps/desktop/src/pages/Settings.tsx
@@ -5,6 +5,7 @@ import { invoke } from "@tauri-apps/api/tauri";
 import { killAllMerodProcesses, deleteCalimeroDataDir, stopMerod } from "../utils/merod";
 import { startCloudLogin, disconnectCloud } from "../utils/cloudAuth";
 import { getCloudSubscription, CloudSessionExpiredError } from "../utils/cloudApi";
+import { isCloudEnabled } from "../utils/featureFlags";
 import { useTheme } from "../contexts/ThemeContext";
 import { useToast } from "../contexts/ToastContext";
 import { ArrowLeft, RotateCcw, Trash2, Cloud } from "lucide-react";
@@ -170,13 +171,15 @@ export default function Settings({ onBack }: SettingsProps) {
           >
             Registries
           </button>
-          <button
-            className={`settings-tab ${activeTab === 'cloud' ? 'active' : ''}`}
-            onClick={() => setActiveTab('cloud')}
-          >
-            <Cloud size={14} style={{ marginRight: '4px', verticalAlign: 'middle' }} />
-            Cloud
-          </button>
+          {isCloudEnabled() && (
+            <button
+              className={`settings-tab ${activeTab === 'cloud' ? 'active' : ''}`}
+              onClick={() => setActiveTab('cloud')}
+            >
+              <Cloud size={14} style={{ marginRight: '4px', verticalAlign: 'middle' }} />
+              Cloud
+            </button>
+          )}
         </div>
 
         {activeTab === 'general' && (
@@ -413,7 +416,7 @@ export default function Settings({ onBack }: SettingsProps) {
         )}
 
 
-        {activeTab === 'cloud' && (
+        {isCloudEnabled() && activeTab === 'cloud' && (
           <div className="settings-content">
             <div className="settings-card">
               <h2>Calimero Cloud</h2>

--- a/apps/desktop/src/pages/Settings.tsx
+++ b/apps/desktop/src/pages/Settings.tsx
@@ -56,7 +56,13 @@ export default function Settings({ onBack }: SettingsProps) {
         .then((sub) => { if (sub) setCloudPlan(sub.plan); })
         .catch((err) => {
           if (err instanceof CloudSessionExpiredError) {
+            // Persist the disconnect so stale credentials are cleared.
+            disconnectCloud();
             setCloudConnected(false);
+            setCloudEmail(undefined);
+            setCloudName(undefined);
+            setCloudPicture(undefined);
+            setCloudPlan(undefined);
           }
         });
     }

--- a/apps/desktop/src/pages/Settings.tsx
+++ b/apps/desktop/src/pages/Settings.tsx
@@ -3,9 +3,11 @@ import { getSettings, saveSettings, clearAllAppData } from "../utils/settings";
 import { parseTauriError } from "../utils/appUtils";
 import { invoke } from "@tauri-apps/api/tauri";
 import { killAllMerodProcesses, deleteCalimeroDataDir, stopMerod } from "../utils/merod";
+import { startCloudLogin, disconnectCloud } from "../utils/cloudAuth";
+import { getCloudSubscription, CloudSessionExpiredError } from "../utils/cloudApi";
 import { useTheme } from "../contexts/ThemeContext";
 import { useToast } from "../contexts/ToastContext";
-import { ArrowLeft, RotateCcw, Trash2 } from "lucide-react";
+import { ArrowLeft, RotateCcw, Trash2, Cloud } from "lucide-react";
 import "./Settings.css";
 
 interface SettingsProps {
@@ -19,9 +21,15 @@ export default function Settings({ onBack }: SettingsProps) {
   const [newRegistryUrl, setNewRegistryUrl] = useState("");
   
   // Node management state (removed - now in NodeManagement page)
-  const [activeTab, setActiveTab] = useState<'general' | 'registries'>('general');
+  const [activeTab, setActiveTab] = useState<'general' | 'registries' | 'cloud'>('general');
   const [developerMode, setDeveloperMode] = useState(false);
   const [debugLogs, setDebugLogs] = useState(false);
+  const [cloudConnected, setCloudConnected] = useState(false);
+  const [cloudEmail, setCloudEmail] = useState<string | undefined>();
+  const [cloudName, setCloudName] = useState<string | undefined>();
+  const [cloudPicture, setCloudPicture] = useState<string | undefined>();
+  const [cloudPlan, setCloudPlan] = useState<string | undefined>();
+  const [cloudLoading, setCloudLoading] = useState(false);
   const [showResetConfirm, setShowResetConfirm] = useState(false);
   const [resetConfirmed, setResetConfirmed] = useState(false);
   const [resetting, setResetting] = useState(false);
@@ -37,6 +45,21 @@ export default function Settings({ onBack }: SettingsProps) {
     setRegistries(settings.registries || []);
     setDeveloperMode(settings.developerMode ?? false);
     setDebugLogs(settings.debugLogs ?? false);
+    setCloudConnected(settings.cloudConnected ?? false);
+    setCloudEmail(settings.cloudUserEmail);
+    setCloudName(settings.cloudUserName);
+    setCloudPicture(settings.cloudUserPicture);
+
+    // Fetch cloud plan if connected
+    if (settings.cloudConnected && settings.cloudIdToken) {
+      getCloudSubscription(settings.cloudIdToken)
+        .then((sub) => { if (sub) setCloudPlan(sub.plan); })
+        .catch((err) => {
+          if (err instanceof CloudSessionExpiredError) {
+            setCloudConnected(false);
+          }
+        });
+    }
   }, []);
 
   useEffect(() => {
@@ -135,12 +158,19 @@ export default function Settings({ onBack }: SettingsProps) {
           >
             General
           </button>
-          <button 
+          <button
             className={`settings-tab ${activeTab === 'registries' ? 'active' : ''}`}
             onClick={() => setActiveTab('registries')}
           >
             Registries
-            </button>
+          </button>
+          <button
+            className={`settings-tab ${activeTab === 'cloud' ? 'active' : ''}`}
+            onClick={() => setActiveTab('cloud')}
+          >
+            <Cloud size={14} style={{ marginRight: '4px', verticalAlign: 'middle' }} />
+            Cloud
+          </button>
         </div>
 
         {activeTab === 'general' && (
@@ -376,6 +406,109 @@ export default function Settings({ onBack }: SettingsProps) {
           </div>
         )}
 
+
+        {activeTab === 'cloud' && (
+          <div className="settings-content">
+            <div className="settings-card">
+              <h2>Calimero Cloud</h2>
+              {!cloudConnected ? (
+                <>
+                  <p className="field-hint" style={{ marginBottom: '16px' }}>
+                    Connect to Calimero Cloud for cloud-hosted contexts, High Availability replication,
+                    and managed infrastructure. Your local node stays primary — cloud features are additive.
+                  </p>
+                  <button
+                    className="button button-primary"
+                    onClick={async () => {
+                      setCloudLoading(true);
+                      try {
+                        const userInfo = await startCloudLogin();
+                        if (userInfo) {
+                          setCloudConnected(true);
+                          setCloudEmail(userInfo.email);
+                          setCloudName(userInfo.name);
+                          setCloudPicture(userInfo.picture);
+                          toast.success('Connected to Calimero Cloud');
+                          // Fetch plan
+                          const settings = getSettings();
+                          if (settings.cloudIdToken) {
+                            const sub = await getCloudSubscription(settings.cloudIdToken).catch(() => null);
+                            if (sub) setCloudPlan(sub.plan);
+                          }
+                        } else {
+                          toast.error('Cloud login timed out or was cancelled');
+                        }
+                      } catch (err: unknown) {
+                        toast.error(`Cloud login failed: ${String(err)}`);
+                      } finally {
+                        setCloudLoading(false);
+                      }
+                    }}
+                    disabled={cloudLoading}
+                  >
+                    {cloudLoading ? 'Waiting for sign-in...' : 'Sign in with Google'}
+                  </button>
+                  <p className="field-hint" style={{ marginTop: '12px', fontStyle: 'italic' }}>
+                    Your data stays on your device. Cloud features are optional.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '16px' }}>
+                    {cloudPicture && (
+                      <img
+                        src={cloudPicture}
+                        alt=""
+                        style={{ width: 40, height: 40, borderRadius: '50%' }}
+                      />
+                    )}
+                    <div>
+                      <div style={{ fontWeight: 600 }}>{cloudName || 'Connected'}</div>
+                      <div style={{ fontSize: '0.85rem', opacity: 0.7 }}>{cloudEmail}</div>
+                    </div>
+                    {cloudPlan && (
+                      <span style={{
+                        marginLeft: 'auto',
+                        padding: '2px 10px',
+                        borderRadius: '12px',
+                        fontSize: '0.75rem',
+                        fontWeight: 600,
+                        textTransform: 'capitalize',
+                        background: 'var(--accent-bg, #1a3a1a)',
+                        color: 'var(--accent-color, #4ade80)',
+                        border: '1px solid var(--accent-border, #2d5a2d)',
+                      }}>
+                        {cloudPlan} plan
+                      </span>
+                    )}
+                  </div>
+                  <div style={{ display: 'flex', gap: '8px' }}>
+                    <button
+                      className="button button-secondary"
+                      onClick={() => invoke('open_url_in_browser', { url: 'https://cloud.calimero.network' })}
+                    >
+                      Manage on cloud.calimero.network
+                    </button>
+                    <button
+                      className="button button-danger"
+                      onClick={() => {
+                        disconnectCloud();
+                        setCloudConnected(false);
+                        setCloudEmail(undefined);
+                        setCloudName(undefined);
+                        setCloudPicture(undefined);
+                        setCloudPlan(undefined);
+                        toast.success('Disconnected from Calimero Cloud');
+                      }}
+                    >
+                      Disconnect
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        )}
 
         {activeTab === 'registries' && (
           <div className="settings-content">

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -1,3 +1,5 @@
+import { getAccessToken } from '../lib/token-storage';
+
 const CLOUD_BASE_URL = 'https://cloud.calimero.network';
 
 export interface CloudNode {
@@ -90,6 +92,20 @@ export async function getCloudSubscription(
   return res.json();
 }
 
+export interface CloudGroup {
+  group_id: string;
+  contexts: string[];
+  ha_status: string;
+  ha_enabled_at: string | null;
+  fleet_replicas: { active: number; assigned: number; limit: number };
+}
+
+export async function getCloudGroups(idToken: string): Promise<CloudGroup[]> {
+  const res = await cloudFetch('/api/cloud/me/groups', idToken);
+  if (!res.ok) return [];
+  return res.json();
+}
+
 // ── HA (High Availability) via TEE Fleet Nodes ──
 
 export interface FleetMeasurements {
@@ -150,9 +166,13 @@ export async function disableHa(
   idToken: string,
   contextId: string,
 ): Promise<void> {
-  await cloudFetch(`/api/cloud/ha/disable/${contextId}`, idToken, {
+  const res = await cloudFetch(`/api/cloud/ha/disable/${contextId}`, idToken, {
     method: 'POST',
   });
+  if (!res.ok) {
+    const error = await res.json().catch(() => null);
+    throw new Error(error?.detail || 'Failed to disable HA');
+  }
 }
 
 // ── Local Node Admin API ──
@@ -171,11 +191,18 @@ export async function setTeeAdmissionPolicy(
   groupId: string,
   allowedMrtd?: string[],
 ): Promise<void> {
+  const accessToken = getAccessToken();
+  if (!accessToken) {
+    throw new Error('Not authenticated to local node — sign in first');
+  }
   const res = await fetch(
     `${nodeUrl}/admin-api/groups/${groupId}/settings/tee-admission-policy`,
     {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
       body: JSON.stringify({
         allowed_mrtd: allowedMrtd ?? [],
         allowed_rtmr0: [],

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -11,19 +11,6 @@ export interface CloudNode {
   status: string;
 }
 
-export interface CloudContext {
-  context_id: string;
-  node_name: string;
-  node_url: string;
-  public_ip: string;
-  plan: string;
-  status: string;
-}
-
-export interface CloudProfile {
-  display_name: string | null;
-}
-
 export interface CloudSubscription {
   plan: string;
   status: string;
@@ -66,22 +53,6 @@ export async function getCloudNode(
   idToken: string,
 ): Promise<CloudNode | null> {
   const res = await cloudFetch('/api/cloud/me/node', idToken);
-  if (!res.ok) return null;
-  return res.json();
-}
-
-export async function getCloudContexts(
-  idToken: string,
-): Promise<CloudContext[]> {
-  const res = await cloudFetch('/api/cloud/me/contexts', idToken);
-  if (!res.ok) return [];
-  return res.json();
-}
-
-export async function getCloudProfile(
-  idToken: string,
-): Promise<CloudProfile | null> {
-  const res = await cloudFetch('/api/cloud/me/profile', idToken);
   if (!res.ok) return null;
   return res.json();
 }
@@ -148,10 +119,14 @@ export async function enableHa(
   contextId: string,
   groupId?: string,
 ): Promise<EnableHaResponse | null> {
-  const res = await cloudFetch(`/api/cloud/me/contexts/${contextId}/enable-ha`, idToken, {
-    method: 'POST',
-    body: JSON.stringify(groupId ? { group_id: groupId } : {}),
-  });
+  const res = await cloudFetch(
+    `/api/cloud/me/contexts/${encodeURIComponent(contextId)}/enable-ha`,
+    idToken,
+    {
+      method: 'POST',
+      body: JSON.stringify(groupId ? { group_id: groupId } : {}),
+    },
+  );
   if (!res.ok) {
     const error = await res.json().catch(() => null);
     if (res.status === 402) {
@@ -169,9 +144,11 @@ export async function disableHa(
   idToken: string,
   contextId: string,
 ): Promise<void> {
-  const res = await cloudFetch(`/api/cloud/me/contexts/${contextId}/disable-ha`, idToken, {
-    method: 'POST',
-  });
+  const res = await cloudFetch(
+    `/api/cloud/me/contexts/${encodeURIComponent(contextId)}/disable-ha`,
+    idToken,
+    { method: 'POST' },
+  );
   if (!res.ok) {
     const error = await res.json().catch(() => null);
     throw new Error(error?.detail || 'Failed to disable HA');
@@ -201,7 +178,7 @@ export async function enableHaNamespace(
   groups: NamespaceHaGroup[],
 ): Promise<EnableHaNamespaceResponse> {
   const res = await cloudFetch(
-    `/api/cloud/me/namespaces/${namespaceId}/enable-ha`,
+    `/api/cloud/me/namespaces/${encodeURIComponent(namespaceId)}/enable-ha`,
     idToken,
     { method: 'POST', body: JSON.stringify({ groups }) },
   );
@@ -223,7 +200,7 @@ export async function disableHaNamespace(
   namespaceId: string,
 ): Promise<void> {
   const res = await cloudFetch(
-    `/api/cloud/me/namespaces/${namespaceId}/disable-ha`,
+    `/api/cloud/me/namespaces/${encodeURIComponent(namespaceId)}/disable-ha`,
     idToken,
     { method: 'POST' },
   );
@@ -254,7 +231,7 @@ export async function setTeeAdmissionPolicy(
     throw new Error('Not authenticated to local node — sign in first');
   }
   const res = await fetch(
-    `${nodeUrl}/admin-api/groups/${groupId}/settings/tee-admission-policy`,
+    `${nodeUrl}/admin-api/groups/${encodeURIComponent(groupId)}/settings/tee-admission-policy`,
     {
       method: 'PUT',
       headers: {

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -279,14 +279,16 @@ export async function setTeeAdmissionPolicy(
 }
 
 /**
- * Enable HA end-to-end for every group in a namespace:
- * 1. Fetch fleet measurements from cloud once (trusted MRTD values)
- * 2. Set TEE admission policy on the local node for each group
- * 3. Register the whole namespace with cloud in one bulk call
- *
- * Caller supplies the list of groups; the tauri app uses mero-react's
- * `mero.admin.listNamespaceGroups` + `listGroupContexts` to enumerate
- * them before calling this.
+ * Enable HA end-to-end for a namespace:
+ * 1. Fetch fleet measurements from cloud once (trusted MRTD values).
+ * 2. Set the TEE admission policy on the *namespace root only*. Subgroup
+ *    policies are ignored by core (namespace-scoped since rc.29 /
+ *    calimero-network/core#2188) — applying them would error. Auto-follow
+ *    propagates fleet-node membership into subgroups without a second
+ *    admission check.
+ * 3. Register the namespace with cloud. MDMA still needs the full group
+ *    list for billing + per-group status rows until the server-side
+ *    flattening lands, so the caller keeps enumerating groups.
  */
 export async function enableHaForNamespace(
   idToken: string,
@@ -303,11 +305,9 @@ export async function enableHaForNamespace(
     throw new Error('No fleet MRTD measurements available — cannot set admission policy');
   }
 
-  // Apply local admission policy per group. If any fails we abort; the
-  // user can retry after fixing whatever is wrong on the local node.
-  for (const g of groups) {
-    await setTeeAdmissionPolicy(nodeUrl, g.group_id, measurements.allowed_mrtd);
-  }
+  // The namespace root's group_id equals the namespaceId. Set the policy
+  // there and only there — subgroups inherit it via resolve-to-root.
+  await setTeeAdmissionPolicy(nodeUrl, namespaceId, measurements.allowed_mrtd);
 
   return enableHaNamespace(idToken, namespaceId, groups);
 }

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -90,4 +90,106 @@ export async function getCloudSubscription(
   return res.json();
 }
 
+// ── HA (High Availability) via TEE Fleet Nodes ──
+
+export interface EnableHaResponse {
+  status: string;
+  context_id: string;
+}
+
+/**
+ * Enable HA for a context — requests TEE fleet nodes to join this
+ * namespace/group. Requires a paid plan.
+ */
+export async function enableHa(
+  idToken: string,
+  contextId: string,
+  groupId?: string,
+): Promise<EnableHaResponse | null> {
+  const res = await cloudFetch(`/api/cloud/ha/enable/${contextId}`, idToken, {
+    method: 'POST',
+    body: JSON.stringify(groupId ? { group_id: groupId } : {}),
+  });
+  if (!res.ok) {
+    const error = await res.json().catch(() => null);
+    if (res.status === 402) {
+      throw new Error(error?.detail?.message || 'Plan limit reached — upgrade to enable HA');
+    }
+    throw new Error(error?.detail || 'Failed to enable HA');
+  }
+  return res.json();
+}
+
+/**
+ * Disable HA for a context.
+ */
+export async function disableHa(
+  idToken: string,
+  contextId: string,
+): Promise<void> {
+  await cloudFetch(`/api/cloud/ha/disable/${contextId}`, idToken, {
+    method: 'POST',
+  });
+}
+
+// ── Local Node Admin API ──
+
+/**
+ * Set the TEE admission policy on a group via the local node's admin API.
+ * This must be called after enabling HA so that fleet TEE nodes can be
+ * admitted into the group's governance DAG.
+ */
+export async function setTeeAdmissionPolicy(
+  nodeUrl: string,
+  groupId: string,
+  options?: {
+    allowedMrtd?: string[];
+    acceptMock?: boolean;
+  },
+): Promise<void> {
+  const res = await fetch(
+    `${nodeUrl}/admin-api/groups/${groupId}/settings/tee-admission-policy`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        allowed_mrtd: options?.allowedMrtd ?? [],
+        allowed_rtmr0: [],
+        allowed_rtmr1: [],
+        allowed_rtmr2: [],
+        allowed_rtmr3: [],
+        allowed_tcb_statuses: [],
+        accept_mock: options?.acceptMock ?? false,
+      }),
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Failed to set TEE admission policy: ${text}`);
+  }
+}
+
+/**
+ * Enable HA end-to-end: sets TEE admission policy on the local node,
+ * then registers the HA request with the cloud.
+ */
+export async function enableHaForNamespace(
+  idToken: string,
+  nodeUrl: string,
+  contextId: string,
+  groupId: string,
+  options?: {
+    allowedMrtd?: string[];
+    acceptMock?: boolean;
+  },
+): Promise<EnableHaResponse | null> {
+  // 1. Set TEE admission policy on the local node so fleet nodes
+  //    can be admitted when they present valid attestations.
+  await setTeeAdmissionPolicy(nodeUrl, groupId, options);
+
+  // 2. Register HA request with the cloud — fleet nodes will poll
+  //    should-join and get assigned to this group.
+  return enableHa(idToken, contextId, groupId);
+}
+
 export { CloudSessionExpiredError };

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -138,14 +138,15 @@ export async function disableHa(
  * Set the TEE admission policy on a group via the local node's admin API.
  * This must be called after enabling HA so that fleet TEE nodes can be
  * admitted into the group's governance DAG.
+ *
+ * accept_mock is always false — only real TDX attestations are accepted.
+ * allowedMrtd should be populated from the cloud's fleet measurements;
+ * an empty list means any MRTD is accepted (not recommended for production).
  */
 export async function setTeeAdmissionPolicy(
   nodeUrl: string,
   groupId: string,
-  options?: {
-    allowedMrtd?: string[];
-    acceptMock?: boolean;
-  },
+  allowedMrtd?: string[],
 ): Promise<void> {
   const res = await fetch(
     `${nodeUrl}/admin-api/groups/${groupId}/settings/tee-admission-policy`,
@@ -153,13 +154,13 @@ export async function setTeeAdmissionPolicy(
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        allowed_mrtd: options?.allowedMrtd ?? [],
+        allowed_mrtd: allowedMrtd ?? [],
         allowed_rtmr0: [],
         allowed_rtmr1: [],
         allowed_rtmr2: [],
         allowed_rtmr3: [],
         allowed_tcb_statuses: [],
-        accept_mock: options?.acceptMock ?? false,
+        accept_mock: false,
       }),
     },
   );
@@ -178,14 +179,11 @@ export async function enableHaForNamespace(
   nodeUrl: string,
   contextId: string,
   groupId: string,
-  options?: {
-    allowedMrtd?: string[];
-    acceptMock?: boolean;
-  },
+  allowedMrtd?: string[],
 ): Promise<EnableHaResponse | null> {
   // 1. Set TEE admission policy on the local node so fleet nodes
   //    can be admitted when they present valid attestations.
-  await setTeeAdmissionPolicy(nodeUrl, groupId, options);
+  await setTeeAdmissionPolicy(nodeUrl, groupId, allowedMrtd);
 
   // 2. Register HA request with the cloud — fleet nodes will poll
   //    should-join and get assigned to this group.

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -1,0 +1,93 @@
+const CLOUD_BASE_URL = 'https://cloud.calimero.network';
+
+export interface CloudNode {
+  name: string;
+  public_ip: string;
+  plan: string;
+  status: string;
+}
+
+export interface CloudContext {
+  context_id: string;
+  node_name: string;
+  node_url: string;
+  public_ip: string;
+  plan: string;
+  status: string;
+}
+
+export interface CloudProfile {
+  display_name: string | null;
+}
+
+export interface CloudSubscription {
+  plan: string;
+  status: string;
+  current_period_end: string | null;
+}
+
+class CloudSessionExpiredError extends Error {
+  constructor() {
+    super('Cloud session expired');
+    this.name = 'CloudSessionExpiredError';
+  }
+}
+
+async function cloudFetch(
+  path: string,
+  idToken: string,
+  options?: RequestInit,
+): Promise<Response> {
+  const res = await fetch(`${CLOUD_BASE_URL}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
+  });
+
+  if (res.status === 401) {
+    throw new CloudSessionExpiredError();
+  }
+
+  return res;
+}
+
+/**
+ * Get the user's assigned cloud node. Also triggers auto-registration
+ * on first call (creates free plan account + default context).
+ */
+export async function getCloudNode(
+  idToken: string,
+): Promise<CloudNode | null> {
+  const res = await cloudFetch('/api/cloud/me/node', idToken);
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export async function getCloudContexts(
+  idToken: string,
+): Promise<CloudContext[]> {
+  const res = await cloudFetch('/api/cloud/me/contexts', idToken);
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export async function getCloudProfile(
+  idToken: string,
+): Promise<CloudProfile | null> {
+  const res = await cloudFetch('/api/cloud/me/profile', idToken);
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export async function getCloudSubscription(
+  idToken: string,
+): Promise<CloudSubscription | null> {
+  const res = await cloudFetch('/api/cloud/me/subscription', idToken);
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export { CloudSessionExpiredError };

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -92,6 +92,29 @@ export async function getCloudSubscription(
 
 // ── HA (High Availability) via TEE Fleet Nodes ──
 
+export interface FleetMeasurements {
+  release_tag: string;
+  allowed_mrtd: string[];
+  allowed_rtmr0: string[];
+  allowed_rtmr1: string[];
+  allowed_rtmr2: string[];
+  allowed_rtmr3: string[];
+}
+
+/**
+ * Fetch the fleet's trusted TEE measurements (MRTD, RTMR values)
+ * from the cloud. Used to populate set_tee_admission_policy.
+ */
+export async function getFleetMeasurements(
+  idToken: string,
+): Promise<FleetMeasurements> {
+  const res = await cloudFetch('/api/cloud/fleet/measurements', idToken);
+  if (!res.ok) {
+    throw new Error('Failed to fetch fleet measurements');
+  }
+  return res.json();
+}
+
 export interface EnableHaResponse {
   status: string;
   context_id: string;
@@ -171,21 +194,29 @@ export async function setTeeAdmissionPolicy(
 }
 
 /**
- * Enable HA end-to-end: sets TEE admission policy on the local node,
- * then registers the HA request with the cloud.
+ * Enable HA end-to-end:
+ * 1. Fetch fleet measurements from cloud (trusted MRTD values)
+ * 2. Set TEE admission policy on the local node with those values
+ * 3. Register HA request with cloud for fleet node assignment
  */
 export async function enableHaForNamespace(
   idToken: string,
   nodeUrl: string,
   contextId: string,
   groupId: string,
-  allowedMrtd?: string[],
 ): Promise<EnableHaResponse | null> {
-  // 1. Set TEE admission policy on the local node so fleet nodes
-  //    can be admitted when they present valid attestations.
-  await setTeeAdmissionPolicy(nodeUrl, groupId, allowedMrtd);
+  // 1. Fetch the fleet's trusted measurements from the cloud.
+  const measurements = await getFleetMeasurements(idToken);
+  if (!measurements.allowed_mrtd.length) {
+    throw new Error('No fleet MRTD measurements available — cannot set admission policy');
+  }
 
-  // 2. Register HA request with the cloud — fleet nodes will poll
+  // 2. Set TEE admission policy on the local node with the fleet's
+  //    trusted MRTD values. Only TEE nodes matching these measurements
+  //    will be admitted.
+  await setTeeAdmissionPolicy(nodeUrl, groupId, measurements.allowed_mrtd);
+
+  // 3. Register HA request with the cloud — fleet nodes will poll
   //    should-join and get assigned to this group.
   return enableHa(idToken, contextId, groupId);
 }

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -1,6 +1,8 @@
 import { getAccessToken } from '../lib/token-storage';
 
-const CLOUD_BASE_URL = 'https://cloud.calimero.network';
+// API lives at manager.cloud.calimero.network; cloud.calimero.network is
+// the static portal and does not proxy /api/*.
+const CLOUD_BASE_URL = 'https://manager.cloud.calimero.network';
 
 export interface CloudNode {
   name: string;

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -96,6 +96,7 @@ export async function getCloudSubscription(
 
 export interface CloudGroup {
   group_id: string;
+  namespace_id: string | null;
   contexts: string[];
   ha_status: string;
   ha_enabled_at: string | null;
@@ -147,7 +148,7 @@ export async function enableHa(
   contextId: string,
   groupId?: string,
 ): Promise<EnableHaResponse | null> {
-  const res = await cloudFetch(`/api/cloud/ha/enable/${contextId}`, idToken, {
+  const res = await cloudFetch(`/api/cloud/me/contexts/${contextId}/enable-ha`, idToken, {
     method: 'POST',
     body: JSON.stringify(groupId ? { group_id: groupId } : {}),
   });
@@ -168,12 +169,67 @@ export async function disableHa(
   idToken: string,
   contextId: string,
 ): Promise<void> {
-  const res = await cloudFetch(`/api/cloud/ha/disable/${contextId}`, idToken, {
+  const res = await cloudFetch(`/api/cloud/me/contexts/${contextId}/disable-ha`, idToken, {
     method: 'POST',
   });
   if (!res.ok) {
     const error = await res.json().catch(() => null);
     throw new Error(error?.detail || 'Failed to disable HA');
+  }
+}
+
+export interface NamespaceHaGroup {
+  group_id: string;
+  context_id: string;
+}
+
+export interface EnableHaNamespaceResponse {
+  status: string;
+  namespace_id: string;
+  groups: { group_id: string; context_id: string; status: string }[];
+}
+
+/**
+ * Enable HA for every group in a namespace in one call. Client is
+ * responsible for enumerating the groups and picking a representative
+ * context_id per group (manager needs the context for billing + row
+ * bookkeeping but does not itself know the namespace topology).
+ */
+export async function enableHaNamespace(
+  idToken: string,
+  namespaceId: string,
+  groups: NamespaceHaGroup[],
+): Promise<EnableHaNamespaceResponse> {
+  const res = await cloudFetch(
+    `/api/cloud/me/namespaces/${namespaceId}/enable-ha`,
+    idToken,
+    { method: 'POST', body: JSON.stringify({ groups }) },
+  );
+  if (!res.ok) {
+    const error = await res.json().catch(() => null);
+    if (res.status === 402) {
+      throw new Error(error?.detail?.message || 'Plan limit reached — upgrade to enable HA');
+    }
+    throw new Error(error?.detail || 'Failed to enable HA for namespace');
+  }
+  return res.json();
+}
+
+/**
+ * Disable HA for every group previously enabled under this namespace.
+ */
+export async function disableHaNamespace(
+  idToken: string,
+  namespaceId: string,
+): Promise<void> {
+  const res = await cloudFetch(
+    `/api/cloud/me/namespaces/${namespaceId}/disable-ha`,
+    idToken,
+    { method: 'POST' },
+  );
+  if (!res.ok) {
+    const error = await res.json().catch(() => null);
+    throw new Error(error?.detail || 'Failed to disable HA for namespace');
   }
 }
 
@@ -223,31 +279,37 @@ export async function setTeeAdmissionPolicy(
 }
 
 /**
- * Enable HA end-to-end:
- * 1. Fetch fleet measurements from cloud (trusted MRTD values)
- * 2. Set TEE admission policy on the local node with those values
- * 3. Register HA request with cloud for fleet node assignment
+ * Enable HA end-to-end for every group in a namespace:
+ * 1. Fetch fleet measurements from cloud once (trusted MRTD values)
+ * 2. Set TEE admission policy on the local node for each group
+ * 3. Register the whole namespace with cloud in one bulk call
+ *
+ * Caller supplies the list of groups; the tauri app uses mero-react's
+ * `mero.admin.listNamespaceGroups` + `listGroupContexts` to enumerate
+ * them before calling this.
  */
 export async function enableHaForNamespace(
   idToken: string,
   nodeUrl: string,
-  contextId: string,
-  groupId: string,
-): Promise<EnableHaResponse | null> {
-  // 1. Fetch the fleet's trusted measurements from the cloud.
+  namespaceId: string,
+  groups: NamespaceHaGroup[],
+): Promise<EnableHaNamespaceResponse> {
+  if (groups.length === 0) {
+    throw new Error('Namespace has no groups to enable HA on');
+  }
+
   const measurements = await getFleetMeasurements(idToken);
   if (!measurements.allowed_mrtd.length) {
     throw new Error('No fleet MRTD measurements available — cannot set admission policy');
   }
 
-  // 2. Set TEE admission policy on the local node with the fleet's
-  //    trusted MRTD values. Only TEE nodes matching these measurements
-  //    will be admitted.
-  await setTeeAdmissionPolicy(nodeUrl, groupId, measurements.allowed_mrtd);
+  // Apply local admission policy per group. If any fails we abort; the
+  // user can retry after fixing whatever is wrong on the local node.
+  for (const g of groups) {
+    await setTeeAdmissionPolicy(nodeUrl, g.group_id, measurements.allowed_mrtd);
+  }
 
-  // 3. Register HA request with the cloud — fleet nodes will poll
-  //    should-join and get assigned to this group.
-  return enableHa(idToken, contextId, groupId);
+  return enableHaNamespace(idToken, namespaceId, groups);
 }
 
 export { CloudSessionExpiredError };

--- a/apps/desktop/src/utils/cloudAuth.ts
+++ b/apps/desktop/src/utils/cloudAuth.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api';
+import { listen } from '@tauri-apps/api/event';
 import { getSettings, saveSettings } from './settings';
 import { getCloudNode } from './cloudApi';
 
@@ -101,28 +102,44 @@ export async function startCloudLogin(): Promise<CloudUserInfo | null> {
 }
 
 /**
- * Poll the Tauri backend for a pending cloud auth deep link.
- * The OS launches the app with calimero:// as a CLI arg, which
- * parse_deep_link_arg() catches and stores in PendingCloudAuth state.
+ * Wait for the deep-link callback via two channels:
+ *   - `cloud-auth-callback` Tauri event (hot-launch case: app already running,
+ *     the deep-link plugin forwards the URL from the OS handler)
+ *   - Polling `get_pending_cloud_auth` (cold-launch case: OS launched the
+ *     app with the URL in argv before any listener was set up)
  */
 async function pollForCloudAuth(): Promise<string | null> {
-  const deadline = Date.now() + LOGIN_TIMEOUT_MS;
+  return new Promise<string | null>(async (resolve) => {
+    let resolved = false;
+    const finish = (token: string | null) => {
+      if (resolved) return;
+      resolved = true;
+      if (unlisten) unlisten();
+      clearInterval(pollTimer);
+      clearTimeout(timeoutTimer);
+      resolve(token);
+    };
 
-  while (Date.now() < deadline) {
-    try {
-      const url = await invoke<string | null>('get_pending_cloud_auth');
-      if (url) {
-        await invoke('clear_pending_cloud_auth');
-        return extractTokenFromCallbackUrl(url);
+    const unlisten = await listen<string>('cloud-auth-callback', (event) => {
+      const token = extractTokenFromCallbackUrl(event.payload);
+      if (token) finish(token);
+    }).catch(() => null);
+
+    const pollTimer = setInterval(async () => {
+      try {
+        const url = await invoke<string | null>('get_pending_cloud_auth');
+        if (url) {
+          await invoke('clear_pending_cloud_auth');
+          const token = extractTokenFromCallbackUrl(url);
+          if (token) finish(token);
+        }
+      } catch {
+        // Command not available yet or error — keep polling
       }
-    } catch {
-      // Command not available yet or error — keep polling
-    }
+    }, LOGIN_POLL_INTERVAL_MS);
 
-    await new Promise((resolve) => setTimeout(resolve, LOGIN_POLL_INTERVAL_MS));
-  }
-
-  return null;
+    const timeoutTimer = setTimeout(() => finish(null), LOGIN_TIMEOUT_MS);
+  });
 }
 
 /**

--- a/apps/desktop/src/utils/cloudAuth.ts
+++ b/apps/desktop/src/utils/cloudAuth.ts
@@ -10,12 +10,71 @@ const LOGIN_TIMEOUT_MS = 120_000; // 2 minutes
 
 // OAuth CSRF state — rotated per startCloudLogin() call and checked when
 // the deep link arrives. Blocks forged calimero:// callbacks.
-let pendingState: string | null = null;
+//
+// Persisted to localStorage instead of a module variable so it survives the
+// "cold-launch" case: if the user closes the app between clicking "Connect
+// Cloud" and the browser redirecting back via calimero://, the OS launches
+// a *new* process to handle the URL. A module-level variable would be null
+// in that fresh process and state validation would always fail closed —
+// correct security posture but a silent UX dead-end for a common flow.
+// localStorage survives process restart, so the new process can still
+// verify the nonce the old one generated.
+//
+// TTL guards against stale nonces from abandoned login attempts (10 min is
+// longer than any plausible interactive Google sign-in). Each new
+// startCloudLogin() overwrites the previous record; rapid repeat clicks
+// therefore invalidate earlier callbacks, which is the intended behavior.
+const OAUTH_STATE_KEY = 'calimero_oauth_pending_state';
+const OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
+
+interface PendingOAuthState {
+  state: string;
+  expiresAt: number;
+}
 
 function generateState(): string {
   const buf = new Uint8Array(16);
   crypto.getRandomValues(buf);
   return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function savePendingState(state: string): void {
+  try {
+    const record: PendingOAuthState = {
+      state,
+      expiresAt: Date.now() + OAUTH_STATE_TTL_MS,
+    };
+    localStorage.setItem(OAUTH_STATE_KEY, JSON.stringify(record));
+  } catch {
+    // localStorage unavailable — CSRF check will fail closed on the
+    // callback side, which is safer than silently succeeding.
+  }
+}
+
+function consumePendingState(): string | null {
+  try {
+    const raw = localStorage.getItem(OAUTH_STATE_KEY);
+    if (!raw) return null;
+    // Clear immediately so the nonce cannot be replayed by a second
+    // callback (e.g. a slow redirect racing with a retry).
+    localStorage.removeItem(OAUTH_STATE_KEY);
+    const record = JSON.parse(raw) as Partial<PendingOAuthState>;
+    if (!record || typeof record.state !== 'string' || typeof record.expiresAt !== 'number') {
+      return null;
+    }
+    if (Date.now() > record.expiresAt) return null;
+    return record.state;
+  } catch {
+    return null;
+  }
+}
+
+function clearPendingState(): void {
+  try {
+    localStorage.removeItem(OAUTH_STATE_KEY);
+  } catch {
+    // Ignore — same rationale as savePendingState's silent failure.
+  }
 }
 
 export interface CloudUserInfo {
@@ -66,8 +125,9 @@ export function isTokenExpired(token: string): boolean {
  * 4. Store credentials in settings
  */
 export async function startCloudLogin(): Promise<CloudUserInfo | null> {
-  pendingState = generateState();
-  const callback = `${CLOUD_CALLBACK_SCHEME}?state=${pendingState}`;
+  const state = generateState();
+  savePendingState(state);
+  const callback = `${CLOUD_CALLBACK_SCHEME}?state=${state}`;
   const loginUrl = `${CLOUD_LOGIN_URL}/?callback-url=${encodeURIComponent(callback)}`;
 
   // Clear any stale pending auth
@@ -159,10 +219,10 @@ function extractTokenFromCallbackUrl(url: string): string | null {
       ? ''
       : url.substring(queryIndex + 1, queryEnd);
 
-    const expected = pendingState;
+    // `consumePendingState` atomically reads and clears the nonce, so it
+    // cannot be replayed by a second callback that arrives after the first.
+    const expected = consumePendingState();
     const got = query ? new URLSearchParams(query).get('state') : null;
-    // Clear nonce as soon as any callback is seen so it can't be replayed.
-    pendingState = null;
     if (!expected || got !== expected) return null;
 
     if (!fragment) return null;
@@ -176,6 +236,7 @@ function extractTokenFromCallbackUrl(url: string): string | null {
  * Disconnect from Calimero Cloud. Clears all cloud state from settings.
  */
 export function disconnectCloud(): void {
+  clearPendingState();
   const settings = getSettings();
   saveSettings({
     ...settings,

--- a/apps/desktop/src/utils/cloudAuth.ts
+++ b/apps/desktop/src/utils/cloudAuth.ts
@@ -7,6 +7,16 @@ const CLOUD_CALLBACK_SCHEME = 'calimero://cloud-callback';
 const LOGIN_POLL_INTERVAL_MS = 1500;
 const LOGIN_TIMEOUT_MS = 120_000; // 2 minutes
 
+// OAuth CSRF state — rotated per startCloudLogin() call and checked when
+// the deep link arrives. Blocks forged calimero:// callbacks.
+let pendingState: string | null = null;
+
+function generateState(): string {
+  const buf = new Uint8Array(16);
+  crypto.getRandomValues(buf);
+  return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
 export interface CloudUserInfo {
   email: string;
   name: string;
@@ -55,7 +65,9 @@ export function isTokenExpired(token: string): boolean {
  * 4. Store credentials in settings
  */
 export async function startCloudLogin(): Promise<CloudUserInfo | null> {
-  const loginUrl = `${CLOUD_LOGIN_URL}/?callback-url=${encodeURIComponent(CLOUD_CALLBACK_SCHEME)}`;
+  pendingState = generateState();
+  const callback = `${CLOUD_CALLBACK_SCHEME}?state=${pendingState}`;
+  const loginUrl = `${CLOUD_LOGIN_URL}/?callback-url=${encodeURIComponent(callback)}`;
 
   // Clear any stale pending auth
   await invoke('clear_pending_cloud_auth');
@@ -115,17 +127,29 @@ async function pollForCloudAuth(): Promise<string | null> {
 
 /**
  * Extract the id_token from a callback URL like:
- * calimero://cloud-callback#id_token=eyJ...
+ * calimero://cloud-callback?state=ABC#id_token=eyJ...
+ *
+ * Validates the state param against the nonce we generated when starting
+ * the flow — rejects the token on mismatch to block forged callbacks.
  */
 function extractTokenFromCallbackUrl(url: string): string | null {
   try {
-    // The token is in the URL fragment (after #)
     const hashIndex = url.indexOf('#');
-    if (hashIndex === -1) return null;
+    const fragment = hashIndex === -1 ? '' : url.substring(hashIndex + 1);
+    const queryIndex = url.indexOf('?');
+    const queryEnd = hashIndex === -1 ? url.length : hashIndex;
+    const query = queryIndex === -1 || queryIndex >= queryEnd
+      ? ''
+      : url.substring(queryIndex + 1, queryEnd);
 
-    const fragment = url.substring(hashIndex + 1);
-    const params = new URLSearchParams(fragment);
-    return params.get('id_token');
+    const expected = pendingState;
+    const got = query ? new URLSearchParams(query).get('state') : null;
+    // Clear nonce as soon as any callback is seen so it can't be replayed.
+    pendingState = null;
+    if (!expected || got !== expected) return null;
+
+    if (!fragment) return null;
+    return new URLSearchParams(fragment).get('id_token');
   } catch {
     return null;
   }

--- a/apps/desktop/src/utils/cloudAuth.ts
+++ b/apps/desktop/src/utils/cloudAuth.ts
@@ -1,5 +1,4 @@
 import { invoke } from '@tauri-apps/api';
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { getSettings, saveSettings } from './settings';
 import { getCloudNode } from './cloudApi';
 
@@ -90,49 +89,28 @@ export async function startCloudLogin(): Promise<CloudUserInfo | null> {
 }
 
 /**
- * Wait for the cloud auth deep link callback.
- * Uses both Tauri event listener (for when app is already running)
- * and polling (for when app was launched by the deep link).
+ * Poll the Tauri backend for a pending cloud auth deep link.
+ * The OS launches the app with calimero:// as a CLI arg, which
+ * parse_deep_link_arg() catches and stores in PendingCloudAuth state.
  */
 async function pollForCloudAuth(): Promise<string | null> {
-  return new Promise<string | null>((resolve) => {
-    let unlisten: UnlistenFn | null = null;
-    let resolved = false;
+  const deadline = Date.now() + LOGIN_TIMEOUT_MS;
 
-    const done = (token: string | null) => {
-      if (resolved) return;
-      resolved = true;
-      if (unlisten) unlisten();
-      clearInterval(pollTimer);
-      clearTimeout(timeout);
-      resolve(token);
-    };
-
-    // Listen for the Tauri event (app already running, receives Apple Event)
-    listen<string>('cloud-auth-callback', (event) => {
-      const token = extractTokenFromCallbackUrl(event.payload);
-      if (token) done(token);
-    }).then((fn) => {
-      unlisten = fn;
-    });
-
-    // Poll for the pending state (app launched by deep link URL)
-    const pollTimer = setInterval(async () => {
-      try {
-        const url = await invoke<string | null>('get_pending_cloud_auth');
-        if (url) {
-          await invoke('clear_pending_cloud_auth');
-          const token = extractTokenFromCallbackUrl(url);
-          if (token) done(token);
-        }
-      } catch {
-        // Command not available yet or error — keep polling
+  while (Date.now() < deadline) {
+    try {
+      const url = await invoke<string | null>('get_pending_cloud_auth');
+      if (url) {
+        await invoke('clear_pending_cloud_auth');
+        return extractTokenFromCallbackUrl(url);
       }
-    }, LOGIN_POLL_INTERVAL_MS);
+    } catch {
+      // Command not available yet or error — keep polling
+    }
 
-    // Timeout
-    const timeout = setTimeout(() => done(null), LOGIN_TIMEOUT_MS);
-  });
+    await new Promise((resolve) => setTimeout(resolve, LOGIN_POLL_INTERVAL_MS));
+  }
+
+  return null;
 }
 
 /**

--- a/apps/desktop/src/utils/cloudAuth.ts
+++ b/apps/desktop/src/utils/cloudAuth.ts
@@ -1,0 +1,188 @@
+import { invoke } from '@tauri-apps/api';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { getSettings, saveSettings } from './settings';
+import { getCloudNode } from './cloudApi';
+
+const CLOUD_LOGIN_URL = 'https://cloud.calimero.network';
+const CLOUD_CALLBACK_SCHEME = 'calimero://cloud-callback';
+const LOGIN_POLL_INTERVAL_MS = 1500;
+const LOGIN_TIMEOUT_MS = 120_000; // 2 minutes
+
+export interface CloudUserInfo {
+  email: string;
+  name: string;
+  picture: string;
+}
+
+/**
+ * Decode a Google ID token JWT to extract user claims.
+ * No signature verification — the Cloud API server handles that.
+ */
+export function decodeIdToken(token: string): CloudUserInfo | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
+    return {
+      email: payload.email ?? '',
+      name: payload.name ?? '',
+      picture: payload.picture ?? '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a Google ID token has expired.
+ */
+export function isTokenExpired(token: string): boolean {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return true;
+    const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
+    if (!payload.exp) return true;
+    return Date.now() >= payload.exp * 1000;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Start the Cloud login flow:
+ * 1. Open cloud portal in system browser with callback-url param
+ * 2. Poll for deep link callback with the ID token
+ * 3. Auto-register by calling GET /api/cloud/me/node
+ * 4. Store credentials in settings
+ */
+export async function startCloudLogin(): Promise<CloudUserInfo | null> {
+  const loginUrl = `${CLOUD_LOGIN_URL}/?callback-url=${encodeURIComponent(CLOUD_CALLBACK_SCHEME)}`;
+
+  // Clear any stale pending auth
+  await invoke('clear_pending_cloud_auth');
+
+  // Open cloud portal in system browser
+  await invoke('open_url_in_browser', { url: loginUrl });
+
+  // Poll for the deep link callback
+  const token = await pollForCloudAuth();
+  if (!token) return null;
+
+  // Decode user info from token
+  const userInfo = decodeIdToken(token);
+  if (!userInfo) return null;
+
+  // Auto-register by fetching cloud node (creates account on first call)
+  await getCloudNode(token).catch(() => null);
+
+  // Save to settings
+  const settings = getSettings();
+  saveSettings({
+    ...settings,
+    cloudConnected: true,
+    cloudIdToken: token,
+    cloudUserEmail: userInfo.email,
+    cloudUserName: userInfo.name,
+    cloudUserPicture: userInfo.picture,
+  });
+
+  return userInfo;
+}
+
+/**
+ * Wait for the cloud auth deep link callback.
+ * Uses both Tauri event listener (for when app is already running)
+ * and polling (for when app was launched by the deep link).
+ */
+async function pollForCloudAuth(): Promise<string | null> {
+  return new Promise<string | null>((resolve) => {
+    let unlisten: UnlistenFn | null = null;
+    let resolved = false;
+
+    const done = (token: string | null) => {
+      if (resolved) return;
+      resolved = true;
+      if (unlisten) unlisten();
+      clearInterval(pollTimer);
+      clearTimeout(timeout);
+      resolve(token);
+    };
+
+    // Listen for the Tauri event (app already running, receives Apple Event)
+    listen<string>('cloud-auth-callback', (event) => {
+      const token = extractTokenFromCallbackUrl(event.payload);
+      if (token) done(token);
+    }).then((fn) => {
+      unlisten = fn;
+    });
+
+    // Poll for the pending state (app launched by deep link URL)
+    const pollTimer = setInterval(async () => {
+      try {
+        const url = await invoke<string | null>('get_pending_cloud_auth');
+        if (url) {
+          await invoke('clear_pending_cloud_auth');
+          const token = extractTokenFromCallbackUrl(url);
+          if (token) done(token);
+        }
+      } catch {
+        // Command not available yet or error — keep polling
+      }
+    }, LOGIN_POLL_INTERVAL_MS);
+
+    // Timeout
+    const timeout = setTimeout(() => done(null), LOGIN_TIMEOUT_MS);
+  });
+}
+
+/**
+ * Extract the id_token from a callback URL like:
+ * calimero://cloud-callback#id_token=eyJ...
+ */
+function extractTokenFromCallbackUrl(url: string): string | null {
+  try {
+    // The token is in the URL fragment (after #)
+    const hashIndex = url.indexOf('#');
+    if (hashIndex === -1) return null;
+
+    const fragment = url.substring(hashIndex + 1);
+    const params = new URLSearchParams(fragment);
+    return params.get('id_token');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Disconnect from Calimero Cloud. Clears all cloud state from settings.
+ */
+export function disconnectCloud(): void {
+  const settings = getSettings();
+  saveSettings({
+    ...settings,
+    cloudConnected: false,
+    cloudIdToken: undefined,
+    cloudUserEmail: undefined,
+    cloudUserName: undefined,
+    cloudUserPicture: undefined,
+  });
+}
+
+/**
+ * Check if the user has a valid (non-expired) cloud connection.
+ */
+export function isCloudConnected(): boolean {
+  const settings = getSettings();
+  if (!settings.cloudConnected || !settings.cloudIdToken) return false;
+  return !isTokenExpired(settings.cloudIdToken);
+}
+
+/**
+ * Get the stored cloud ID token if valid, or null if expired/missing.
+ */
+export function getCloudIdToken(): string | null {
+  const settings = getSettings();
+  if (!settings.cloudIdToken) return null;
+  if (isTokenExpired(settings.cloudIdToken)) return null;
+  return settings.cloudIdToken;
+}

--- a/apps/desktop/src/utils/cloudAuth.ts
+++ b/apps/desktop/src/utils/cloudAuth.ts
@@ -188,15 +188,6 @@ export function disconnectCloud(): void {
 }
 
 /**
- * Check if the user has a valid (non-expired) cloud connection.
- */
-export function isCloudConnected(): boolean {
-  const settings = getSettings();
-  if (!settings.cloudConnected || !settings.cloudIdToken) return false;
-  return !isTokenExpired(settings.cloudIdToken);
-}
-
-/**
  * Get the stored cloud ID token if valid, or null if expired/missing.
  */
 export function getCloudIdToken(): string | null {

--- a/apps/desktop/src/utils/featureFlags.ts
+++ b/apps/desktop/src/utils/featureFlags.ts
@@ -1,0 +1,8 @@
+/// <reference types="vite/client" />
+
+const RAW_CLOUD = import.meta.env.VITE_ENABLE_CLOUD as string | undefined;
+
+export function isCloudEnabled(): boolean {
+  if (RAW_CLOUD === undefined || RAW_CLOUD === "") return Boolean(import.meta.env.DEV);
+  return RAW_CLOUD === "true" || RAW_CLOUD === "1";
+}

--- a/apps/desktop/src/utils/onboardingProgress.ts
+++ b/apps/desktop/src/utils/onboardingProgress.ts
@@ -1,6 +1,6 @@
 const ONBOARDING_PROGRESS_KEY = 'calimero-onboarding-progress';
 
-export type OnboardingStep = 'welcome' | 'what-is' | 'node-setup' | 'login' | 'install-app';
+export type OnboardingStep = 'welcome' | 'what-is' | 'node-setup' | 'cloud-connect' | 'login' | 'install-app';
 
 export interface OnboardingProgress {
   currentStep: OnboardingStep;

--- a/apps/desktop/src/utils/settings.ts
+++ b/apps/desktop/src/utils/settings.ts
@@ -9,6 +9,11 @@ export interface AppSettings {
   developerMode?: boolean; // Developer mode - shows advanced features like multiple nodes and contexts
   debugLogs?: boolean; // Enable debug-level logging for the merod node
   onboardingCompleted?: boolean; // True once user has completed first-time setup - never show onboarding again
+  cloudConnected?: boolean; // Whether user is connected to Calimero Cloud
+  cloudIdToken?: string; // Google ID token for Cloud API auth
+  cloudUserEmail?: string; // User's Google email (for display)
+  cloudUserName?: string; // User's Google display name
+  cloudUserPicture?: string; // User's Google profile picture URL
 }
 
 const SETTINGS_KEY = 'calimero-desktop-settings';
@@ -80,6 +85,11 @@ export function getSettings(): AppSettings {
         developerMode: rawSettings.developerMode ?? false, // Default to false
         debugLogs: rawSettings.debugLogs ?? false,
         onboardingCompleted: rawSettings.onboardingCompleted ?? false,
+        cloudConnected: rawSettings.cloudConnected ?? false,
+        cloudIdToken: rawSettings.cloudIdToken,
+        cloudUserEmail: rawSettings.cloudUserEmail,
+        cloudUserName: rawSettings.cloudUserName,
+        cloudUserPicture: rawSettings.cloudUserPicture,
       };
     }
   } catch (error) {


### PR DESCRIPTION
Add cloud connection flow via browser-based Google OAuth with deep link callback (calimero:// URL scheme). Users can connect during onboarding (new skippable step after node setup) or later via the new Cloud tab in Settings.

All cloud surfaces (onboarding cloud-connect step, Settings → Cloud tab, namespace **High Availability** section) are gated behind the **`VITE_ENABLE_CLOUD`** feature flag. The flag defaults to `import.meta.env.DEV` — on in `vite dev`, off in production `vite build` — and can be overridden by setting `VITE_ENABLE_CLOUD=true|false` in the build env. HA is gated together with cloud because it depends on a cloud session.

- Add cloudAuth.ts: login orchestration, token decode, deep link polling
- Add cloudApi.ts: Cloud API client (node, profile, subscription)
- Add cloud-connect onboarding step between node-setup and login
- Add Cloud tab to Settings with connect/disconnect UI
- Register calimero:// URL scheme (Info.plist for macOS)
- Add PendingCloudAuth state + deep link handler in Tauri backend
- Extend AppSettings with cloud connection fields
- Add `isCloudEnabled()` helper (apps/desktop/src/utils/featureFlags.ts) and gate the three cloud surfaces on it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new Google OAuth-based Cloud login flow with deep-link handling and persists ID tokens in app settings, which is security-sensitive and easy to break across OS launch paths. Also introduces new Cloud/HA API calls that can affect namespace replication behavior.
>
> **Overview**
> Adds Calimero Cloud integration to the desktop app, including a browser-based Google OAuth flow that returns via the \`calimero://\` deep-link scheme and persists Cloud session/user details in settings.
>
> Extends the Tauri backend with \`tauri-plugin-deep-link\`, macOS \`Info.plist\` URL scheme registration, and new \`get_pending_cloud_auth\`/\`clear_pending_cloud_auth\` commands to support both cold-launch and hot-launch callback delivery.
>
> Updates the UI with an optional onboarding **Cloud connect** step, a new **Cloud** tab in Settings (connect/disconnect + plan fetch), and a Namespaces **High Availability** toggle that calls Cloud APIs to enable/disable HA and sets the local node's TEE admission policy before enabling.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a263a0128757589d1ebe5b10983f4f85f9a28d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->