### PR TITLE
fix(cloud): apply TEE admission policy only on namespace root

### DIFF
--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -279,14 +279,16 @@ export async function setTeeAdmissionPolicy(
 }
 
 /**
- * Enable HA end-to-end for every group in a namespace:
- * 1. Fetch fleet measurements from cloud once (trusted MRTD values)
- * 2. Set TEE admission policy on the local node for each group
- * 3. Register the whole namespace with cloud in one bulk call
- *
- * Caller supplies the list of groups; the tauri app uses mero-react's
- * `mero.admin.listNamespaceGroups` + `listGroupContexts` to enumerate
- * them before calling this.
+ * Enable HA end-to-end for a namespace:
+ * 1. Fetch fleet measurements from cloud once (trusted MRTD values).
+ * 2. Set the TEE admission policy on the *namespace root only*. Subgroup
+ *    policies are ignored by core (namespace-scoped since rc.29 /
+ *    calimero-network/core#2188) — applying them would error. Auto-follow
+ *    propagates fleet-node membership into subgroups without a second
+ *    admission check.
+ * 3. Register the namespace with cloud. MDMA still needs the full group
+ *    list for billing + per-group status rows until the server-side
+ *    flattening lands, so the caller keeps enumerating groups.
  */
 export async function enableHaForNamespace(
   idToken: string,
@@ -303,11 +305,9 @@ export async function enableHaForNamespace(
     throw new Error('No fleet MRTD measurements available — cannot set admission policy');
   }
 
-  // Apply local admission policy per group. If any fails we abort; the
-  // user can retry after fixing whatever is wrong on the local node.
-  for (const g of groups) {
-    await setTeeAdmissionPolicy(nodeUrl, g.group_id, measurements.allowed_mrtd);
-  }
+  // The namespace root's group_id equals the namespaceId. Set the policy
+  // there and only there — subgroups inherit it via resolve-to-root.
+  await setTeeAdmissionPolicy(nodeUrl, namespaceId, measurements.allowed_mrtd);
 
   return enableHaNamespace(idToken, namespaceId, groups);
 }


### PR DESCRIPTION
## Summary
`enableHaForNamespace` was calling `setTeeAdmissionPolicy` once per group (root + every subgroup). Switch to one call on the namespace root.

## Why
Auto-follow propagates fleet-node membership into subgroups without a second admission check, so per-subgroup TEE policies were always inert. Core merod rc.29 (calimero-network/core#2188) makes the scope explicit — the write handler now refuses `TeeAdmissionPolicySet` on subgroups. Our old loop would start failing subgroup writes against rc.29+.

## Compatibility
Backward-compatible against older merod: setting only the root's policy is valid on any version. This PR is purely a future-compat fix — no regression risk pre-rc.29.

## What's unchanged (intentional)
- `enableHaNamespace` still sends the full `groups` array to MDMA — the server-side HaRequest flattening is tracked as a follow-up in the mdma repo. No desktop change needed when that lands; MDMA keeps the old body shape for one release.
- `setTeeAdmissionPolicy` itself is untouched — only its caller.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Manual: enable HA on a namespace with ≥1 subgroup against a rc.29 merod; verify (a) no errors, (b) exactly one `PUT /admin-api/groups/{namespace_id}/settings/tee-admission-policy` request, (c) fleet-join on a ReadOnlyTee node completes and auto-follows into subgroups.
- [ ] Manual: same flow against a pre-rc.29 merod — should also succeed with just one policy set.

## Release coordination
Merges cleanly standalone, but the operational intent is to land this in the same release window as core rc.29. Pre-rc.29, no user impact. Post-rc.29, required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new Cloud OAuth/deep-link callback flow and stores Google ID tokens in app settings, plus new Cloud API calls that modify HA/TEE admission behavior; these are security- and reliability-sensitive paths across OS integration and backend coordination.
> 
> **Overview**
> Introduces **Calimero Cloud connectivity** to the desktop app: a new `Cloud` settings tab and an optional onboarding step start a Google sign-in flow, persist the resulting ID token/user info in settings, and fetch/display the user’s subscription plan.
> 
> Adds **deep-link handling** (`calimero://…`) via `tauri-plugin-deep-link` (plus macOS URL scheme registration) to receive cloud auth callbacks for both cold- and hot-launch cases, exposing new Tauri commands/events (`get/clear_pending_cloud_auth`, `cloud-auth-callback`).
> 
> Enables **High Availability (TEE replication) toggling per namespace** from the Namespaces UI by calling new Cloud APIs; HA enable now sets the TEE admission policy **only on the namespace root group** before registering HA for all groups in the namespace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bfc644ad92e1f5d406276431826baab451a96e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->