### PR TITLE
feat(cloud): drop N+1 subgroup enumeration when enabling HA

### DIFF
--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -36,44 +36,72 @@ type View =
  *
  * Fast path: most namespaces have a context in the root group
  * (group_id === namespace_id), so one admin-API call usually suffices.
- * Fallback: probe every subgroup in parallel and return the first with
- * a context. Parallel not sequential — the old code did O(N) round
- * trips serially, which scaled badly with subgroup count.
+ * Fallback: probe subgroups in bounded-concurrency batches and
+ * early-exit as soon as one batch returns a match. The old code did
+ * O(N) sequential round-trips; bounded batches keep the local admin
+ * API from seeing a burst of parallel requests on large namespaces
+ * while still amortising latency.
  */
+const PROBE_BATCH_SIZE = 6;
+
 async function findRepresentativeHaGroup(
   mero: NonNullable<ReturnType<typeof useMero>["mero"]>,
   namespaceId: string,
 ): Promise<NamespaceHaGroup> {
+  // Fast path failure is tolerated but logged — if it's a real
+  // connectivity issue the fallback path's listNamespaceGroups call
+  // will surface the same error with proper context. We don't
+  // distinguish "404 / no contexts" from other errors here because
+  // mero-js doesn't expose a stable error shape to switch on; the
+  // warning in dev console is what surfaces the cause.
   const rootCtxs = await mero.admin
     .listGroupContexts(namespaceId)
-    .catch(() => [] as { contextId: string }[]);
+    .catch((err: unknown) => {
+      console.warn(
+        `listGroupContexts(${namespaceId}) failed on fast path, falling through to subgroup probe:`,
+        err,
+      );
+      return [] as { contextId: string }[];
+    });
   if (rootCtxs.length) {
     return { group_id: namespaceId, context_id: rootCtxs[0].contextId };
   }
 
-  const subgroups = await mero.admin.listNamespaceGroups(namespaceId);
+  const allGroups = await mero.admin.listNamespaceGroups(namespaceId);
+  // Root already proven empty on the fast path — drop it so we don't
+  // re-probe it in the fallback.
+  const subgroups = allGroups.filter((g) => g.groupId !== namespaceId);
   if (!subgroups.length) {
     throw new Error("This namespace has no groups");
   }
 
-  const probes = await Promise.all(
-    subgroups.map((g) =>
-      mero.admin
-        .listGroupContexts(g.groupId)
-        .then(
-          (ctxs) =>
-            ctxs[0]
-              ? ({ group_id: g.groupId, context_id: ctxs[0].contextId } as NamespaceHaGroup)
-              : null,
-          () => null,
-        ),
-    ),
-  );
-  const found = probes.find((p): p is NamespaceHaGroup => p !== null);
-  if (!found) {
-    throw new Error("No group in this namespace has a context yet");
+  for (let i = 0; i < subgroups.length; i += PROBE_BATCH_SIZE) {
+    const batch = subgroups.slice(i, i + PROBE_BATCH_SIZE);
+    const probes = await Promise.all(
+      batch.map((g) =>
+        mero.admin
+          .listGroupContexts(g.groupId)
+          .then(
+            (ctxs) =>
+              ctxs[0]
+                ? ({ group_id: g.groupId, context_id: ctxs[0].contextId } as NamespaceHaGroup)
+                : null,
+            (err: unknown) => {
+              // Per-probe failure logged but non-fatal — another
+              // subgroup may still resolve. If every probe fails the
+              // caller sees the "no context yet" error below, and the
+              // dev console has the underlying reason.
+              console.warn(`listGroupContexts(${g.groupId}) failed:`, err);
+              return null;
+            },
+          ),
+      ),
+    );
+    const found = probes.find((p): p is NamespaceHaGroup => p !== null);
+    if (found) return found;
   }
-  return found;
+
+  throw new Error("No group in this namespace has a context yet");
 }
 
 export default function Namespaces() {

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -27,6 +27,55 @@ type View =
   | { type: "namespace"; ns: Namespace }
   | { type: "group"; ns: Namespace; groupId: string };
 
+/**
+ * Find any {group_id, context_id} pair owned by the user under this
+ * namespace. The manager only stores one HaRequest + HaContextStatus
+ * per namespace regardless of how many groups the client sends, so
+ * there is no reason to enumerate them all — we just need one entry
+ * to attach billing + fleet-join bookkeeping to.
+ *
+ * Fast path: most namespaces have a context in the root group
+ * (group_id === namespace_id), so one admin-API call usually suffices.
+ * Fallback: probe every subgroup in parallel and return the first with
+ * a context. Parallel not sequential — the old code did O(N) round
+ * trips serially, which scaled badly with subgroup count.
+ */
+async function findRepresentativeHaGroup(
+  mero: NonNullable<ReturnType<typeof useMero>["mero"]>,
+  namespaceId: string,
+): Promise<NamespaceHaGroup> {
+  const rootCtxs = await mero.admin
+    .listGroupContexts(namespaceId)
+    .catch(() => [] as { contextId: string }[]);
+  if (rootCtxs.length) {
+    return { group_id: namespaceId, context_id: rootCtxs[0].contextId };
+  }
+
+  const subgroups = await mero.admin.listNamespaceGroups(namespaceId);
+  if (!subgroups.length) {
+    throw new Error("This namespace has no groups");
+  }
+
+  const probes = await Promise.all(
+    subgroups.map((g) =>
+      mero.admin
+        .listGroupContexts(g.groupId)
+        .then(
+          (ctxs) =>
+            ctxs[0]
+              ? ({ group_id: g.groupId, context_id: ctxs[0].contextId } as NamespaceHaGroup)
+              : null,
+          () => null,
+        ),
+    ),
+  );
+  const found = probes.find((p): p is NamespaceHaGroup => p !== null);
+  if (!found) {
+    throw new Error("No group in this namespace has a context yet");
+  }
+  return found;
+}
+
 export default function Namespaces() {
   const toast = useToast();
   const { mero } = useMero();
@@ -103,24 +152,15 @@ export default function Namespaces() {
         setHaEnabled((prev) => ({ ...prev, [nsId]: false }));
         toast.success('HA disabled — TEE nodes will stop replicating');
       } else {
-        // Enumerate groups + representative context from the local node so
-        // the cloud can register HA on each group.
-        const groupsInNs = await mero.admin.listNamespaceGroups(nsId);
-        if (!groupsInNs.length) {
-          throw new Error('This namespace has no groups');
-        }
-        const haGroups: NamespaceHaGroup[] = [];
-        for (const g of groupsInNs) {
-          const ctxs = await mero.admin.listGroupContexts(g.groupId);
-          if (!ctxs.length) continue; // skip groups with no contexts
-          haGroups.push({ group_id: g.groupId, context_id: ctxs[0].contextId });
-        }
-        if (!haGroups.length) {
-          throw new Error('No group in this namespace has a context yet');
-        }
-        await enableHaForNamespace(token, settings.nodeUrl, nsId, haGroups);
+        // The cloud only needs ONE representative {group_id, context_id}
+        // per namespace (post mdma#30 / core rc.29 — one HaRequest row
+        // per namespace, auto-follow propagates fleet membership into
+        // subgroups). Find one quickly instead of enumerating every
+        // subgroup sequentially.
+        const haGroup = await findRepresentativeHaGroup(mero, nsId);
+        await enableHaForNamespace(token, settings.nodeUrl, nsId, [haGroup]);
         setHaEnabled((prev) => ({ ...prev, [nsId]: true }));
-        toast.success(`HA enabled on ${haGroups.length} group${haGroups.length === 1 ? '' : 's'} — TEE fleet nodes will join`);
+        toast.success('HA enabled — TEE fleet nodes will join');
       }
     } catch (err: any) {
       if (err instanceof CloudSessionExpiredError) {


### PR DESCRIPTION
## Summary

When the user toggles HA on a namespace, the client was enumerating every subgroup sequentially and doing a `listGroupContexts` admin-API call per group — O(N) round-trips to assemble a `groups: [{group_id, context_id}, …]` list that the manager immediately collapses to one representative entry.

Since [mdma#30](https://github.com/calimero-network/mdma/pull/30) (core rc.29+'s auto-follow propagates fleet-node membership across subgroups) the manager has stored exactly **one** `HaRequest` + **one** `HaContextStatus` row per namespace. Whatever the client sends in `body.groups`, the server picks a representative (`group_id == namespace_id` if present, else `body.groups[0]`), writes one row, and echoes the rest back cosmetically. The round-trip cost on the client side is wasted.

### The change

`Namespaces.tsx` gets a `findRepresentativeHaGroup` helper:

- **Fast path**: `listGroupContexts(namespaceId)` against the root. Most namespaces have a context there, so one admin-API call suffices.
- **Fallback**: `listNamespaceGroups` + parallel probe via `Promise.all` — returns the first subgroup that has a user-owned context.

The helper returns one `NamespaceHaGroup` which we pass as a single-entry list to `enableHaForNamespace`. Manager picks the same representative it would have, so the wire contract is unchanged.

Toast wording updated to drop the per-group count (inaccurate now that auto-follow propagates invisibly).

### Base branch

Stacked on `feat/cloud-integration` (PR #52) since that's where `Namespaces.tsx` + `enableHaForNamespace` live. Retarget to master once #52 merges.

## Test plan

- [ ] Enable HA on a namespace with only a root context: **1** admin-API call total (`listGroupContexts(nsId)`), no `listNamespaceGroups`.
- [ ] Enable HA on a namespace where the root has no context but subgroups do: 1 `listNamespaceGroups` + N parallel `listGroupContexts` calls (previously N sequential).
- [ ] Empty namespace: fast-path returns `[]`, fallback also returns `[]` → error surfaces as "No group in this namespace has a context yet" (unchanged).
- [ ] Server-side `HaRequest` row written under `group_id = namespaceId` as before — observable via `SELECT * FROM ha_requests WHERE namespace_id = ?`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the HA enablement flow and its error/selection behavior by choosing a single representative group/context; mis-selection or unexpected admin-API failures could prevent HA from enabling for some namespaces.
> 
> **Overview**
> When enabling HA for a namespace, the desktop client now sends only **one** representative `{group_id, context_id}` to `enableHaForNamespace` instead of enumerating every group and context.
> 
> A new `findRepresentativeHaGroup` helper adds a fast-path probe for root contexts and a bounded-concurrency subgroup probe with early-exit, reducing sequential admin-API round trips; the HA-enabled toast text was updated to drop per-group counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d35f2ea0f4c6bcdc7c3760b8418ca1bfda1a74f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->