### PR TITLE
feat(cloud): migrate desktop app to MDMA session tokens

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -17,6 +17,8 @@
     "tauri:build:full": "pnpm merod:prepare && tauri build",
     "icon": "node scripts/svg-to-icon.js && pnpm tauri icon src-tauri/icons/icon-1024.png",
     "clean": "rm -rf dist src-tauri/target",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:install": "playwright install chromium"
@@ -41,6 +43,7 @@
     "sharp": "^0.34.5",
     "tar": "^7.5.13",
     "typescript": "^5.8.3",
-    "vite": "^4.1.0"
+    "vite": "^4.1.0",
+    "vitest": "^0.34.6"
   }
 }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.5", features = [ "http-all", "system-tray", "updater", "process-relaunch", "shell-open", "window-all", "dialog-all", "icon-png"] }
+tauri = { version = "1.5", features = [ "system-tray", "updater", "process-relaunch", "shell-open", "window-all", "dialog-all", "icon-png"] }
 tauri-plugin-autostart = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -2,8 +2,9 @@ import { getAccessToken } from '../lib/token-storage';
 import { getSettings, saveSettings } from './settings';
 
 // API lives at manager.cloud.calimero.network; cloud.calimero.network is
-// the static portal and does not proxy /api/*.
-const CLOUD_BASE_URL = 'https://manager.cloud.calimero.network';
+// the static portal and does not proxy /api/*. Exported so cloudAuth
+// can reuse it — we don't want two independent constants drifting.
+export const CLOUD_BASE_URL = 'https://manager.cloud.calimero.network';
 const MDMA_SESSION_REFRESH_HEADER = 'X-MDMA-Session-Refresh';
 
 export interface CloudNode {

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -1,8 +1,10 @@
 import { getAccessToken } from '../lib/token-storage';
+import { getSettings, saveSettings } from './settings';
 
 // API lives at manager.cloud.calimero.network; cloud.calimero.network is
 // the static portal and does not proxy /api/*.
 const CLOUD_BASE_URL = 'https://manager.cloud.calimero.network';
+const MDMA_SESSION_REFRESH_HEADER = 'X-MDMA-Session-Refresh';
 
 export interface CloudNode {
   name: string;
@@ -37,6 +39,24 @@ async function cloudFetch(
       ...options?.headers,
     },
   });
+
+  // Rolling refresh: the server re-issued our session silently because
+  // this one was past the refresh threshold. Persist the new token
+  // directly to settings — next call reads from settings.cloudIdToken
+  // and picks it up. We intentionally don't propagate via React state
+  // or events: same sid = same logical session, so there's nothing
+  // UI-level to re-derive, and routing refresh through render would
+  // re-fire every useEffect that depends on the token.
+  const refreshed = res.headers.get(MDMA_SESSION_REFRESH_HEADER);
+  if (refreshed) {
+    const settings = getSettings();
+    // Only update if the session we just used is still the active one;
+    // avoids clobbering a fresh login that landed between the request
+    // leaving and the response arriving.
+    if (settings.cloudIdToken === idToken) {
+      saveSettings({ ...settings, cloudIdToken: refreshed });
+    }
+  }
 
   if (res.status === 401) {
     throw new CloudSessionExpiredError();

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -1,6 +1,6 @@
 import { getAccessToken } from '../lib/token-storage';
 import { getSettings, saveSettings } from './settings';
-import { isMdmaSessionToken } from './jwt';
+import { isMdmaSessionToken, isTokenExpired } from './jwt';
 
 // API lives at manager.cloud.calimero.network; cloud.calimero.network is
 // the static portal and does not proxy /api/*. Exported so cloudAuth
@@ -42,6 +42,10 @@ async function cloudFetch(
     },
   });
 
+  if (res.status === 401) {
+    throw new CloudSessionExpiredError();
+  }
+
   // Rolling refresh: the server re-issued our session silently because
   // this one was past the refresh threshold. Persist the new token
   // directly to settings — next call reads from settings.cloudIdToken
@@ -49,13 +53,24 @@ async function cloudFetch(
   // or events: same sid = same logical session, so there's nothing
   // UI-level to re-derive, and routing refresh through render would
   // re-fire every useEffect that depends on the token.
+  //
+  // Only honoured on a successful response. A refresh header attached
+  // to a 4xx/5xx response is suspicious (either a misbehaving server
+  // or a header-injecting MITM trying to plant a token on us during a
+  // failure path) — the 401 branch above already threw, but the same
+  // logic applies to other non-ok statuses. Drop silently.
+  if (!res.ok) {
+    return res;
+  }
+
+  // Validate the header value before persisting it. An MDMA-issued
+  // JWT that is not yet expired is the only shape we should ever
+  // write to settings.cloudIdToken via this path; anything else
+  // (wrong issuer, malformed, already-expired) we silently drop and
+  // keep the current token, which the caller will detect as expired
+  // via isTokenExpired on the next request.
   const refreshed = res.headers.get(MDMA_SESSION_REFRESH_HEADER);
-  // Validate the header value before persisting it — a compromised or
-  // misbehaving server (or header-injecting MITM) could otherwise
-  // plant arbitrary strings as our session token. An MDMA-issued JWT
-  // is the only shape we should ever write to settings.cloudIdToken
-  // via this path; anything else we silently drop.
-  if (refreshed && isMdmaSessionToken(refreshed)) {
+  if (refreshed && isMdmaSessionToken(refreshed) && !isTokenExpired(refreshed)) {
     const settings = getSettings();
     // Only update if the session we just used is still the active one;
     // avoids clobbering a fresh login that landed between the request
@@ -63,10 +78,6 @@ async function cloudFetch(
     if (settings.cloudIdToken === idToken) {
       saveSettings({ ...settings, cloudIdToken: refreshed });
     }
-  }
-
-  if (res.status === 401) {
-    throw new CloudSessionExpiredError();
   }
 
   return res;
@@ -266,13 +277,21 @@ export async function setTeeAdmissionPolicy(
         Authorization: `Bearer ${accessToken}`,
       },
       body: JSON.stringify({
-        allowed_mrtd: allowedMrtd ?? [],
-        allowed_rtmr0: [],
-        allowed_rtmr1: [],
-        allowed_rtmr2: [],
-        allowed_rtmr3: [],
-        allowed_tcb_statuses: [],
-        accept_mock: false,
+        // The merod admin API deserialises this request with
+        // `#[serde(rename_all = "camelCase")]` (see
+        // SetTeeAdmissionPolicyApiRequest in
+        // calimero-network/core: crates/server/primitives/src/admin/mod.rs).
+        // Snake_case keys are silently ignored as unknown fields and every
+        // field falls through to its #[serde(default)] — so the server sees
+        // allowed_mrtd: [] and accept_mock: false, and validation rejects
+        // with a misleading "at least one MRTD must be specified" error.
+        allowedMrtd: allowedMrtd ?? [],
+        allowedRtmr0: [],
+        allowedRtmr1: [],
+        allowedRtmr2: [],
+        allowedRtmr3: [],
+        allowedTcbStatuses: [],
+        acceptMock: false,
       }),
     },
   );

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -1,5 +1,6 @@
 import { getAccessToken } from '../lib/token-storage';
 import { getSettings, saveSettings } from './settings';
+import { isMdmaSessionToken } from './jwt';
 
 // API lives at manager.cloud.calimero.network; cloud.calimero.network is
 // the static portal and does not proxy /api/*. Exported so cloudAuth
@@ -49,7 +50,12 @@ async function cloudFetch(
   // UI-level to re-derive, and routing refresh through render would
   // re-fire every useEffect that depends on the token.
   const refreshed = res.headers.get(MDMA_SESSION_REFRESH_HEADER);
-  if (refreshed) {
+  // Validate the header value before persisting it — a compromised or
+  // misbehaving server (or header-injecting MITM) could otherwise
+  // plant arbitrary strings as our session token. An MDMA-issued JWT
+  // is the only shape we should ever write to settings.cloudIdToken
+  // via this path; anything else we silently drop.
+  if (refreshed && isMdmaSessionToken(refreshed)) {
     const settings = getSettings();
     // Only update if the session we just used is still the active one;
     // avoids clobbering a fresh login that landed between the request

--- a/apps/desktop/src/utils/cloudAuth.ts
+++ b/apps/desktop/src/utils/cloudAuth.ts
@@ -1,10 +1,9 @@
 import { invoke } from '@tauri-apps/api';
 import { listen } from '@tauri-apps/api/event';
 import { getSettings, saveSettings } from './settings';
-import { getCloudNode } from './cloudApi';
+import { CLOUD_BASE_URL, getCloudNode } from './cloudApi';
 
 const CLOUD_LOGIN_URL = 'https://cloud.calimero.network';
-const CLOUD_API_BASE = 'https://manager.cloud.calimero.network';
 const CLOUD_CALLBACK_SCHEME = 'calimero://cloud-callback';
 const LOGIN_POLL_INTERVAL_MS = 1500;
 const LOGIN_TIMEOUT_MS = 120_000; // 2 minutes
@@ -146,7 +145,7 @@ async function exchangeGoogleForMdmaSession(
   googleIdToken: string,
 ): Promise<MdmaSessionResponse | null> {
   try {
-    const res = await fetch(`${CLOUD_API_BASE}/api/auth/google`, {
+    const res = await fetch(`${CLOUD_BASE_URL}/api/auth/google`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id_token: googleIdToken }),
@@ -170,7 +169,7 @@ async function exchangeGoogleForMdmaSession(
  */
 export function revokeMdmaSession(sessionToken: string | undefined | null): void {
   if (!sessionToken || !isMdmaSessionToken(sessionToken)) return;
-  fetch(`${CLOUD_API_BASE}/api/auth/logout`, {
+  fetch(`${CLOUD_BASE_URL}/api/auth/logout`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${sessionToken}` },
   }).catch(() => {});

--- a/apps/desktop/src/utils/cloudAuth.ts
+++ b/apps/desktop/src/utils/cloudAuth.ts
@@ -2,6 +2,9 @@ import { invoke } from '@tauri-apps/api';
 import { listen } from '@tauri-apps/api/event';
 import { getSettings, saveSettings } from './settings';
 import { CLOUD_BASE_URL, getCloudNode } from './cloudApi';
+import { parseJwtPayload, isMdmaSessionToken, isTokenExpired } from './jwt';
+
+export { isMdmaSessionToken, isTokenExpired };
 
 const CLOUD_LOGIN_URL = 'https://cloud.calimero.network';
 const CLOUD_CALLBACK_SCHEME = 'calimero://cloud-callback';
@@ -88,36 +91,13 @@ export interface CloudUserInfo {
  * No signature verification — the Cloud API server handles that.
  */
 export function decodeIdToken(token: string): CloudUserInfo | null {
-  try {
-    const parts = token.split('.');
-    if (parts.length !== 3) return null;
-    const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
-    return {
-      email: payload.email ?? '',
-      name: payload.name ?? '',
-      picture: payload.picture ?? '',
-    };
-  } catch {
-    return null;
-  }
-}
-
-/**
- * `true` if the token was issued by MDMA (iss claim = "mdma"). MDMA
- * sessions have 7-day TTL with rolling refresh; raw Google tokens
- * expire after ~1 hour. Used to tell a pre-migration Google token
- * apart from a migrated session.
- */
-export function isMdmaSessionToken(token: string | undefined | null): boolean {
-  if (!token || typeof token !== 'string') return false;
-  const parts = token.split('.');
-  if (parts.length !== 3) return false;
-  try {
-    const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
-    return payload?.iss === 'mdma';
-  } catch {
-    return false;
-  }
+  const payload = parseJwtPayload(token);
+  if (!payload) return null;
+  return {
+    email: typeof payload.email === 'string' ? payload.email : '',
+    name: typeof payload.name === 'string' ? payload.name : '',
+    picture: typeof payload.picture === 'string' ? payload.picture : '',
+  };
 }
 
 interface MdmaSessionResponse {
@@ -151,7 +131,21 @@ async function exchangeGoogleForMdmaSession(
       body: JSON.stringify({ id_token: googleIdToken }),
     });
     if (!res.ok) return null;
-    return (await res.json()) as MdmaSessionResponse;
+    const body = (await res.json()) as unknown;
+    // Validate the shape before trusting the cast. A 200 with an
+    // unexpected body (deployment mid-rollout, bad proxy) would
+    // otherwise fall through as `{ session_token: undefined }` and
+    // the nullish-coalesce in startCloudLogin would silently re-use
+    // the raw Google token — masking a server regression.
+    if (
+      !body ||
+      typeof body !== 'object' ||
+      typeof (body as { session_token?: unknown }).session_token !== 'string' ||
+      !(body as { session_token: string }).session_token
+    ) {
+      return null;
+    }
+    return body as MdmaSessionResponse;
   } catch {
     return null;
   }
@@ -172,24 +166,13 @@ export function revokeMdmaSession(sessionToken: string | undefined | null): void
   fetch(`${CLOUD_BASE_URL}/api/auth/logout`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${sessionToken}` },
-  }).catch(() => {});
-}
-
-/**
- * Check if a token (Google ID token or MDMA session JWT) has expired.
- * Both carry an `exp` claim in seconds since the epoch, so one parser
- * handles both.
- */
-export function isTokenExpired(token: string): boolean {
-  try {
-    const parts = token.split('.');
-    if (parts.length !== 3) return true;
-    const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
-    if (!payload.exp) return true;
-    return Date.now() >= payload.exp * 1000;
-  } catch {
-    return true;
-  }
+  }).catch((err) => {
+    // Best-effort: we don't block logout on this. But a persistent
+    // failure (wrong URL, TLS issue, endpoint 500) leaves sessions
+    // unrevoked server-side — log so the dev console surfaces it
+    // rather than the failure being completely invisible.
+    console.warn('MDMA session revocation failed (best-effort):', err);
+  });
 }
 
 /**

--- a/apps/desktop/src/utils/cloudAuth.ts
+++ b/apps/desktop/src/utils/cloudAuth.ts
@@ -4,6 +4,7 @@ import { getSettings, saveSettings } from './settings';
 import { getCloudNode } from './cloudApi';
 
 const CLOUD_LOGIN_URL = 'https://cloud.calimero.network';
+const CLOUD_API_BASE = 'https://manager.cloud.calimero.network';
 const CLOUD_CALLBACK_SCHEME = 'calimero://cloud-callback';
 const LOGIN_POLL_INTERVAL_MS = 1500;
 const LOGIN_TIMEOUT_MS = 120_000; // 2 minutes
@@ -103,7 +104,82 @@ export function decodeIdToken(token: string): CloudUserInfo | null {
 }
 
 /**
- * Check if a Google ID token has expired.
+ * `true` if the token was issued by MDMA (iss claim = "mdma"). MDMA
+ * sessions have 7-day TTL with rolling refresh; raw Google tokens
+ * expire after ~1 hour. Used to tell a pre-migration Google token
+ * apart from a migrated session.
+ */
+export function isMdmaSessionToken(token: string | undefined | null): boolean {
+  if (!token || typeof token !== 'string') return false;
+  const parts = token.split('.');
+  if (parts.length !== 3) return false;
+  try {
+    const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
+    return payload?.iss === 'mdma';
+  } catch {
+    return false;
+  }
+}
+
+interface MdmaSessionResponse {
+  session_token: string;
+  expires_at: number;
+  user: CloudUserInfo;
+}
+
+/**
+ * Exchange a Google OAuth ID token for an MDMA session token.
+ * Called once after the OAuth deep-link callback returns a Google
+ * credential. The resulting session token is what gets persisted in
+ * `settings.cloudIdToken` and used for every subsequent cloud API
+ * call — MDMA session tokens live for 7 days and are silently rolled
+ * forward by the server (see `cloudFetch`), so the user no longer
+ * has to re-authenticate every hour.
+ *
+ * Returns `null` if the exchange fails for any reason; callers should
+ * fall back to using the raw Google token during the backend's
+ * migration window (`_verify_session_or_google` still accepts Google
+ * tokens). Once the fallback is removed, the exchange becoming
+ * mandatory will surface as a login failure at the call site.
+ */
+async function exchangeGoogleForMdmaSession(
+  googleIdToken: string,
+): Promise<MdmaSessionResponse | null> {
+  try {
+    const res = await fetch(`${CLOUD_API_BASE}/api/auth/google`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id_token: googleIdToken }),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as MdmaSessionResponse;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fire-and-forget server-side session revocation. Adds the session's
+ * sid to the RevokedSession table so the same token can't be
+ * refreshed or re-used. No await / no error surfacing — the caller
+ * has already cleared local state and the worst case is a
+ * short-lived token staying usable until its exp.
+ *
+ * Safe to call with a Google token or undefined; non-MDMA tokens
+ * short-circuit without hitting the network.
+ */
+export function revokeMdmaSession(sessionToken: string | undefined | null): void {
+  if (!sessionToken || !isMdmaSessionToken(sessionToken)) return;
+  fetch(`${CLOUD_API_BASE}/api/auth/logout`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${sessionToken}` },
+  }).catch(() => {});
+}
+
+/**
+ * Check if a token (Google ID token or MDMA session JWT) has expired.
+ * Both carry an `exp` claim in seconds since the epoch, so one parser
+ * handles both.
  */
 export function isTokenExpired(token: string): boolean {
   try {
@@ -137,11 +213,20 @@ export async function startCloudLogin(): Promise<CloudUserInfo | null> {
   await invoke('open_url_in_browser', { url: loginUrl });
 
   // Poll for the deep link callback
-  const token = await pollForCloudAuth();
-  if (!token) return null;
+  const googleToken = await pollForCloudAuth();
+  if (!googleToken) return null;
 
-  // Decode user info from token
-  const userInfo = decodeIdToken(token);
+  // Exchange the Google credential for a 7-day MDMA session. The
+  // session token is what gets persisted and used for every cloud API
+  // call — the Google token is one-shot. If the exchange fails
+  // (server temporarily unavailable, network blip) we fall back to
+  // the raw Google token; the backend's migration-window middleware
+  // still accepts Google tokens, so the user is not blocked. The
+  // fallback expires in ~1 hour and the user will re-auth at that
+  // point.
+  const exchange = await exchangeGoogleForMdmaSession(googleToken);
+  const token = exchange?.session_token ?? googleToken;
+  const userInfo = exchange?.user ?? decodeIdToken(googleToken);
   if (!userInfo) return null;
 
   // Auto-register by fetching cloud node (creates account on first call)
@@ -233,11 +318,16 @@ function extractTokenFromCallbackUrl(url: string): string | null {
 }
 
 /**
- * Disconnect from Calimero Cloud. Clears all cloud state from settings.
+ * Disconnect from Calimero Cloud. Clears all cloud state from settings
+ * and fires a best-effort server-side session revocation so the same
+ * sid can't be replayed.
  */
 export function disconnectCloud(): void {
   clearPendingState();
   const settings = getSettings();
+  // Revoke before clearing: once settings.cloudIdToken is undefined,
+  // we can't address the session on the server any more.
+  revokeMdmaSession(settings.cloudIdToken);
   saveSettings({
     ...settings,
     cloudConnected: false,

--- a/apps/desktop/src/utils/cloudAuth.ts
+++ b/apps/desktop/src/utils/cloudAuth.ts
@@ -145,6 +145,17 @@ async function exchangeGoogleForMdmaSession(
     ) {
       return null;
     }
+    // Belt-and-suspenders: confirm what we got back is actually an
+    // MDMA-issued JWT. A misconfigured backend (or a bug in the
+    // exchange handler) could return a 200 with a session_token that
+    // is a non-JWT string, a JWT with the wrong issuer, or even our
+    // own Google token echoed back — none of which should be allowed
+    // to land in settings.cloudIdToken. isMdmaSessionToken returns
+    // false on all of those so we reject and surface as a login
+    // failure at the call site.
+    if (!isMdmaSessionToken((body as { session_token: string }).session_token)) {
+      return null;
+    }
     return body as MdmaSessionResponse;
   } catch {
     return null;

--- a/apps/desktop/src/utils/jwt.test.ts
+++ b/apps/desktop/src/utils/jwt.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { parseJwtPayload, isMdmaSessionToken, isTokenExpired } from "./jwt";
+
+function base64url(s: string): string {
+  return btoa(s).replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+function makeJwt(payload: object): string {
+  const header = base64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const body = base64url(JSON.stringify(payload));
+  return `${header}.${body}.signature`;
+}
+
+describe("parseJwtPayload", () => {
+  it("returns null for null, undefined, empty, or non-string input", () => {
+    expect(parseJwtPayload(null)).toBeNull();
+    expect(parseJwtPayload(undefined)).toBeNull();
+    expect(parseJwtPayload("")).toBeNull();
+    expect(parseJwtPayload(123 as unknown as string)).toBeNull();
+  });
+
+  it("returns null when the JWT does not have three segments", () => {
+    expect(parseJwtPayload("no-dots")).toBeNull();
+    expect(parseJwtPayload("a.b")).toBeNull();
+    expect(parseJwtPayload("a.b.c.d")).toBeNull();
+  });
+
+  it("returns null when the payload segment is not valid base64", () => {
+    expect(parseJwtPayload("header.@@@.signature")).toBeNull();
+  });
+
+  it("returns null when the decoded JSON is the literal null", () => {
+    const nullPayload = `header.${base64url("null")}.sig`;
+    expect(parseJwtPayload(nullPayload)).toBeNull();
+  });
+
+  it("decodes a standard MDMA session token correctly", () => {
+    const jwt = makeJwt({ iss: "mdma", sub: "user-1", exp: 9999999999 });
+    expect(parseJwtPayload(jwt)).toEqual({
+      iss: "mdma",
+      sub: "user-1",
+      exp: 9999999999,
+    });
+  });
+
+  it("handles URL-safe base64 (- and _) in the payload — Google ID token shape", () => {
+    const payload = { iss: "https://accounts.google.com", note: "???" };
+    const jwt = makeJwt(payload);
+    expect(jwt).toMatch(/[-_]/);
+    expect(parseJwtPayload(jwt)).toEqual(payload);
+  });
+
+  it("handles different unpadded base64 lengths (padding restoration)", () => {
+    expect(parseJwtPayload(makeJwt({}))).toEqual({});
+    expect(parseJwtPayload(makeJwt({ a: 1 }))).toEqual({ a: 1 });
+    expect(parseJwtPayload(makeJwt({ ab: 12 }))).toEqual({ ab: 12 });
+  });
+});
+
+describe("isMdmaSessionToken", () => {
+  it("returns true when iss is 'mdma'", () => {
+    expect(isMdmaSessionToken(makeJwt({ iss: "mdma" }))).toBe(true);
+  });
+
+  it("returns false for Google ID tokens (iss !== 'mdma')", () => {
+    expect(isMdmaSessionToken(makeJwt({ iss: "https://accounts.google.com" }))).toBe(false);
+  });
+
+  it("returns false when iss is missing", () => {
+    expect(isMdmaSessionToken(makeJwt({ sub: "user" }))).toBe(false);
+  });
+
+  it("returns false for null or malformed input", () => {
+    expect(isMdmaSessionToken(null)).toBe(false);
+    expect(isMdmaSessionToken("garbage")).toBe(false);
+    expect(isMdmaSessionToken("")).toBe(false);
+  });
+});
+
+describe("isTokenExpired", () => {
+  it("treats missing exp as expired", () => {
+    expect(isTokenExpired(makeJwt({ iss: "mdma" }))).toBe(true);
+  });
+
+  it("treats non-numeric exp as expired", () => {
+    expect(isTokenExpired(makeJwt({ exp: "never" }))).toBe(true);
+  });
+
+  it("returns true when exp is in the past", () => {
+    const yesterday = Math.floor(Date.now() / 1000) - 86400;
+    expect(isTokenExpired(makeJwt({ exp: yesterday }))).toBe(true);
+  });
+
+  it("returns false when exp is in the future", () => {
+    const tomorrow = Math.floor(Date.now() / 1000) + 86400;
+    expect(isTokenExpired(makeJwt({ exp: tomorrow }))).toBe(false);
+  });
+
+  it("treats null or malformed input as expired", () => {
+    expect(isTokenExpired(null)).toBe(true);
+    expect(isTokenExpired("garbage")).toBe(true);
+  });
+});

--- a/apps/desktop/src/utils/jwt.test.ts
+++ b/apps/desktop/src/utils/jwt.test.ts
@@ -5,9 +5,18 @@ function base64url(s: string): string {
   return btoa(s).replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
 }
 
+// UTF-8-aware base64url for payloads containing non-ASCII characters.
+// `btoa` only accepts Latin-1, so we have to encode to bytes first.
+function utf8Base64url(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary).replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
 function makeJwt(payload: object): string {
   const header = base64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
-  const body = base64url(JSON.stringify(payload));
+  const body = utf8Base64url(JSON.stringify(payload));
   return `${header}.${body}.signature`;
 }
 
@@ -32,6 +41,19 @@ describe("parseJwtPayload", () => {
   it("returns null when the decoded JSON is the literal null", () => {
     const nullPayload = `header.${base64url("null")}.sig`;
     expect(parseJwtPayload(nullPayload)).toBeNull();
+  });
+
+  it("returns null when the decoded JSON is an array (not a claim set)", () => {
+    const arrayPayload = `header.${base64url(JSON.stringify(["a", "b"]))}.sig`;
+    expect(parseJwtPayload(arrayPayload)).toBeNull();
+  });
+
+  it("decodes non-ASCII claim values via TextDecoder (UTF-8 round-trip)", () => {
+    // Realistic Google ID token shape: 'name' often contains accented or
+    // non-Latin chars. atob alone misdecodes these as garbled Latin-1.
+    const payload = { iss: "mdma", name: "Xabi Losada — éñü 日本語" };
+    const jwt = makeJwt(payload);
+    expect(parseJwtPayload(jwt)).toEqual(payload);
   });
 
   it("decodes a standard MDMA session token correctly", () => {

--- a/apps/desktop/src/utils/jwt.ts
+++ b/apps/desktop/src/utils/jwt.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared JWT payload decoding helpers. Used by the cloud auth flow
+ * (Google ID tokens and MDMA session tokens are both JWTs) and by the
+ * cloud API client (validates rolling-refresh header values before
+ * persisting them). Factored out so neither caller has to re-inline
+ * the base64url-decode-then-parse preamble — a bug in one copy is the
+ * kind of thing that stays uncaught for a while.
+ *
+ * No signature verification anywhere — the manager backend is the
+ * source of truth. These helpers only read claims.
+ */
+
+/** Decode the payload segment of a JWT. Returns `null` on any
+ * malformed input so callers can default without a try/catch. */
+export function parseJwtPayload(token: string | undefined | null): Record<string, unknown> | null {
+  if (!token || typeof token !== 'string') return null;
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+    const decoded = JSON.parse(atob(padded));
+    if (!decoded || typeof decoded !== 'object') return null;
+    return decoded as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `true` if the token was issued by MDMA (iss claim = "mdma"). MDMA
+ * sessions have 7-day TTL with rolling refresh; raw Google tokens
+ * expire after ~1 hour.
+ */
+export function isMdmaSessionToken(token: string | undefined | null): boolean {
+  const payload = parseJwtPayload(token);
+  return payload?.iss === 'mdma';
+}
+
+/**
+ * Check if a JWT (Google ID token or MDMA session) has expired. Both
+ * carry an `exp` claim in seconds since the epoch. Missing/invalid
+ * `exp` is treated as expired rather than trusted — callers almost
+ * always want to route to the re-auth path on ambiguity.
+ */
+export function isTokenExpired(token: string | undefined | null): boolean {
+  const payload = parseJwtPayload(token);
+  if (!payload) return true;
+  const exp = payload.exp;
+  if (typeof exp !== 'number') return true;
+  return Date.now() >= exp * 1000;
+}

--- a/apps/desktop/src/utils/jwt.ts
+++ b/apps/desktop/src/utils/jwt.ts
@@ -19,8 +19,22 @@ export function parseJwtPayload(token: string | undefined | null): Record<string
   try {
     const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
     const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
-    const decoded = JSON.parse(atob(padded));
-    if (!decoded || typeof decoded !== 'object') return null;
+    // atob returns a binary string (one char per byte). The payload is
+    // UTF-8, so non-ASCII claims (e.g., a `name` with é/ü/CJK) would
+    // misdecode if we JSON.parse(atob(...)) directly — each multi-byte
+    // sequence ends up as garbled characters. Round through Uint8Array
+    // + TextDecoder so the JSON parser sees real UTF-8.
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    const decoded = JSON.parse(new TextDecoder().decode(bytes));
+    // Reject anything that isn't a JSON object — JWT payloads are
+    // RFC-defined as a JSON object. Arrays pass `typeof === 'object'`
+    // but aren't a sensible claim set; null is caught by the truthy
+    // guard. Reject both so callers can rely on `Record<string, unknown>`.
+    if (!decoded || typeof decoded !== 'object' || Array.isArray(decoded)) {
+      return null;
+    }
     return decoded as Record<string, unknown>;
   } catch {
     return null;

--- a/apps/desktop/src/utils/settings.ts
+++ b/apps/desktop/src/utils/settings.ts
@@ -10,7 +10,7 @@ export interface AppSettings {
   debugLogs?: boolean; // Enable debug-level logging for the merod node
   onboardingCompleted?: boolean; // True once user has completed first-time setup - never show onboarding again
   cloudConnected?: boolean; // Whether user is connected to Calimero Cloud
-  cloudIdToken?: string; // Google ID token for Cloud API auth
+  cloudIdToken?: string; // MDMA session token for Cloud API auth (7d TTL, rolling refresh). During the migration window may hold a Google ID token until exchange lands.
   cloudUserEmail?: string; // User's Google email (for display)
   cloudUserName?: string; // User's Google display name
   cloudUserPicture?: string; // User's Google profile picture URL

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,0 +1,9 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       vite:
         specifier: ^4.1.0
         version: 4.5.14(@types/node@18.19.130)
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6(playwright@1.58.2)
 
   apps/download-site:
     dependencies:
@@ -630,6 +633,10 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -766,6 +773,9 @@ packages:
     resolution: {integrity: sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==}
     cpu: [x64]
     os: [win32]
+
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
   '@tauri-apps/api@1.6.0':
     resolution: {integrity: sha512-rqI++FWClU5I2UBp4HXFvl+sBWkdigBkxnpJDQUWttNyG7IZP4FwQGhTNL5EOw0vI8i6eSAJ5frLqO7n7jbJdg==}
@@ -1018,6 +1028,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai-subset@1.3.6':
+    resolution: {integrity: sha512-m8lERkkQj+uek18hXOZuec3W/fCRTrU4hrnXjH3qhHy96ytuPaPiWGgu7sJb7tZxZonO75vYAjCvpe/e4VUwRw==}
+    peerDependencies:
+      '@types/chai': <5.2.0
+
+  '@types/chai@4.3.20':
+    resolution: {integrity: sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1056,6 +1074,34 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@0.34.6':
+    resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
+
+  '@vitest/runner@0.34.6':
+    resolution: {integrity: sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==}
+
+  '@vitest/snapshot@0.34.6':
+    resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
+
+  '@vitest/spy@0.34.6':
+    resolution: {integrity: sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==}
+
+  '@vitest/utils@0.34.6':
+    resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-to-html@0.7.2:
     resolution: {integrity: sha512-v6MqmEpNlxF+POuyhKkidusCHWWkaLcGRURzivcU3I9tv7k4JVhFcnukrM5Rlk2rUywdZuzYAZ+kbZqWCnfN3g==}
     engines: {node: '>=8.0.0'}
@@ -1063,6 +1109,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
   base-x@5.0.1:
     resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
@@ -1079,12 +1128,26 @@ packages:
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   caniuse-lite@1.0.30001760:
     resolution: {integrity: sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==}
+
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1104,9 +1167,17 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
@@ -1154,6 +1225,9 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1173,6 +1247,13 @@ packages:
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
 
+  local-pkg@0.4.3:
+    resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
+    engines: {node: '>=14'}
+
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1184,6 +1265,9 @@ packages:
   magic-string@0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
     engines: {node: '>=12'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
@@ -1200,6 +1284,9 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1214,8 +1301,24 @@ packages:
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
+  p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
@@ -1230,6 +1333,10 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   prosemirror-changeset@2.3.1:
     resolution: {integrity: sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ==}
@@ -1298,6 +1405,9 @@ packages:
     peerDependencies:
       react: ^19.2.3
 
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
@@ -1339,16 +1449,43 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@1.3.0:
+    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
 
   tar@7.5.13:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinypool@0.7.0:
+    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1357,6 +1494,9 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -1371,6 +1511,11 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  vite-node@0.34.6:
+    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
 
   vite@4.5.14:
     resolution: {integrity: sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==}
@@ -1431,8 +1576,44 @@ packages:
       terser:
         optional: true
 
+  vitest@0.34.6:
+    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1440,6 +1621,10 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
 snapshots:
 
@@ -1840,6 +2025,10 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1932,6 +2121,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.53.3':
     optional: true
+
+  '@sinclair/typebox@0.27.10': {}
 
   '@tauri-apps/api@1.6.0': {}
 
@@ -2194,6 +2385,12 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
+  '@types/chai-subset@1.3.6(@types/chai@4.3.20)':
+    dependencies:
+      '@types/chai': 4.3.20
+
+  '@types/chai@4.3.20': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/linkify-it@5.0.0': {}
@@ -2208,7 +2405,6 @@ snapshots:
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
-    optional: true
 
   '@types/react-dom@19.2.3(@types/react@19.2.7)':
     dependencies:
@@ -2243,11 +2439,49 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@0.34.6':
+    dependencies:
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      chai: 4.5.0
+
+  '@vitest/runner@0.34.6':
+    dependencies:
+      '@vitest/utils': 0.34.6
+      p-limit: 4.0.0
+      pathe: 1.1.2
+
+  '@vitest/snapshot@0.34.6':
+    dependencies:
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+
+  '@vitest/spy@0.34.6':
+    dependencies:
+      tinyspy: 2.2.1
+
+  '@vitest/utils@0.34.6':
+    dependencies:
+      diff-sequences: 29.6.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ansi-styles@5.2.0: {}
+
   ansi-to-html@0.7.2:
     dependencies:
       entities: 2.2.0
 
   argparse@2.0.1: {}
+
+  assertion-error@1.1.0: {}
 
   base-x@5.0.1: {}
 
@@ -2265,9 +2499,27 @@ snapshots:
     dependencies:
       base-x: 5.0.1
 
+  cac@6.7.14: {}
+
   caniuse-lite@1.0.30001760: {}
 
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
+
   chownr@3.0.0: {}
+
+  confbox@0.1.8: {}
 
   convert-source-map@2.0.0: {}
 
@@ -2279,7 +2531,13 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
+
   detect-libc@2.1.2: {}
+
+  diff-sequences@29.6.3: {}
 
   electron-to-chromium@1.5.267: {}
 
@@ -2352,6 +2610,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-func-name@2.0.2: {}
+
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
@@ -2364,6 +2624,12 @@ snapshots:
 
   linkifyjs@4.3.2: {}
 
+  local-pkg@0.4.3: {}
+
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2373,6 +2639,10 @@ snapshots:
       react: 19.2.3
 
   magic-string@0.27.0:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -2393,6 +2663,13 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -2401,7 +2678,23 @@ snapshots:
 
   orderedmap@2.1.1: {}
 
+  p-limit@4.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
+  pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
+
   picocolors@1.1.1: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
 
   playwright-core@1.58.2: {}
 
@@ -2416,6 +2709,12 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
 
   prosemirror-changeset@2.3.1:
     dependencies:
@@ -2527,6 +2826,8 @@ snapshots:
       react: 19.2.3
       scheduler: 0.27.0
 
+  react-is@18.3.1: {}
+
   react-refresh@0.14.2: {}
 
   react-refresh@0.17.0: {}
@@ -2604,7 +2905,17 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@1.3.0:
+    dependencies:
+      acorn: 8.16.0
 
   tar@7.5.13:
     dependencies:
@@ -2614,15 +2925,24 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
+  tinybench@2.9.0: {}
+
+  tinypool@0.7.0: {}
+
+  tinyspy@2.2.1: {}
+
   tslib@2.8.1:
     optional: true
+
+  type-detect@4.1.0: {}
 
   typescript@5.9.3: {}
 
   uc.micro@2.1.0: {}
 
-  undici-types@5.26.5:
-    optional: true
+  ufo@1.6.4: {}
+
+  undici-types@5.26.5: {}
 
   update-browserslist-db@1.2.2(browserslist@4.28.1):
     dependencies:
@@ -2633,6 +2953,25 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.3):
     dependencies:
       react: 19.2.3
+
+  vite-node@0.34.6(@types/node@18.19.130):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      mlly: 1.8.2
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.21(@types/node@18.19.130)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vite@4.5.14(@types/node@18.19.130):
     dependencies:
@@ -2652,8 +2991,53 @@ snapshots:
       '@types/node': 18.19.130
       fsevents: 2.3.3
 
+  vitest@0.34.6(playwright@1.58.2):
+    dependencies:
+      '@types/chai': 4.3.20
+      '@types/chai-subset': 1.3.6(@types/chai@4.3.20)
+      '@types/node': 18.19.130
+      '@vitest/expect': 0.34.6
+      '@vitest/runner': 0.34.6
+      '@vitest/snapshot': 0.34.6
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      cac: 6.7.14
+      chai: 4.5.0
+      debug: 4.4.3
+      local-pkg: 0.4.3
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 1.3.0
+      tinybench: 2.9.0
+      tinypool: 0.7.0
+      vite: 5.4.21(@types/node@18.19.130)
+      vite-node: 0.34.6(@types/node@18.19.130)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      playwright: 1.58.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   w3c-keyname@2.2.8: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
+
+  yocto-queue@1.2.2: {}


### PR DESCRIPTION
## Summary

Mirror of the cloud portal ([mdma#53](https://github.com/calimero-network/mdma/pull/53)) and manager frontend ([mdma#54](https://github.com/calimero-network/mdma/pull/54)) migrations. After the Google OAuth deep-link callback returns a Google ID token, the desktop now exchanges it for a 7-day MDMA session via `POST /api/auth/google` and uses that session token for every subsequent cloud API call. No more 1-hour re-login loop.

- **`exchangeGoogleForMdmaSession`** in `cloudAuth.ts` runs inside `startCloudLogin`. On exchange failure we fall back to the raw Google token — the backend's `_verify_session_or_google` still accepts Google tokens during the migration window, so users aren't blocked if the new endpoint is temporarily unreachable.
- **`cloudFetch`** persists the `X-MDMA-Session-Refresh` response header directly to `settings.cloudIdToken` — no React-state update, so the next call picks it up without a render cascade. Only applies when the just-used token is still the active one (guards a concurrent fresh login).
- **`disconnectCloud`** calls `revokeMdmaSession` before clearing settings, so the sid lands in `RevokedSession` server-side and can't be refreshed. `revokeMdmaSession` sniffs `iss=='mdma'` before hitting the network, so it's safe to call with a Google token or undefined.
- `isMdmaSessionToken` helper exported for callers that need to discriminate.

## Base branch

This is stacked on `feat/cloud-integration` (PR #52). Once that merges, this will retarget to master.

## Dependencies

Depends on `/api/auth/*` endpoints (merged in [mdma#51](https://github.com/calimero-network/mdma/pull/51)) and the middleware fallback (merged in [mdma#52](https://github.com/calimero-network/mdma/pull/52)).

This is the final client-side migration in the session-token rollout. Once it ships, the Google-token fallback in `_verify_session_or_google` can be dropped (planned follow-up on the mdma side).

## Test plan

- [ ] Fresh cloud connect: deep-link callback returns Google token → exchange succeeds → `settings.cloudIdToken` holds an MDMA session JWT (`iss=="mdma"`), not the Google token.
- [ ] Reconnect after 1+ hour: no re-login prompt, session still valid.
- [ ] Rolling refresh: force-issue a token past the 24h threshold via backend test config; next cloud API call sees `X-MDMA-Session-Refresh` header, `settings.cloudIdToken` swapped silently.
- [ ] Disconnect: revokeMdmaSession fires against the current session, settings cleared, subsequent calls get `CloudSessionExpiredError`.
- [ ] Exchange failure fallback: server returns 5xx on `/api/auth/google`; the Google token is persisted as-is and cloud API calls continue working during the 1h Google TTL.
- [ ] Pre-migration Google token in settings (upgrade case): keeps working until Google exp — next disconnect/re-auth migrates naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the desktop cloud authentication and token persistence/refresh behavior, which can impact login/logout correctness and API authorization. Adds new session exchange/revocation network calls and JWT parsing logic that must match backend expectations.
> 
> **Overview**
> Desktop Cloud auth now **persists MDMA 7-day session tokens** instead of relying on 1-hour Google ID tokens: `startCloudLogin` exchanges the OAuth `id_token` via `POST /api/auth/google` (with fallback to the Google token during migration) and stores the resulting session in `settings.cloudIdToken`.
> 
> Cloud API calls gain **rolling session refresh** support by honoring `X-MDMA-Session-Refresh` on successful responses and updating `settings.cloudIdToken` after validating the refreshed JWT; disconnect now triggers best-effort server-side revocation via `POST /api/auth/logout`. JWT decoding/expiry checks are factored into a new `jwt.ts` with Vitest unit coverage.
> 
> Also fixes a request payload bug in `setTeeAdmissionPolicy` by switching to camelCase keys expected by the admin API, adds Vitest scripts/config, and trims the Tauri `http-all` feature from the Rust build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d786b2097d3ad298336795610a22a5515d92d6ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->