### PR TITLE
feat: bump to rc37

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.5", features = [ "system-tray", "updater", "process-relaunch", "shell-open", "window-all", "dialog-all", "icon-png"] }
+tauri = { version = "1.5", features = [ "http-all", "system-tray", "updater", "process-relaunch", "shell-open", "window-all", "dialog-all", "icon-png"] }
 tauri-plugin-autostart = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/apps/desktop/src/pages/Namespaces.css
+++ b/apps/desktop/src/pages/Namespaces.css
@@ -5,6 +5,205 @@
   animation: fadeUp 0.4s ease-out;
 }
 
+.ns-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--accent-primary, #a5ff11);
+  background: var(--accent-primary, #a5ff11);
+  color: #0a0a0a;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter 0.15s ease, transform 0.05s ease;
+  margin-left: auto;
+}
+
+.ns-action-btn:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.ns-action-btn:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.ns-action-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.ns-launch-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary, #999);
+  font-size: 12px;
+  cursor: pointer;
+  margin-left: 8px;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.ns-launch-btn:hover {
+  border-color: var(--accent-primary, #a5ff11);
+  color: var(--accent-primary, #a5ff11);
+}
+
+.ns-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.15s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.ns-modal {
+  background: var(--bg-primary, #141414);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  width: min(480px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+  overflow: auto;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.5);
+}
+
+.ns-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.ns-modal-header h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.ns-modal-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+}
+
+.ns-modal-close:hover {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.06));
+  color: var(--text-primary);
+}
+
+.ns-modal-body {
+  padding: 16px 20px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.ns-modal-readonly {
+  background: var(--bg-secondary, rgba(255, 255, 255, 0.03));
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ns-modal-readonly code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.ns-modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.ns-modal-field input,
+.ns-modal-field select {
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary, rgba(255, 255, 255, 0.03));
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+}
+
+.ns-modal-field input:focus,
+.ns-modal-field select:focus {
+  outline: none;
+  border-color: var(--accent-primary, #a5ff11);
+}
+
+.ns-modal-hint {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.ns-modal-hint code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  padding: 1px 4px;
+  background: var(--bg-secondary, rgba(255, 255, 255, 0.05));
+  border-radius: 3px;
+}
+
+.ns-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.ns-modal-cancel {
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.ns-modal-cancel:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.ns-modal-cancel:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .ns-header {
   display: flex;
   align-items: center;

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   useNamespaces,
   useNamespaceGroups,
@@ -6,11 +6,47 @@ import {
   useGroupMembers,
   useGroupContexts,
   useSubgroups,
+  useCreateNamespace,
+  useCreateContext,
+  useMero,
   type Namespace,
 } from "@calimero-network/mero-react";
 import { useToast } from "../contexts/ToastContext";
-import { ArrowLeft, Users, Box, Layers, Copy, ChevronRight, Shield, Globe } from "lucide-react";
+import { ArrowLeft, Users, Box, Layers, Copy, ChevronRight, Shield, Globe, Plus, X, Play } from "lucide-react";
+import { apiClient } from "../lib/mero-client";
+import { saveContextKey, getContextKey } from "../utils/contextKeys";
+import { decodeMetadata, openAppFrontend } from "../utils/appUtils";
 import "./Namespaces.css";
+
+// Same default as battleships: CAN_CREATE_CONTEXT (1) | CAN_INVITE_MEMBERS (2) | MANAGE_MEMBERS (8).
+const DEFAULT_NAMESPACE_CAPABILITIES = 1 | 2 | 8;
+
+interface InstalledApp {
+  id: string;
+  name: string;
+  frontendUrl: string | null;
+  metadata?: unknown;
+}
+
+function readInstalledApps(): Promise<InstalledApp[]> {
+  return apiClient.node.listApplications().then((res) => {
+    if (res.error || !Array.isArray(res.data)) return [];
+    return res.data.map((app: any) => {
+      let name: string = app.id;
+      let frontendUrl: string | null = null;
+      try {
+        const meta = decodeMetadata(app.metadata);
+        if (meta) {
+          name = meta.name || meta.alias || app.id;
+          frontendUrl = meta?.links?.frontend ?? null;
+        }
+      } catch {
+        // ignore
+      }
+      return { id: app.id, name, frontendUrl };
+    });
+  });
+}
 
 type View =
   | { type: "list" }
@@ -19,6 +55,7 @@ type View =
 
 export default function Namespaces() {
   const toast = useToast();
+  const { mero } = useMero();
   const [view, setView] = useState<View>({ type: "list" });
 
   // Current namespace/group IDs for hooks
@@ -26,14 +63,99 @@ export default function Namespaces() {
   const activeGroupId = view.type === "group" ? view.groupId : null;
 
   // Hooks
-  const { namespaces, loading, error } = useNamespaces();
+  const { namespaces, loading, error, refetch: refetchNamespaces } = useNamespaces();
   const { groups: nsGroups, loading: nsLoadingGroups, error: nsGroupsError } = useNamespaceGroups(activeNsId);
   const { groupInfo, loading: groupInfoLoading } = useGroupInfo(activeGroupId);
   const { members: groupMembers } = useGroupMembers(activeGroupId);
-  const { contexts: groupContexts } = useGroupContexts(activeGroupId);
+  const { contexts: groupContexts, refetch: refetchGroupContexts } = useGroupContexts(activeGroupId);
+  // Contexts that live directly in a namespace's root group (battleships-style lobby contexts)
+  const { contexts: nsRootContexts, refetch: refetchNsRootContexts } = useGroupContexts(
+    view.type === "namespace" ? view.ns.namespaceId : null,
+  );
   const { subgroups: groupSubgroups } = useSubgroups(activeGroupId);
 
+  const { createNamespace, loading: creatingNamespace } = useCreateNamespace();
+  const { createContext, loading: creatingContext } = useCreateContext();
+
+  // Installed apps (loaded lazily for the Create-Namespace dropdown)
+  const [installedApps, setInstalledApps] = useState<InstalledApp[]>([]);
+  useEffect(() => {
+    readInstalledApps().then(setInstalledApps).catch(() => setInstalledApps([]));
+  }, []);
+
+  // Modals
+  const [nsModalOpen, setNsModalOpen] = useState(false);
+  const [ctxModalOpen, setCtxModalOpen] = useState<{ namespaceId: string; applicationId: string } | null>(null);
+
   const groupLoading = groupInfoLoading;
+
+  const onCreateNamespace = async (applicationId: string, alias: string | undefined) => {
+    if (!mero) {
+      toast.error("Node client not ready");
+      return;
+    }
+    try {
+      const result = await createNamespace({
+        applicationId,
+        upgradePolicy: "Automatic",
+        alias: alias?.trim() || undefined,
+      });
+      if (!result) throw new Error("createNamespace returned null");
+      try {
+        await mero.admin.setDefaultCapabilities(result.namespaceId, {
+          defaultCapabilities: DEFAULT_NAMESPACE_CAPABILITIES,
+        });
+      } catch (capErr) {
+        console.warn("setDefaultCapabilities failed:", capErr);
+      }
+      toast.success(`Namespace created: ${truncateId(result.namespaceId)}`);
+      setNsModalOpen(false);
+      await refetchNamespaces();
+    } catch (e: any) {
+      toast.error(`Failed to create namespace: ${e?.message ?? String(e)}`);
+    }
+  };
+
+  const onCreateContext = async (
+    namespaceId: string,
+    applicationId: string,
+    serviceName: string,
+    alias: string | undefined,
+  ) => {
+    try {
+      const result = await createContext({
+        applicationId,
+        groupId: namespaceId,
+        serviceName: serviceName.trim() || undefined,
+        initializationParams: [],
+        alias: alias?.trim() || undefined,
+      });
+      if (!result) throw new Error("createContext returned null");
+      saveContextKey(result.contextId, result.memberPublicKey, applicationId);
+      toast.success(`Context created: ${truncateId(result.contextId)}`);
+      setCtxModalOpen(null);
+      await Promise.all([
+        refetchGroupContexts?.(),
+        refetchNsRootContexts?.(),
+      ]);
+    } catch (e: any) {
+      toast.error(`Failed to create context: ${e?.message ?? String(e)}`);
+    }
+  };
+
+  const handleLaunchContext = async (contextId: string, applicationId: string) => {
+    const app = installedApps.find((a) => a.id === applicationId);
+    if (!app?.frontendUrl) {
+      toast.error("This application has no frontend URL");
+      return;
+    }
+    const key = getContextKey(contextId);
+    await openAppFrontend(app.frontendUrl, app.name, undefined, {
+      applicationId,
+      contextId,
+      executorPublicKey: key?.publicKey,
+    });
+  };
 
   // View transitions
   const openNamespace = (ns: Namespace) => {
@@ -68,12 +190,45 @@ export default function Namespaces() {
     }
   };
 
+  const modalOverlay = (
+    <>
+      {nsModalOpen && (
+        <CreateNamespaceModal
+          installedApps={installedApps}
+          loading={creatingNamespace}
+          onClose={() => setNsModalOpen(false)}
+          onSubmit={onCreateNamespace}
+        />
+      )}
+      {ctxModalOpen && (
+        <CreateContextModal
+          namespaceId={ctxModalOpen.namespaceId}
+          applicationId={ctxModalOpen.applicationId}
+          loading={creatingContext}
+          onClose={() => setCtxModalOpen(null)}
+          onSubmit={(serviceName, alias) =>
+            onCreateContext(ctxModalOpen.namespaceId, ctxModalOpen.applicationId, serviceName, alias)
+          }
+        />
+      )}
+    </>
+  );
+
   // ─── Namespace List View ───
   if (view.type === "list") {
     return (
+      <>
       <div className="ns-page">
         <header className="ns-header">
           <h1>Namespaces</h1>
+          <button
+            className="ns-action-btn"
+            onClick={() => setNsModalOpen(true)}
+            disabled={installedApps.length === 0}
+            title={installedApps.length === 0 ? "Install an application first" : "Create a new namespace"}
+          >
+            <Plus size={14} /> Create Namespace
+          </button>
         </header>
         <main className="ns-main">
           {error && <div className="error-message">{error.message}</div>}
@@ -84,8 +239,17 @@ export default function Namespaces() {
               <Globe size={48} style={{ opacity: 0.3, marginBottom: 12 }} />
               <p>No namespaces found</p>
               <p style={{ fontSize: "0.85rem" }}>
-                Namespaces are created when you install an application and create a context.
+                Create a namespace bound to an installed application, then create a context inside it.
               </p>
+              {installedApps.length === 0 ? (
+                <p style={{ fontSize: "0.85rem", opacity: 0.7 }}>
+                  Install an application first (Marketplace).
+                </p>
+              ) : (
+                <button className="ns-action-btn" onClick={() => setNsModalOpen(true)} style={{ marginTop: 12 }}>
+                  <Plus size={14} /> Create Namespace
+                </button>
+              )}
             </div>
           ) : (
             <div className="ns-grid">
@@ -128,6 +292,8 @@ export default function Namespaces() {
           )}
         </main>
       </div>
+      {modalOverlay}
+      </>
     );
   }
 
@@ -135,12 +301,13 @@ export default function Namespaces() {
   if (view.type === "namespace") {
     const { ns } = view;
     return (
+      <>
       <div className="ns-page">
         <header className="ns-header">
           <button className="ns-back" onClick={goBack}>
             <ArrowLeft size={16} /> Back
           </button>
-          <div>
+          <div style={{ flex: 1 }}>
             <h1>{(ns as any).alias || truncateId(ns.namespaceId)}</h1>
             <div className="ns-header-id">
               {truncateId(ns.namespaceId)}
@@ -149,6 +316,12 @@ export default function Namespaces() {
               </button>
             </div>
           </div>
+          <button
+            className="ns-action-btn"
+            onClick={() => setCtxModalOpen({ namespaceId: ns.namespaceId, applicationId: ns.targetApplicationId })}
+          >
+            <Plus size={14} /> Create Context
+          </button>
         </header>
 
         <main className="ns-main">
@@ -183,6 +356,39 @@ export default function Namespaces() {
           </div>
 
           <div className="ns-detail-section">
+            <h2><Box size={16} /> Contexts ({nsRootContexts.length})</h2>
+            {nsRootContexts.length === 0 ? (
+              <p className="empty-hint">No contexts in this namespace yet. Click "Create Context" to add one.</p>
+            ) : (
+              <div className="ns-context-list">
+                {nsRootContexts.map((c: any) => {
+                  const app = installedApps.find((a) => a.id === ns.targetApplicationId);
+                  const canLaunch = !!app?.frontendUrl;
+                  return (
+                    <div key={c.contextId} className="ns-context-item">
+                      <Box size={14} />
+                      <span className="context-name">{c.alias || truncateId(c.contextId)}</span>
+                      <span className="context-id mono">{truncateId(c.contextId)}</span>
+                      <button className="copy-btn" onClick={() => copyToClipboard(c.contextId)} title="Copy ID">
+                        <Copy size={12} />
+                      </button>
+                      {canLaunch && (
+                        <button
+                          className="ns-launch-btn"
+                          onClick={() => handleLaunchContext(c.contextId, ns.targetApplicationId)}
+                          title={`Launch ${app?.name ?? "app"} with this context`}
+                        >
+                          <Play size={12} /> Launch
+                        </button>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <div className="ns-detail-section">
             <h2>Groups</h2>
             {nsLoadingGroups ? (
               <div className="loading">Loading groups...</div>
@@ -209,6 +415,8 @@ export default function Namespaces() {
           </div>
         </main>
       </div>
+      {modalOverlay}
+      </>
     );
   }
 
@@ -216,6 +424,7 @@ export default function Namespaces() {
   if (view.type === "group") {
     const { ns, groupId } = view;
     return (
+      <>
       <div className="ns-page">
         <header className="ns-header">
           <button className="ns-back" onClick={goBack}>
@@ -290,16 +499,29 @@ export default function Namespaces() {
                   <p className="empty-hint">No contexts in this group</p>
                 ) : (
                   <div className="ns-context-list">
-                    {groupContexts.map((c) => (
-                      <div key={c.contextId} className="ns-context-item">
-                        <Box size={14} />
-                        <span className="context-name">{(c as any).alias || truncateId(c.contextId)}</span>
-                        <span className="context-id mono">{truncateId(c.contextId)}</span>
-                        <button className="copy-btn" onClick={() => copyToClipboard(c.contextId)} title="Copy ID">
-                          <Copy size={12} />
-                        </button>
-                      </div>
-                    ))}
+                    {groupContexts.map((c: any) => {
+                      const app = installedApps.find((a) => a.id === ns.targetApplicationId);
+                      const canLaunch = !!app?.frontendUrl;
+                      return (
+                        <div key={c.contextId} className="ns-context-item">
+                          <Box size={14} />
+                          <span className="context-name">{c.alias || truncateId(c.contextId)}</span>
+                          <span className="context-id mono">{truncateId(c.contextId)}</span>
+                          <button className="copy-btn" onClick={() => copyToClipboard(c.contextId)} title="Copy ID">
+                            <Copy size={12} />
+                          </button>
+                          {canLaunch && (
+                            <button
+                              className="ns-launch-btn"
+                              onClick={() => handleLaunchContext(c.contextId, ns.targetApplicationId)}
+                              title={`Launch ${app?.name ?? "app"} with this context`}
+                            >
+                              <Play size={12} /> Launch
+                            </button>
+                          )}
+                        </div>
+                      );
+                    })}
                   </div>
                 )}
               </div>
@@ -328,8 +550,145 @@ export default function Namespaces() {
           )}
         </main>
       </div>
+      {modalOverlay}
+      </>
     );
   }
 
   return null;
+}
+
+// ─── Modals ───
+
+interface CreateNamespaceModalProps {
+  installedApps: InstalledApp[];
+  loading: boolean;
+  onClose: () => void;
+  onSubmit: (applicationId: string, alias: string | undefined) => void;
+}
+
+function CreateNamespaceModal({ installedApps, loading, onClose, onSubmit }: CreateNamespaceModalProps) {
+  const [applicationId, setApplicationId] = useState(installedApps[0]?.id ?? "");
+  const [alias, setAlias] = useState("");
+
+  return (
+    <div className="ns-modal-backdrop" onClick={onClose}>
+      <div className="ns-modal" onClick={(e) => e.stopPropagation()} role="dialog" aria-label="Create Namespace">
+        <div className="ns-modal-header">
+          <h2>Create Namespace</h2>
+          <button className="ns-modal-close" onClick={onClose} aria-label="Close">
+            <X size={16} />
+          </button>
+        </div>
+        <form
+          className="ns-modal-body"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!applicationId) return;
+            onSubmit(applicationId, alias);
+          }}
+        >
+          <label className="ns-modal-field">
+            <span>Application</span>
+            <select
+              value={applicationId}
+              onChange={(e) => setApplicationId(e.target.value)}
+              required
+            >
+              {installedApps.length === 0 && <option value="">No applications installed</option>}
+              {installedApps.map((app) => (
+                <option key={app.id} value={app.id}>
+                  {app.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="ns-modal-field">
+            <span>Alias (optional)</span>
+            <input
+              type="text"
+              value={alias}
+              onChange={(e) => setAlias(e.target.value)}
+              placeholder="e.g. my-namespace"
+            />
+          </label>
+          <p className="ns-modal-hint">
+            Upgrade policy: <code>Automatic</code>. Default capabilities (create context, invite, manage members) will be applied to new members.
+          </p>
+          <div className="ns-modal-actions">
+            <button type="button" className="ns-modal-cancel" onClick={onClose} disabled={loading}>
+              Cancel
+            </button>
+            <button type="submit" className="ns-action-btn" disabled={loading || !applicationId}>
+              {loading ? "Creating..." : "Create Namespace"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+interface CreateContextModalProps {
+  namespaceId: string;
+  applicationId: string;
+  loading: boolean;
+  onClose: () => void;
+  onSubmit: (serviceName: string, alias: string | undefined) => void;
+}
+
+function CreateContextModal({ namespaceId, applicationId, loading, onClose, onSubmit }: CreateContextModalProps) {
+  const [serviceName, setServiceName] = useState("");
+  const [alias, setAlias] = useState("");
+
+  return (
+    <div className="ns-modal-backdrop" onClick={onClose}>
+      <div className="ns-modal" onClick={(e) => e.stopPropagation()} role="dialog" aria-label="Create Context">
+        <div className="ns-modal-header">
+          <h2>Create Context</h2>
+          <button className="ns-modal-close" onClick={onClose} aria-label="Close">
+            <X size={16} />
+          </button>
+        </div>
+        <form
+          className="ns-modal-body"
+          onSubmit={(e) => {
+            e.preventDefault();
+            onSubmit(serviceName, alias);
+          }}
+        >
+          <div className="ns-modal-readonly">
+            <div><strong>Namespace:</strong> <code>{namespaceId.slice(0, 8)}…{namespaceId.slice(-8)}</code></div>
+            <div><strong>Application:</strong> <code>{applicationId.slice(0, 8)}…{applicationId.slice(-8)}</code></div>
+          </div>
+          <label className="ns-modal-field">
+            <span>Service name (optional)</span>
+            <input
+              type="text"
+              value={serviceName}
+              onChange={(e) => setServiceName(e.target.value)}
+              placeholder="e.g. lobby"
+            />
+          </label>
+          <label className="ns-modal-field">
+            <span>Alias (optional)</span>
+            <input
+              type="text"
+              value={alias}
+              onChange={(e) => setAlias(e.target.value)}
+              placeholder="e.g. main-lobby"
+            />
+          </label>
+          <div className="ns-modal-actions">
+            <button type="button" className="ns-modal-cancel" onClick={onClose} disabled={loading}>
+              Cancel
+            </button>
+            <button type="submit" className="ns-action-btn" disabled={loading}>
+              {loading ? "Creating..." : "Create Context"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
 }

--- a/apps/desktop/src/utils/appUtils.ts
+++ b/apps/desktop/src/utils/appUtils.ts
@@ -58,10 +58,17 @@ export function decodeMetadata(metadata: any): any {
  * @param onError - Optional error callback
  * @returns Promise that resolves with the window label when the window is created (for focusing)
  */
+export interface OpenAppFrontendContext {
+  applicationId?: string;
+  contextId?: string;
+  executorPublicKey?: string;
+}
+
 export async function openAppFrontend(
   frontendUrl: string,
   appName?: string,
-  onError?: (error: Error) => void
+  onError?: (error: Error) => void,
+  context?: OpenAppFrontendContext,
 ): Promise<string | void> {
   try {
     const settings = getSettings();
@@ -77,6 +84,9 @@ export async function openAppFrontend(
       hashParams.set('refresh_token', refreshToken);
       hashParams.set('expires_in', '3600');
     }
+    if (context?.applicationId) hashParams.set('application_id', context.applicationId);
+    if (context?.contextId) hashParams.set('context_id', context.contextId);
+    if (context?.executorPublicKey) hashParams.set('executor_public_key', context.executorPublicKey);
 
     const urlToOpen = `${frontendUrl}#${hashParams.toString()}`;
 

--- a/apps/desktop/src/utils/contextKeys.ts
+++ b/apps/desktop/src/utils/contextKeys.ts
@@ -1,0 +1,37 @@
+const STORAGE_KEY = "calimero-context-keys";
+
+type ContextKeyRecord = {
+  publicKey: string;
+  applicationId?: string;
+};
+
+type ContextKeyMap = Record<string, ContextKeyRecord>;
+
+function readAll(): ContextKeyMap {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeAll(map: ContextKeyMap) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+}
+
+export function saveContextKey(
+  contextId: string,
+  publicKey: string,
+  applicationId?: string,
+) {
+  const map = readAll();
+  map[contextId] = { publicKey, applicationId };
+  writeAll(map);
+}
+
+export function getContextKey(contextId: string): ContextKeyRecord | null {
+  return readAll()[contextId] ?? null;
+}

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.10.1-rc.22"
+    "version": "0.10.1-rc.37"
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new namespace/context creation flows and persists context public keys in `localStorage`, plus passes context identifiers into app frontend URLs; mistakes could affect permissions defaults, UX, or leak context identifiers via URL fragments.
> 
> **Overview**
> Enables creating namespaces and contexts directly from the `Namespaces` page, including new modal forms, default capability assignment on namespace creation, and refreshed lists after mutations.
> 
> Adds context launching from namespace/group context lists by discovering installed apps + frontend URLs and opening a new Tauri window with additional URL hash params (`application_id`, `context_id`, `executor_public_key`), persisting the executor public key per context in `localStorage`.
> 
> Updates the desktop Tauri build to include the `http-all` feature and bumps `merod-config.json` from `0.10.1-rc.22` to `0.10.1-rc.37`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f9cc9da1ed741fb2c6fd969834f9b3c2d243dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->