### PR TITLE
fix: secure token storage

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +109,175 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "async-broadcast"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
+dependencies = [
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.3.0",
+ "futures-lite 2.6.1",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "blocking",
+ "futures-lite 1.13.0",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.28",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "parking",
+ "polling 3.11.0",
+ "rustix 1.1.3",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+dependencies = [
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 3.1.0",
+ "futures-lite 1.13.0",
+ "rustix 0.38.44",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io 2.6.0",
+ "async-lock 3.4.2",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.3",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "atk"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +300,12 @@ dependencies = [
  "libc",
  "system-deps 6.2.2",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auto-launch"
@@ -181,6 +367,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "piper",
 ]
 
 [[package]]
@@ -271,6 +479,7 @@ version = "0.1.0"
 dependencies = [
  "dirs 5.0.1",
  "env_logger",
+ "keyring",
  "log",
  "regex",
  "reqwest",
@@ -292,6 +501,15 @@ checksum = "599aa35200ffff8f04c1925aa1acc92fa2e08874379ef42e210a80e527e60838"
 dependencies = [
  "serde",
  "toml 0.7.8",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -359,6 +577,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +636,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -601,6 +838,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +869,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -759,6 +1008,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +1068,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,7 +1135,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "rustc_version",
 ]
 
@@ -929,6 +1246,34 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand 2.3.0",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1335,10 +1680,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html5ever"
@@ -1634,12 +2009,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1767,6 +2163,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "363387f0019d714aa60cc30ab4fe501a747f4c08fc58f069dd14be971bd495a0"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "linux-keyutils",
+ "secret-service",
+ "security-framework",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,6 +2245,28 @@ dependencies = [
  "libc",
  "redox_syscall 0.7.0",
 ]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1930,6 +2362,15 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -2022,6 +2463,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2037,10 +2490,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2184,6 +2701,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "pango"
 version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2734,12 @@ dependencies = [
  "libc",
  "system-deps 6.2.2",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2390,6 +2923,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.3.0",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,6 +2963,36 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.5.2",
+ "pin-project-lite",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2781,6 +3355,33 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.37.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -2788,7 +3389,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -2866,6 +3467,25 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secret-service"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5204d39df37f06d1944935232fd2dfe05008def7ca599bf28c0800366c8a8f9"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "sha2",
+ "zbus",
+]
 
 [[package]]
 name = "security-framework"
@@ -3060,6 +3680,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3758,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
@@ -3189,6 +3830,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3218,6 +3865,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -3602,10 +4255,10 @@ version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
- "fastrand",
+ "fastrand 2.3.0",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -3889,6 +4542,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset 0.9.1",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3991,6 +4655,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -4380,6 +5050,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -4830,7 +5509,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.3",
+]
+
+[[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4854,6 +5543,72 @@ dependencies = [
  "quote",
  "syn 2.0.114",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "byteorder",
+ "derivative",
+ "enumflags2",
+ "event-listener 2.5.3",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "once_cell",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "winapi",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7131497b0f887e8061b430c530240063d33bf9455fa34438f388a245da69e0a5"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
 ]
 
 [[package]]
@@ -4946,3 +5701,41 @@ name = "zmij"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+
+[[package]]
+name = "zvariant"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eef2be88ba09b358d3b58aca6e41cd853631d44787f319a1383ca83424fb2db"
+dependencies = [
+ "byteorder",
+ "enumflags2",
+ "libc",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c24dc0bed72f5f90d1f8bb5b07228cbf63b3c6e9f82d82559d4bae666e7ed9"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ env_logger = "0.11"
 dirs = "5.0"
 toml = "0.8"
 regex = "1.10"
+keyring = "2"
 
 [profile.release]
 strip = "symbols"

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1872,6 +1872,58 @@ fn graceful_shutdown(merod_state: &MerodState) {
     info!("[Shutdown] Graceful shutdown complete");
 }
 
+// ─── Secure Token Storage ──────────────────────────────────────────────────────
+// Stores JWT tokens in the OS keychain (Keychain on macOS, Credential Manager
+// on Windows, libsecret on Linux) instead of plaintext localStorage.
+
+const KEYRING_SERVICE: &str = "calimero-desktop";
+
+#[tauri::command]
+fn secure_store_token(key: String, value: String) -> Result<(), String> {
+    let entry = keyring::Entry::new(KEYRING_SERVICE, &key)
+        .map_err(|e| format!("Failed to create keyring entry: {}", e))?;
+    entry
+        .set_password(&value)
+        .map_err(|e| format!("Failed to store token: {}", e))?;
+    debug!("[SecureStorage] Stored token for key: {}", key);
+    Ok(())
+}
+
+#[tauri::command]
+fn secure_get_token(key: String) -> Result<Option<String>, String> {
+    let entry = keyring::Entry::new(KEYRING_SERVICE, &key)
+        .map_err(|e| format!("Failed to create keyring entry: {}", e))?;
+    match entry.get_password() {
+        Ok(password) => {
+            debug!("[SecureStorage] Retrieved token for key: {}", key);
+            Ok(Some(password))
+        }
+        Err(keyring::Error::NoEntry) => {
+            debug!("[SecureStorage] No token found for key: {}", key);
+            Ok(None)
+        }
+        Err(e) => Err(format!("Failed to retrieve token: {}", e)),
+    }
+}
+
+#[tauri::command]
+fn secure_delete_token(key: String) -> Result<(), String> {
+    let entry = keyring::Entry::new(KEYRING_SERVICE, &key)
+        .map_err(|e| format!("Failed to create keyring entry: {}", e))?;
+    match entry.delete_password() {
+        Ok(()) => {
+            debug!("[SecureStorage] Deleted token for key: {}", key);
+            Ok(())
+        }
+        Err(keyring::Error::NoEntry) => {
+            // Token doesn't exist — deletion is idempotent
+            debug!("[SecureStorage] Token for key {} didn't exist, nothing to delete", key);
+            Ok(())
+        }
+        Err(e) => Err(format!("Failed to delete token: {}", e)),
+    }
+}
+
 fn main() {
     // Initialize logger - reads from RUST_LOG environment variable
     // Default: info level in release, debug level in debug builds
@@ -2025,7 +2077,10 @@ fn main() {
             autostart_disable,
             autostart_is_enabled,
             close_current_window,
-            open_url_in_browser
+            open_url_in_browser,
+            secure_store_token,
+            secure_get_token,
+            secure_delete_token
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -49,12 +49,12 @@ function App() {
   const [appVersion, setAppVersion] = useState<string>("");
   const [runningNodes, setRunningNodes] = useState<RunningMerodNode[]>([]);
 
-  const handleSelectNode = useCallback((nodeUrl: string) => {
+  const handleSelectNode = useCallback(async (nodeUrl: string) => {
     const settings = getSettings();
     if (settings.nodeUrl !== nodeUrl) {
       // Clear auth tokens — old tokens are invalid for the new node
-      clearAccessToken();
-      clearRefreshToken();
+      await clearAccessToken();
+      await clearRefreshToken();
       localStorage.removeItem('calimero-auth-tokens');
     }
     saveSettings({ ...settings, nodeUrl });

--- a/apps/desktop/src/pages/NodeManagement.tsx
+++ b/apps/desktop/src/pages/NodeManagement.tsx
@@ -187,8 +187,8 @@ export default function NodeManagement() {
 
       // Clear auth tokens when switching nodes — old tokens are invalid
       if (urlChanged) {
-        clearAccessToken();
-        clearRefreshToken();
+        await clearAccessToken();
+        await clearRefreshToken();
         localStorage.removeItem('calimero-auth-tokens');
       }
 
@@ -264,7 +264,7 @@ export default function NodeManagement() {
     }
   };
 
-  const handleSaveNodeConfig = () => {
+  const handleSaveNodeConfig = async () => {
     try {
       const settings = getSettings();
       const newNodeUrl = nodeUrl.trim() || "http://localhost:2528";
@@ -277,8 +277,8 @@ export default function NodeManagement() {
 
       // Clear auth tokens when switching to a different node — old tokens are invalid
       if (urlChanged) {
-        clearAccessToken();
-        clearRefreshToken();
+        await clearAccessToken();
+        await clearRefreshToken();
         localStorage.removeItem('calimero-auth-tokens');
       }
 

--- a/packages/mero-react/src/client/client.ts
+++ b/packages/mero-react/src/client/client.ts
@@ -1,38 +1,44 @@
 import { MeroJs, type TokenStorage, type TokenData } from '@calimero-network/mero-js';
 import type { ApiResponse, ClientConfig, Provider, TokenResponse } from './types';
 import { setClientInstance } from './singleton';
+import {
+  getAccessToken,
+  getRefreshToken,
+  getTokenExpiresAt,
+  setAccessToken,
+  setRefreshToken,
+  setTokenExpiresAt,
+  clearAllTokens,
+  initializeTokenStorage,
+} from './token-storage';
 
 /**
- * LocalStorage-based TokenStorage implementation for browser/Tauri
- * 
- * IMPORTANT: Uses the same keys as the exported token-storage utilities
- * to maintain consistency across login flows and API calls.
+ * TokenStorage implementation backed by the token-storage cache.
+ *
+ * Reads go through the in-memory cache (populated from the OS keychain in
+ * Tauri, or from localStorage in web/test environments) rather than hitting
+ * localStorage directly. This means tokens are visible to mero-js even after
+ * the one-time migration that removes them from localStorage.
  */
-class LocalStorageTokenStorage implements TokenStorage {
-  // Match the keys from token-storage.ts
-  private readonly ACCESS_TOKEN_KEY = 'calimero_access_token';
-  private readonly REFRESH_TOKEN_KEY = 'calimero_refresh_token';
-  private readonly EXPIRES_AT_KEY = 'calimero_token_expires_at';
-
+class CacheBackedTokenStorage implements TokenStorage {
   async get(): Promise<TokenData | null> {
     try {
-      const accessToken = localStorage.getItem(this.ACCESS_TOKEN_KEY);
-      const refreshToken = localStorage.getItem(this.REFRESH_TOKEN_KEY);
-      const expiresAt = localStorage.getItem(this.EXPIRES_AT_KEY);
-      
+      const accessToken = getAccessToken();
+      const refreshToken = getRefreshToken();
+
       console.log('[TokenStorage.get] accessToken:', accessToken ? 'EXISTS' : 'NULL');
       console.log('[TokenStorage.get] refreshToken:', refreshToken ? 'EXISTS' : 'NULL');
-      console.log('[TokenStorage.get] expiresAt:', expiresAt);
-      
+
       if (!accessToken || !refreshToken) {
         console.log('[TokenStorage.get] Missing tokens, returning null');
         return null;
       }
-      
+
+      const expiresAt = getTokenExpiresAt();
       const tokenData = {
         access_token: accessToken,
         refresh_token: refreshToken,
-        expires_at: expiresAt ? parseInt(expiresAt, 10) : Date.now() + 3600000,
+        expires_at: expiresAt ?? Date.now() + 3600000,
       };
       console.log('[TokenStorage.get] Returning tokenData with expires_at:', tokenData.expires_at);
       return tokenData;
@@ -43,17 +49,15 @@ class LocalStorageTokenStorage implements TokenStorage {
   }
 
   async set(token: TokenData): Promise<void> {
-    localStorage.setItem(this.ACCESS_TOKEN_KEY, token.access_token);
-    localStorage.setItem(this.REFRESH_TOKEN_KEY, token.refresh_token);
+    setAccessToken(token.access_token);
+    setRefreshToken(token.refresh_token);
     if (token.expires_at) {
-      localStorage.setItem(this.EXPIRES_AT_KEY, token.expires_at.toString());
+      setTokenExpiresAt(token.expires_at);
     }
   }
 
   async clear(): Promise<void> {
-    localStorage.removeItem(this.ACCESS_TOKEN_KEY);
-    localStorage.removeItem(this.REFRESH_TOKEN_KEY);
-    localStorage.removeItem(this.EXPIRES_AT_KEY);
+    clearAllTokens();
   }
 }
 
@@ -561,8 +565,8 @@ export class Client {
     console.log('[Client] Constructor called with config:', config);
     
     // Create token storage
-    const tokenStorage = new LocalStorageTokenStorage();
-    console.log('[Client] Created LocalStorageTokenStorage');
+    const tokenStorage = new CacheBackedTokenStorage();
+    console.log('[Client] Created CacheBackedTokenStorage');
     
     // Create MeroJs instance with token storage
     this.meroJs = new MeroJs({
@@ -615,6 +619,10 @@ export function createClient(config: ClientConfig): Client {
  */
 export async function createClientAsync(config: ClientConfig): Promise<Client> {
   console.log('[createClientAsync] Creating client with config:', config);
+  // Warm the token cache from the OS keychain BEFORE the client reads tokens.
+  // Without this, getAccessToken() returns null on first call after a keychain
+  // migration, causing the app to show the login screen on every cold start.
+  await initializeTokenStorage();
   const client = new Client(config);
   
   // Update global singleton

--- a/packages/mero-react/src/client/client.ts
+++ b/packages/mero-react/src/client/client.ts
@@ -49,15 +49,17 @@ class CacheBackedTokenStorage implements TokenStorage {
   }
 
   async set(token: TokenData): Promise<void> {
-    setAccessToken(token.access_token);
-    setRefreshToken(token.refresh_token);
+    await Promise.all([
+      setAccessToken(token.access_token),
+      setRefreshToken(token.refresh_token),
+    ]);
     if (token.expires_at) {
       setTokenExpiresAt(token.expires_at);
     }
   }
 
   async clear(): Promise<void> {
-    clearAllTokens();
+    await clearAllTokens();
   }
 }
 
@@ -600,16 +602,17 @@ export class Client {
 export function createClient(config: ClientConfig): Client {
   console.log('[createClient] Creating client with config:', config);
   const client = new Client(config);
-  
+
   // Update global singleton immediately
   setClientInstance(client);
-  
-  // Initialize async (load tokens from storage)
-  // This runs in background - use createClientAsync if you need guaranteed token loading
-  client.init().then(() => {
-    console.log('[createClient] Token initialization complete');
-  }).catch(console.error);
-  
+
+  // Warm the token cache from the OS keychain BEFORE meroJs.init() reads tokens,
+  // otherwise getAccessToken() returns null after a keychain migration.
+  initializeTokenStorage()
+    .then(() => client.init())
+    .then(() => console.log('[createClient] Token initialization complete'))
+    .catch(console.error);
+
   return client;
 }
 

--- a/packages/mero-react/src/client/token-storage.ts
+++ b/packages/mero-react/src/client/token-storage.ts
@@ -1,33 +1,198 @@
 // Token storage utilities - matches calimero-client API
+// In Tauri: tokens are stored in the OS keychain (Keychain on macOS,
+// Credential Manager on Windows, libsecret on Linux).
+// In web / test environments: falls back to localStorage.
 
 const ACCESS_TOKEN_KEY = 'calimero_access_token';
 const REFRESH_TOKEN_KEY = 'calimero_refresh_token';
 const EXPIRES_AT_KEY = 'calimero_token_expires_at';
 const APP_ENDPOINT_KEY = 'calimero_app_endpoint';
 
+// ─── Tauri detection + invoke ──────────────────────────────────────────────────
+//
+// In Tauri 1.x the webview injects BOTH:
+//   • window.__TAURI__     — configuration / convertFileSrc etc.
+//   • window.__TAURI_IPC__ — the IPC bridge used by invoke()
+//
+// Playwright's stubTauriIPC helper only sets __TAURI_IPC__, not __TAURI__, so
+// tests transparently fall through to the localStorage path.
+
+function isTauriEnv(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    '__TAURI__' in window &&
+    typeof (window as any).__TAURI_IPC__ === 'function'
+  );
+}
+
+/**
+ * Minimal inline invoke — mirrors @tauri-apps/api/tauri so mero-react doesn't
+ * need that package as a dependency.
+ */
+function tauriInvoke<T>(cmd: string, args: Record<string, unknown> = {}): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const cbId = window.crypto.getRandomValues(new Uint32Array(1))[0];
+    const errId = window.crypto.getRandomValues(new Uint32Array(1))[0];
+
+    Object.defineProperty(window, `_${cbId}`, {
+      value: (result: T) => {
+        Reflect.deleteProperty(window, `_${cbId}`);
+        Reflect.deleteProperty(window, `_${errId}`);
+        resolve(result);
+      },
+      configurable: true,
+      writable: false,
+    });
+    Object.defineProperty(window, `_${errId}`, {
+      value: (err: unknown) => {
+        Reflect.deleteProperty(window, `_${cbId}`);
+        Reflect.deleteProperty(window, `_${errId}`);
+        reject(err);
+      },
+      configurable: true,
+      writable: false,
+    });
+
+    (window as any).__TAURI_IPC__({ cmd, callback: cbId, error: errId, ...args });
+  });
+}
+
+// ─── Keychain primitives ───────────────────────────────────────────────────────
+
+async function keychainSet(key: string, value: string): Promise<void> {
+  if (isTauriEnv()) {
+    try {
+      await tauriInvoke('secure_store_token', { key, value });
+      return;
+    } catch (e) {
+      console.warn('[TokenStorage] Keychain write failed, falling back to localStorage:', e);
+    }
+  }
+  localStorage.setItem(key, value);
+}
+
+async function keychainGet(key: string): Promise<string | null> {
+  if (isTauriEnv()) {
+    try {
+      return await tauriInvoke<string | null>('secure_get_token', { key });
+    } catch (e) {
+      console.warn('[TokenStorage] Keychain read failed, falling back to localStorage:', e);
+    }
+  }
+  return localStorage.getItem(key);
+}
+
+async function keychainDelete(key: string): Promise<void> {
+  if (isTauriEnv()) {
+    try {
+      await tauriInvoke('secure_delete_token', { key });
+    } catch (e) {
+      console.warn('[TokenStorage] Keychain delete failed:', e);
+    }
+  }
+  // Always clear localStorage too (handles migration from pre-keychain installs)
+  localStorage.removeItem(key);
+}
+
+// ─── In-memory cache ───────────────────────────────────────────────────────────
+// Lets the existing synchronous API keep working after the first async warm-up.
+
+const cache: Record<string, string | null> = {
+  [ACCESS_TOKEN_KEY]: null,
+  [REFRESH_TOKEN_KEY]: null,
+};
+
+let initialized = false;
+let initPromise: Promise<void> | null = null;
+
+/**
+ * Warm the in-memory cache from secure storage.
+ * Call this once at app startup so subsequent sync reads hit the cache.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ */
+export async function initializeTokenStorage(): Promise<void> {
+  if (initialized) return;
+  if (initPromise) return initPromise;
+
+  initPromise = (async () => {
+    const [access, refresh] = await Promise.all([
+      keychainGet(ACCESS_TOKEN_KEY),
+      keychainGet(REFRESH_TOKEN_KEY),
+    ]).catch((e) => {
+      // Reset so callers can retry on next interaction
+      initPromise = null;
+      throw e;
+    });
+    cache[ACCESS_TOKEN_KEY] = access;
+    cache[REFRESH_TOKEN_KEY] = refresh;
+
+    // One-time migration: if tokens exist in localStorage from a pre-keychain
+    // install, move them into the keychain and remove the plaintext copies.
+    if (isTauriEnv()) {
+      const localAccess = localStorage.getItem(ACCESS_TOKEN_KEY);
+      const localRefresh = localStorage.getItem(REFRESH_TOKEN_KEY);
+      if (localAccess && !cache[ACCESS_TOKEN_KEY]) {
+        await keychainSet(ACCESS_TOKEN_KEY, localAccess);
+        cache[ACCESS_TOKEN_KEY] = localAccess;
+        localStorage.removeItem(ACCESS_TOKEN_KEY);
+      }
+      if (localRefresh && !cache[REFRESH_TOKEN_KEY]) {
+        await keychainSet(REFRESH_TOKEN_KEY, localRefresh);
+        cache[REFRESH_TOKEN_KEY] = localRefresh;
+        localStorage.removeItem(REFRESH_TOKEN_KEY);
+      }
+    }
+
+    initialized = true;
+  })();
+
+  return initPromise;
+}
+
+// ─── Access token ──────────────────────────────────────────────────────────────
+
 export function setAccessToken(token: string): void {
-  localStorage.setItem(ACCESS_TOKEN_KEY, token);
+  cache[ACCESS_TOKEN_KEY] = token;
+  keychainSet(ACCESS_TOKEN_KEY, token).catch(console.error);
 }
 
 export function getAccessToken(): string | null {
-  return localStorage.getItem(ACCESS_TOKEN_KEY);
+  if (!initialized && cache[ACCESS_TOKEN_KEY] === null) {
+    // Best-effort sync fallback before async init completes (e.g. first render)
+    const local = localStorage.getItem(ACCESS_TOKEN_KEY);
+    if (local) cache[ACCESS_TOKEN_KEY] = local;
+    initializeTokenStorage().catch(console.error);
+  }
+  return cache[ACCESS_TOKEN_KEY];
 }
 
 export function clearAccessToken(): void {
-  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  cache[ACCESS_TOKEN_KEY] = null;
+  keychainDelete(ACCESS_TOKEN_KEY).catch(console.error);
 }
 
+// ─── Refresh token ─────────────────────────────────────────────────────────────
+
 export function setRefreshToken(token: string): void {
-  localStorage.setItem(REFRESH_TOKEN_KEY, token);
+  cache[REFRESH_TOKEN_KEY] = token;
+  keychainSet(REFRESH_TOKEN_KEY, token).catch(console.error);
 }
 
 export function getRefreshToken(): string | null {
-  return localStorage.getItem(REFRESH_TOKEN_KEY);
+  if (!initialized && cache[REFRESH_TOKEN_KEY] === null) {
+    const local = localStorage.getItem(REFRESH_TOKEN_KEY);
+    if (local) cache[REFRESH_TOKEN_KEY] = local;
+    initializeTokenStorage().catch(console.error);
+  }
+  return cache[REFRESH_TOKEN_KEY];
 }
 
 export function clearRefreshToken(): void {
-  localStorage.removeItem(REFRESH_TOKEN_KEY);
+  cache[REFRESH_TOKEN_KEY] = null;
+  keychainDelete(REFRESH_TOKEN_KEY).catch(console.error);
 }
+
+// ─── Token expiry (not sensitive — stays in localStorage) ─────────────────────
 
 export function setTokenExpiresAt(expiresAt: number): void {
   localStorage.setItem(EXPIRES_AT_KEY, expiresAt.toString());
@@ -42,6 +207,8 @@ export function clearTokenExpiresAt(): void {
   localStorage.removeItem(EXPIRES_AT_KEY);
 }
 
+// ─── App endpoint (not sensitive — stays in localStorage) ─────────────────────
+
 export function getAppEndpointKey(): string | null {
   return localStorage.getItem(APP_ENDPOINT_KEY);
 }
@@ -53,6 +220,8 @@ export function setAppEndpointKey(endpoint: string): void {
 export function clearAppEndpointKey(): void {
   localStorage.removeItem(APP_ENDPOINT_KEY);
 }
+
+// ─── Bulk clear ────────────────────────────────────────────────────────────────
 
 /**
  * Clear all auth-related tokens

--- a/packages/mero-react/src/client/token-storage.ts
+++ b/packages/mero-react/src/client/token-storage.ts
@@ -156,9 +156,9 @@ export async function initializeTokenStorage(): Promise<void> {
 
 // ─── Access token ──────────────────────────────────────────────────────────────
 
-export function setAccessToken(token: string): void {
+export async function setAccessToken(token: string): Promise<void> {
   cache[ACCESS_TOKEN_KEY] = token;
-  keychainSet(ACCESS_TOKEN_KEY, token).catch(console.error);
+  await keychainSet(ACCESS_TOKEN_KEY, token).catch(console.error);
 }
 
 export function getAccessToken(): string | null {
@@ -171,16 +171,16 @@ export function getAccessToken(): string | null {
   return cache[ACCESS_TOKEN_KEY];
 }
 
-export function clearAccessToken(): void {
+export async function clearAccessToken(): Promise<void> {
   cache[ACCESS_TOKEN_KEY] = null;
-  keychainDelete(ACCESS_TOKEN_KEY).catch(console.error);
+  await keychainDelete(ACCESS_TOKEN_KEY).catch(console.error);
 }
 
 // ─── Refresh token ─────────────────────────────────────────────────────────────
 
-export function setRefreshToken(token: string): void {
+export async function setRefreshToken(token: string): Promise<void> {
   cache[REFRESH_TOKEN_KEY] = token;
-  keychainSet(REFRESH_TOKEN_KEY, token).catch(console.error);
+  await keychainSet(REFRESH_TOKEN_KEY, token).catch(console.error);
 }
 
 export function getRefreshToken(): string | null {
@@ -192,9 +192,9 @@ export function getRefreshToken(): string | null {
   return cache[REFRESH_TOKEN_KEY];
 }
 
-export function clearRefreshToken(): void {
+export async function clearRefreshToken(): Promise<void> {
   cache[REFRESH_TOKEN_KEY] = null;
-  keychainDelete(REFRESH_TOKEN_KEY).catch(console.error);
+  await keychainDelete(REFRESH_TOKEN_KEY).catch(console.error);
 }
 
 // ─── Token expiry (not sensitive — stays in localStorage) ─────────────────────
@@ -231,8 +231,7 @@ export function clearAppEndpointKey(): void {
 /**
  * Clear all auth-related tokens
  */
-export function clearAllTokens(): void {
-  clearAccessToken();
-  clearRefreshToken();
+export async function clearAllTokens(): Promise<void> {
+  await Promise.all([clearAccessToken(), clearRefreshToken()]);
   clearTokenExpiresAt();
 }

--- a/packages/mero-react/src/client/token-storage.ts
+++ b/packages/mero-react/src/client/token-storage.ts
@@ -59,16 +59,21 @@ function tauriInvoke<T>(cmd: string, args: Record<string, unknown> = {}): Promis
 
 // ─── Keychain primitives ───────────────────────────────────────────────────────
 
-async function keychainSet(key: string, value: string): Promise<void> {
+/**
+ * Returns true if the value was written to the keychain, false if it fell back
+ * to localStorage (Tauri not available or keychain write failed).
+ */
+async function keychainSet(key: string, value: string): Promise<boolean> {
   if (isTauriEnv()) {
     try {
       await tauriInvoke('secure_store_token', { key, value });
-      return;
+      return true;
     } catch (e) {
       console.warn('[TokenStorage] Keychain write failed, falling back to localStorage:', e);
     }
   }
   localStorage.setItem(key, value);
+  return false;
 }
 
 async function keychainGet(key: string): Promise<string | null> {
@@ -132,14 +137,14 @@ export async function initializeTokenStorage(): Promise<void> {
       const localAccess = localStorage.getItem(ACCESS_TOKEN_KEY);
       const localRefresh = localStorage.getItem(REFRESH_TOKEN_KEY);
       if (localAccess && !cache[ACCESS_TOKEN_KEY]) {
-        await keychainSet(ACCESS_TOKEN_KEY, localAccess);
+        const wroteToKeychain = await keychainSet(ACCESS_TOKEN_KEY, localAccess);
         cache[ACCESS_TOKEN_KEY] = localAccess;
-        localStorage.removeItem(ACCESS_TOKEN_KEY);
+        if (wroteToKeychain) localStorage.removeItem(ACCESS_TOKEN_KEY);
       }
       if (localRefresh && !cache[REFRESH_TOKEN_KEY]) {
-        await keychainSet(REFRESH_TOKEN_KEY, localRefresh);
+        const wroteToKeychain = await keychainSet(REFRESH_TOKEN_KEY, localRefresh);
         cache[REFRESH_TOKEN_KEY] = localRefresh;
-        localStorage.removeItem(REFRESH_TOKEN_KEY);
+        if (wroteToKeychain) localStorage.removeItem(REFRESH_TOKEN_KEY);
       }
     }
 

--- a/packages/mero-react/src/components/LoginView.tsx
+++ b/packages/mero-react/src/components/LoginView.tsx
@@ -93,8 +93,8 @@ export function LoginView({ onSuccess, onError, variant = 'light' }: LoginViewPr
 
       if (tokenResponse.data?.access_token && tokenResponse.data?.refresh_token) {
         // Store tokens using calimero-client compatible storage
-        setAccessToken(tokenResponse.data.access_token);
-        setRefreshToken(tokenResponse.data.refresh_token);
+        await setAccessToken(tokenResponse.data.access_token);
+        await setRefreshToken(tokenResponse.data.refresh_token);
         
         // Extract expiry from JWT (exp claim is in seconds)
         try {


### PR DESCRIPTION
# fix: secure token storage

## Description 
Cleanup of this [pr](https://github.com/calimero-network/tauri-app/pull/26)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication token persistence and initialization across both the Tauri backend and React client, with a one-time migration path and new async behavior that could affect login state on cold start or node switching. Keychain integration is platform-dependent, so failures/fallbacks need verification on macOS/Windows/Linux.
> 
> **Overview**
> Moves Calimero Desktop JWT persistence from plaintext `localStorage` to **OS keychain-backed storage** via new Tauri commands (`secure_store_token`, `secure_get_token`, `secure_delete_token`) using the Rust `keyring` crate.
> 
> Updates `@calimero-network/mero-react` token handling to use an **in-memory cache warmed from keychain** (`initializeTokenStorage`), performs a one-time migration from `localStorage` into the keychain, and updates the mero-js `TokenStorage` implementation plus client initialization ordering to avoid cold-start “missing token” regressions.
> 
> Adjusts login and node-switch flows to `await` token set/clear operations to match the new async secure storage behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f44abe4d216f124b9ba0b60f1315f8cfd2169e19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->