### PR TITLE
feat: bump version to 34

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.33"
+    "version": "0.0.34"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates version metadata in `package.json` and Tauri `tauri.conf.json`, with no runtime logic changes.
> 
> **Overview**
> Bumps the Calimero Desktop app version from `0.0.33` to `0.0.34` in both `apps/desktop/package.json` and the Tauri packaging config (`src-tauri/tauri.conf.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9269cb853e10f4dc11a509b8fe8d157ecd9d8c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->