### PR TITLE
feat: add HA enable/disable APIs and TEE admission policy

### DIFF
--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -90,4 +90,106 @@ export async function getCloudSubscription(
   return res.json();
 }
 
+// ── HA (High Availability) via TEE Fleet Nodes ──
+
+export interface EnableHaResponse {
+  status: string;
+  context_id: string;
+}
+
+/**
+ * Enable HA for a context — requests TEE fleet nodes to join this
+ * namespace/group. Requires a paid plan.
+ */
+export async function enableHa(
+  idToken: string,
+  contextId: string,
+  groupId?: string,
+): Promise<EnableHaResponse | null> {
+  const res = await cloudFetch(`/api/cloud/ha/enable/${contextId}`, idToken, {
+    method: 'POST',
+    body: JSON.stringify(groupId ? { group_id: groupId } : {}),
+  });
+  if (!res.ok) {
+    const error = await res.json().catch(() => null);
+    if (res.status === 402) {
+      throw new Error(error?.detail?.message || 'Plan limit reached — upgrade to enable HA');
+    }
+    throw new Error(error?.detail || 'Failed to enable HA');
+  }
+  return res.json();
+}
+
+/**
+ * Disable HA for a context.
+ */
+export async function disableHa(
+  idToken: string,
+  contextId: string,
+): Promise<void> {
+  await cloudFetch(`/api/cloud/ha/disable/${contextId}`, idToken, {
+    method: 'POST',
+  });
+}
+
+// ── Local Node Admin API ──
+
+/**
+ * Set the TEE admission policy on a group via the local node's admin API.
+ * This must be called after enabling HA so that fleet TEE nodes can be
+ * admitted into the group's governance DAG.
+ */
+export async function setTeeAdmissionPolicy(
+  nodeUrl: string,
+  groupId: string,
+  options?: {
+    allowedMrtd?: string[];
+    acceptMock?: boolean;
+  },
+): Promise<void> {
+  const res = await fetch(
+    `${nodeUrl}/admin-api/groups/${groupId}/settings/tee-admission-policy`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        allowed_mrtd: options?.allowedMrtd ?? [],
+        allowed_rtmr0: [],
+        allowed_rtmr1: [],
+        allowed_rtmr2: [],
+        allowed_rtmr3: [],
+        allowed_tcb_statuses: [],
+        accept_mock: options?.acceptMock ?? false,
+      }),
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Failed to set TEE admission policy: ${text}`);
+  }
+}
+
+/**
+ * Enable HA end-to-end: sets TEE admission policy on the local node,
+ * then registers the HA request with the cloud.
+ */
+export async function enableHaForNamespace(
+  idToken: string,
+  nodeUrl: string,
+  contextId: string,
+  groupId: string,
+  options?: {
+    allowedMrtd?: string[];
+    acceptMock?: boolean;
+  },
+): Promise<EnableHaResponse | null> {
+  // 1. Set TEE admission policy on the local node so fleet nodes
+  //    can be admitted when they present valid attestations.
+  await setTeeAdmissionPolicy(nodeUrl, groupId, options);
+
+  // 2. Register HA request with the cloud — fleet nodes will poll
+  //    should-join and get assigned to this group.
+  return enableHa(idToken, contextId, groupId);
+}
+
 export { CloudSessionExpiredError };


### PR DESCRIPTION
## Summary

Adds the API layer for enabling TEE High Availability on namespaces. Based on `feat/cloud-integration` (PR #52).

### New functions in `cloudApi.ts`:

| Function | What it does |
|---|---|
| `enableHa(idToken, contextId, groupId?)` | Register HA request with cloud — TEE fleet nodes will poll and join |
| `disableHa(idToken, contextId)` | Disable HA for a context |
| `setTeeAdmissionPolicy(nodeUrl, groupId, options?)` | Set TEE admission policy on the local node via admin API |
| `enableHaForNamespace(idToken, nodeUrl, contextId, groupId, options?)` | End-to-end: set admission policy + register with cloud |

### The flow:

```
enableHaForNamespace()
  ├── 1. PUT /admin-api/groups/{groupId}/settings/tee-admission-policy
  │     └── Sets which TEE measurements are allowed (MRTD, etc.)
  └── 2. POST /api/cloud/ha/enable/{contextId}
        └── Cloud creates HaRequest → fleet nodes poll should-join → fleet-join → admitted
```

### What's NOT in this PR:
- UI button (needs to be added to Namespaces page after branch reconciliation with master)
- MRTD allowlist population (currently empty = accept all; should be populated from cloud-managed list)

### Dependencies:
- PR #52 (cloud login) must merge first
- mdma PR #42 (callback URL support)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new client-side flows that modify HA state and TEE admission policy via remote calls; failures or misconfiguration could affect node governance/availability, though changes are isolated to new utility functions.
> 
> **Overview**
> Adds a new HA API layer in `cloudApi.ts` to **enable/disable High Availability** for a cloud `context` (`POST /api/cloud/ha/enable|disable/...`) with explicit handling for plan-limit errors (HTTP 402).
> 
> Also adds local-node admin API support to **set a group’s TEE admission policy** (`PUT /admin-api/groups/{groupId}/settings/tee-admission-policy`) and an `enableHaForNamespace` helper that performs the end-to-end flow (set policy first, then register HA with the cloud).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8e2cec4db9d2c7c4106335e501589b2258d600a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->