### PR TITLE
fix: react error boundries

### DIFF
--- a/apps/desktop/e2e/error-boundary.spec.ts
+++ b/apps/desktop/e2e/error-boundary.spec.ts
@@ -1,0 +1,206 @@
+import { test, expect } from "@playwright/test";
+import { mockCoreAPIs, setupAuthenticatedPage } from "./fixtures/helpers";
+import { AUTHENTICATED_SETTINGS, STORAGE_KEYS } from "./fixtures/mock-data";
+
+// Helper: seed settings so the app is past onboarding and boots the root ErrorBoundary
+async function seedAndLoad(page: any) {
+  await mockCoreAPIs(page);
+  await page.goto("/");
+  await page.evaluate(
+    ([key, val]: [string, any]) => localStorage.setItem(key, JSON.stringify(val)),
+    [STORAGE_KEYS.settings, AUTHENTICATED_SETTINGS] as const,
+  );
+  await page.reload();
+}
+
+// Helper: trigger root ErrorBoundary via the test hook exposed in componentDidMount
+async function triggerRootError(page: any, message = "Test render error") {
+  await page.waitForFunction(() => typeof (window as any).__triggerErrorBoundary === "function", { timeout: 10_000 });
+  await page.evaluate((msg: string) => (window as any).__triggerErrorBoundary(msg), message);
+}
+
+// ─── Error boundary UI ────────────────────────────────────────────────────────
+
+test.describe("ErrorBoundary — UI", () => {
+  test("shows error UI when a render error occurs", async ({ page }) => {
+    await seedAndLoad(page);
+    await triggerRootError(page, "Something exploded");
+
+    await expect(page.getByTestId("error-boundary")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Something went wrong" })).toBeVisible();
+  });
+
+  test("shows the error message in the details block", async ({ page }) => {
+    await seedAndLoad(page);
+    await triggerRootError(page, "Unique error XYZ-123");
+
+    await expect(page.getByTestId("error-boundary-details")).toContainText("Unique error XYZ-123");
+  });
+
+  test("shows Try Again, Reload App and Copy Error buttons", async ({ page }) => {
+    await seedAndLoad(page);
+    await triggerRootError(page);
+
+    await expect(page.getByTestId("error-boundary-retry")).toBeVisible();
+    await expect(page.getByTestId("error-boundary-reload")).toBeVisible();
+    await expect(page.getByTestId("error-boundary-copy")).toBeVisible();
+  });
+});
+
+// ─── Recovery: Try Again ──────────────────────────────────────────────────────
+
+test.describe("ErrorBoundary — Try Again", () => {
+  test("clicking Try Again hides the error UI", async ({ page }) => {
+    await seedAndLoad(page);
+    await triggerRootError(page);
+
+    await expect(page.getByTestId("error-boundary")).toBeVisible();
+    await page.getByTestId("error-boundary-retry").click();
+    await expect(page.getByTestId("error-boundary")).not.toBeVisible();
+  });
+
+  test("clicking Try Again re-renders the app", async ({ page }) => {
+    await mockCoreAPIs(page);
+    await page.goto("/");
+    await page.evaluate(
+      ([key, val]: [string, any]) => localStorage.setItem(key, JSON.stringify(val)),
+      [STORAGE_KEYS.settings, AUTHENTICATED_SETTINGS] as const,
+    );
+    await page.reload();
+
+    await triggerRootError(page);
+    await page.getByTestId("error-boundary-retry").click();
+
+    // App content should be back — login or main shell visible
+    await expect(
+      page.locator("aside.sidebar, [data-testid='login-screen']")
+    ).toBeVisible({ timeout: 10_000 });
+  });
+});
+
+// ─── Recovery: Reload App ─────────────────────────────────────────────────────
+
+test.describe("ErrorBoundary — Reload App", () => {
+  test("clicking Reload App navigates away from the error screen", async ({ page }) => {
+    await seedAndLoad(page);
+    await triggerRootError(page);
+
+    await expect(page.getByTestId("error-boundary")).toBeVisible();
+
+    // Set up the navigation listener BEFORE clicking so we don't miss it
+    const navPromise = page.waitForNavigation({ timeout: 10_000 }).catch(() => {});
+    await page.getByTestId("error-boundary-reload").click();
+    await navPromise;
+
+    await expect(page.getByTestId("error-boundary")).not.toBeVisible({ timeout: 10_000 });
+  });
+});
+
+// ─── Error logging to localStorage ───────────────────────────────────────────
+
+test.describe("ErrorBoundary — error logging", () => {
+  test("logs error to calimero-error-log in localStorage", async ({ page }) => {
+    await seedAndLoad(page);
+    await triggerRootError(page, "Logged error ABC");
+
+    // Wait until componentDidCatch has written to localStorage
+    await page.waitForFunction(() => localStorage.getItem("calimero-error-log") !== null, { timeout: 5_000 });
+
+    const log = await page.evaluate(() => {
+      const raw = localStorage.getItem("calimero-error-log");
+      return raw ? JSON.parse(raw) : [];
+    });
+
+    expect(Array.isArray(log)).toBe(true);
+    expect(log.length).toBeGreaterThan(0);
+    const last = log[log.length - 1];
+    expect(last).toHaveProperty("timestamp");
+    expect(last).toHaveProperty("error");
+  });
+
+  test("keeps at most 10 entries in error log", async ({ page }) => {
+    await seedAndLoad(page);
+    await triggerRootError(page, "Error log overflow test");
+
+    // Seed 15 pre-existing log entries
+    await page.evaluate(() => {
+      const entries = Array.from({ length: 15 }, (_, i) => ({
+        timestamp: new Date().toISOString(),
+        componentName: "Test",
+        error: { name: "Error", message: `Error ${i}`, stack: "" },
+        componentStack: "",
+      }));
+      localStorage.setItem("calimero-error-log", JSON.stringify(entries));
+    });
+
+    // Trigger another error — should trim to 10
+    await page.getByTestId("error-boundary-retry").click();
+    await triggerRootError(page, "One more error");
+
+    // Wait for the new entry to be written before checking the cap
+    await page.waitForFunction(() => {
+      const raw = localStorage.getItem("calimero-error-log");
+      if (!raw) return false;
+      const entries = JSON.parse(raw);
+      return entries.some((e: any) => e.error?.message === "One more error");
+    }, { timeout: 5_000 });
+
+    const log = await page.evaluate(() => {
+      const raw = localStorage.getItem("calimero-error-log");
+      return raw ? JSON.parse(raw) : [];
+    });
+
+    expect(log.length).toBeLessThanOrEqual(10);
+  });
+});
+
+// ─── Copy Error button ────────────────────────────────────────────────────────
+
+test.describe("ErrorBoundary — Copy Error", () => {
+  test("Copy Error button is clickable without throwing", async ({ page }) => {
+    await seedAndLoad(page);
+    await triggerRootError(page, "Copyable error");
+
+    // Grant clipboard permission and click
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+    await expect(page.getByTestId("error-boundary-copy")).toBeEnabled();
+    await page.getByTestId("error-boundary-copy").click();
+
+    // Error UI should still be visible after copy (no crash)
+    await expect(page.getByTestId("error-boundary")).toBeVisible();
+
+    // Clipboard should contain the error message that was triggered
+    const clipText = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipText).toContain("Copyable error");
+  });
+});
+
+// ─── Authenticated page — boundary wraps sections ────────────────────────────
+
+test.describe("ErrorBoundary — authenticated app sections", () => {
+  test("login screen is wrapped — error boundary test hook is registered", async ({ page }) => {
+    // Verify root ErrorBoundary hook is always available after app boots
+    await mockCoreAPIs(page);
+    await page.goto("/");
+    await page.evaluate(
+      ([key, val]: [string, any]) => localStorage.setItem(key, JSON.stringify(val)),
+      [STORAGE_KEYS.settings, AUTHENTICATED_SETTINGS] as const,
+    );
+    await page.reload();
+
+    const hookExists = await page.waitForFunction(
+      () => typeof (window as any).__triggerErrorBoundary === "function",
+      { timeout: 10_000 },
+    );
+    expect(hookExists).toBeTruthy();
+  });
+
+  test("app recovers to main shell after error + retry on authenticated page", async ({ page }) => {
+    await setupAuthenticatedPage(page);
+    await triggerRootError(page, "Crash in main app");
+
+    await expect(page.getByTestId("error-boundary")).toBeVisible();
+    await page.getByTestId("error-boundary-retry").click();
+    await expect(page.locator("aside.sidebar")).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import ErrorBoundary from "./components/ErrorBoundary";
 import { createClientAsync, apiClient, LoginView, getAccessToken, clearAccessToken, clearRefreshToken } from "@calimero-network/mero-react";
 import { getSettings, getAuthUrl, saveSettings } from "./utils/settings";
 import { clearOnboardingProgress } from "./utils/onboardingProgress";
@@ -509,46 +510,48 @@ function App() {
   // Show login if needed
   if (showLogin) {
     return (
-      <div className="app login-screen" data-testid="login-screen">
-        <header className="login-screen-header">
-          <div className="login-screen-brand">
-            <img src={calimeroLogo} alt="Calimero" className="login-screen-logo" />
-          </div>
-          <button 
-            onClick={() => { 
-              setShowLogin(false); 
-              setShowSettings(true); 
-            }} 
-            className="button button-secondary"
-          >
-            <SettingsIcon size={16} style={{ marginRight: '6px', verticalAlign: 'middle' }} />
-            Settings
-          </button>
-        </header>
-        <main className="login-screen-main">
-        <LoginView
-          variant={theme}
-          onSuccess={() => {
-            setShowLogin(false);
-            // Reload contexts after login
-            loadContexts();
-            loadInstalledApps();
-            checkConnection();
-          }}
-          onError={(error) => {
-            console.error('❌ Login failed:', error);
-          }}
-        />
-        </main>
-      </div>
+      <ErrorBoundary componentName="Login" onReset={() => setShowLogin(true)}>
+        <div className="app login-screen" data-testid="login-screen">
+          <header className="login-screen-header">
+            <div className="login-screen-brand">
+              <img src={calimeroLogo} alt="Calimero" className="login-screen-logo" />
+            </div>
+            <button
+              onClick={() => {
+                setShowLogin(false);
+                setShowSettings(true);
+              }}
+              className="button button-secondary"
+            >
+              <SettingsIcon size={16} style={{ marginRight: '6px', verticalAlign: 'middle' }} />
+              Settings
+            </button>
+          </header>
+          <main className="login-screen-main">
+            <LoginView
+              variant={theme}
+              onSuccess={() => {
+                setShowLogin(false);
+                loadContexts();
+                loadInstalledApps();
+                checkConnection();
+              }}
+              onError={(error) => {
+                console.error('❌ Login failed:', error);
+              }}
+            />
+          </main>
+        </div>
+      </ErrorBoundary>
     );
   }
 
 
   if (showSettings) {
     return (
-      <Settings
-        onBack={async () => {
+      <ErrorBoundary componentName="Settings" onReset={() => setShowSettings(true)}>
+        <Settings
+          onBack={async () => {
           // Reinitialize client BEFORE hiding Settings so the checkConnection useEffect
           // only fires after the client has tokens loaded from localStorage
           const settings = getSettings();
@@ -608,7 +611,8 @@ function App() {
             }
           }
         }}
-      />
+        />
+      </ErrorBoundary>
     );
   }
 

--- a/apps/desktop/src/components/ErrorBoundary.css
+++ b/apps/desktop/src/components/ErrorBoundary.css
@@ -1,0 +1,165 @@
+.error-boundary-full {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+  padding: 40px 20px;
+  background: var(--bg-secondary, #1a1a1a);
+  border-radius: 12px;
+  margin: 20px;
+}
+
+.error-boundary-content {
+  text-align: center;
+  max-width: 500px;
+}
+
+.error-boundary-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 80px;
+  height: 80px;
+  margin: 0 auto 24px;
+  background: rgba(239, 68, 68, 0.1);
+  border-radius: 50%;
+  color: var(--color-danger, #ef4444);
+}
+
+.error-boundary-title {
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text-primary, #ffffff);
+  margin: 0 0 12px;
+}
+
+.error-boundary-message {
+  font-size: 16px;
+  color: var(--text-secondary, #a3a3a3);
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+
+.error-boundary-details {
+  background: var(--bg-tertiary, #262626);
+  border: 1px solid var(--border-color, #404040);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-bottom: 24px;
+  overflow-x: auto;
+}
+
+.error-boundary-details code {
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 13px;
+  color: var(--color-danger, #ef4444);
+  word-break: break-word;
+}
+
+.error-boundary-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+
+.error-boundary-actions .button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: none;
+}
+
+.error-boundary-actions .button-primary {
+  background: var(--color-primary, #3b82f6);
+  color: #ffffff;
+}
+
+.error-boundary-actions .button-primary:hover {
+  background: var(--color-primary-hover, #2563eb);
+}
+
+.error-boundary-actions .button-secondary {
+  background: var(--bg-tertiary, #262626);
+  color: var(--text-primary, #ffffff);
+  border: 1px solid var(--border-color, #404040);
+}
+
+.error-boundary-actions .button-secondary:hover {
+  background: var(--bg-hover, #333333);
+  border-color: var(--border-color-hover, #525252);
+}
+
+.error-boundary-hint {
+  font-size: 13px;
+  color: var(--text-tertiary, #737373);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.error-boundary-minimal {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 6px;
+  color: var(--color-danger, #ef4444);
+  font-size: 13px;
+}
+
+.error-boundary-minimal span {
+  color: var(--text-secondary, #a3a3a3);
+}
+
+.error-boundary-retry-small {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--border-color, #404040);
+  border-radius: 4px;
+  color: var(--text-secondary, #a3a3a3);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.error-boundary-retry-small:hover {
+  background: var(--bg-hover, #333333);
+  color: var(--text-primary, #ffffff);
+}
+
+@keyframes error-shake {
+  0%, 100% { transform: translateX(0); }
+  10%, 30%, 50%, 70%, 90% { transform: translateX(-2px); }
+  20%, 40%, 60%, 80% { transform: translateX(2px); }
+}
+
+.error-boundary-icon svg {
+  animation: error-shake 0.5s ease-in-out;
+}
+
+[data-theme="light"] .error-boundary-full {
+  background: var(--bg-secondary, #f5f5f5);
+}
+
+[data-theme="light"] .error-boundary-details {
+  background: var(--bg-tertiary, #ffffff);
+  border-color: var(--border-color, #e5e5e5);
+}
+
+[data-theme="light"] .error-boundary-actions .button-secondary {
+  background: var(--bg-tertiary, #ffffff);
+  border-color: var(--border-color, #e5e5e5);
+}

--- a/apps/desktop/src/components/ErrorBoundary.tsx
+++ b/apps/desktop/src/components/ErrorBoundary.tsx
@@ -1,0 +1,157 @@
+import { Component, ErrorInfo, ReactNode } from "react";
+import { AlertTriangle, RefreshCw, Home, Bug } from "lucide-react";
+import "./ErrorBoundary.css";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+  componentName?: string;
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  minimal?: boolean;
+  onReset?: () => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null, errorInfo: null };
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { hasError: true, error };
+  }
+
+  componentDidMount(): void {
+    // Test hook: allows e2e tests to trigger error state without a real render crash.
+    // Only registered once — first boundary to mount (root) wins.
+    if (typeof window !== "undefined" && !(window as any).__triggerErrorBoundary) {
+      (window as any).__triggerErrorBoundary = (msg: string) => {
+        const error = new Error(msg);
+        const errorInfo = { componentStack: "" } as ErrorInfo;
+        this.logError(error, errorInfo);
+        this.setState({ hasError: true, error, errorInfo });
+      };
+    }
+  }
+
+  componentWillUnmount(): void {
+    if (typeof window !== "undefined" && (window as any).__triggerErrorBoundary) {
+      delete (window as any).__triggerErrorBoundary;
+    }
+  }
+
+  private logError(error: Error, errorInfo: ErrorInfo): void {
+    const componentName = this.props.componentName || "Unknown Component";
+    console.error(`[ErrorBoundary] Error in ${componentName}:`, error);
+    console.error(`[ErrorBoundary] Component stack:`, errorInfo.componentStack);
+
+    if (this.props.onError) {
+      this.props.onError(error, errorInfo);
+    }
+
+    try {
+      const stored = JSON.parse(localStorage.getItem("calimero-error-log") || "[]");
+      stored.push({
+        timestamp: new Date().toISOString(),
+        componentName: this.props.componentName || "Unknown",
+        error: { name: error.name, message: error.message, stack: error.stack },
+        componentStack: errorInfo.componentStack,
+      });
+      if (stored.length > 10) stored.splice(0, stored.length - 10);
+      localStorage.setItem("calimero-error-log", JSON.stringify(stored));
+    } catch {
+      // ignore
+    }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    this.setState({ errorInfo });
+    this.logError(error, errorInfo);
+  }
+
+  handleReset = (): void => {
+    this.setState({ hasError: false, error: null, errorInfo: null });
+    this.props.onReset?.();
+  };
+
+  handleCopyError = async (): Promise<void> => {
+    const { error, errorInfo } = this.state;
+    const text = [
+      `Error: ${error?.name}`,
+      `Message: ${error?.message}`,
+      `Component: ${this.props.componentName || "Unknown"}`,
+      `Stack: ${error?.stack}`,
+      `Component Stack: ${errorInfo?.componentStack}`,
+      `Time: ${new Date().toISOString()}`,
+    ].join("\n");
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // ignore
+    }
+  };
+
+  render(): ReactNode {
+    if (!this.state.hasError) return this.props.children;
+
+    if (this.props.fallback) return this.props.fallback;
+
+    if (this.props.minimal) {
+      return (
+        <div className="error-boundary error-boundary-minimal">
+          <AlertTriangle size={16} />
+          <span>Something went wrong</span>
+          <button onClick={this.handleReset} className="error-boundary-retry-small" title="Try again">
+            <RefreshCw size={14} />
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="error-boundary error-boundary-full" data-testid="error-boundary">
+        <div className="error-boundary-content">
+          <div className="error-boundary-icon">
+            <AlertTriangle size={48} />
+          </div>
+          <h2 className="error-boundary-title">Something went wrong</h2>
+          <p className="error-boundary-message" data-testid="error-boundary-message">
+            {this.props.componentName
+              ? `An error occurred in ${this.props.componentName}.`
+              : "An unexpected error occurred."}
+          </p>
+          {this.state.error && (
+            <div className="error-boundary-details" data-testid="error-boundary-details">
+              <code>{this.state.error.message}</code>
+            </div>
+          )}
+          <div className="error-boundary-actions">
+            <button onClick={this.handleReset} className="button button-primary" data-testid="error-boundary-retry">
+              <RefreshCw size={16} />
+              Try Again
+            </button>
+            <button onClick={() => window.location.reload()} className="button button-secondary" data-testid="error-boundary-reload">
+              <Home size={16} />
+              Reload App
+            </button>
+            <button onClick={this.handleCopyError} className="button button-secondary" data-testid="error-boundary-copy" title="Copy error details">
+              <Bug size={16} />
+              Copy Error
+            </button>
+          </div>
+          <p className="error-boundary-hint">
+            If this problem persists, try restarting the application.
+          </p>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -3,13 +3,16 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { ToastProvider } from "./contexts/ToastContext";
+import ErrorBoundary from "./components/ErrorBoundary";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ThemeProvider>
       <ToastProvider>
-    <App />
+        <ErrorBoundary componentName="Calimero Desktop">
+          <App />
+        </ErrorBoundary>
       </ToastProvider>
     </ThemeProvider>
   </React.StrictMode>


### PR DESCRIPTION
# fix: react error boundries

## Description
Update related to this [pr](https://github.com/calimero-network/tauri-app/pull/24)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wraps the root app and key screens in a new `ErrorBoundary`, which changes runtime failure behavior and could mask crashes or affect navigation/reset flows. Also adds localStorage-based error logging and clipboard copy, which can have edge-case/browser-permission implications.
> 
> **Overview**
> Adds a new React `ErrorBoundary` component with a full fallback UI (*Try Again*, *Reload App*, *Copy Error*), optional minimal mode, and localStorage-backed error logging capped at 10 entries (`calimero-error-log`).
> 
> Wraps the root `App` in `main.tsx` and additionally wraps the `Login` and `Settings` screens in `App.tsx` so render-time crashes surface a consistent recovery experience.
> 
> Introduces Playwright e2e coverage (`error-boundary.spec.ts`) validating fallback UI, reset/reload behavior, clipboard copy, and persisted error logging via a test-only `window.__triggerErrorBoundary` hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8539cc32369f342cb3f246f655d64f7facde8417. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->