### PR TITLE
ci: run vitest unit tests on push/PR to master

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,43 @@
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+concurrency:
+  group: unit-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  vitest:
+    name: Vitest (desktop)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        working-directory: apps/desktop
+        run: pnpm test:unit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,11 @@ on:
       - master
 
 concurrency:
-  group: unit-tests-${{ github.workflow }}-${{ github.ref }}
+  # Key by event_name + ref so push runs on master and pull_request runs
+  # targeting master don't cancel each other (they're independently valuable).
+  # Dropping the redundant ${{ github.workflow }} since "unit-tests-" already
+  # namespaces this from other workflows' concurrency groups.
+  group: unit-tests-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs `pnpm test:unit` (Vitest) from `apps/desktop` on every push and PR against `master`. Mirrors the existing `e2e-desktop.yml` setup pattern (pnpm v9, Node 20, ubuntu-22.04).

## Context

The `test:unit` script and the first unit-test file (`apps/desktop/src/utils/jwt.test.ts`) were added in [PR #67](https://github.com/calimero-network/tauri-app/pull/67) (commit `4337c8f`, expanded in `d786b20`) as part of the MDMA session-token migration. Local invocation works today:

```bash
cd apps/desktop && pnpm test:unit
# 18/18 tests pass in ~140ms
```

This workflow puts that suite on the merge gate so future changes to the JWT helpers (or any other unit-tested utility) can't regress silently.

## Why this came in as a separate PR

The workflow file was held back from #67 because the `gh` OAuth token used for that push lacked the `workflow` scope (required to create or modify files under `.github/workflows/`). Splitting it out kept the migration unblocked.

## Test plan

- [x] CI runs on this PR itself (the workflow's `pull_request` trigger fires on the PR opening; Vitest job should appear in checks alongside the existing Build × 3 + Playwright)
- [x] Verify Vitest job passes
- [x] After merge: confirm the next PR against `master` also runs the Vitest job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new GitHub Actions workflow only, which may affect CI signal/cost but does not change runtime code or production behavior.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/unit-tests.yml`) that runs the desktop Vitest suite (`pnpm test:unit` in `apps/desktop`) on pushes and pull requests targeting `main`/`master`.
> 
> The job standardizes on Ubuntu 22.04 with Node 20 and pnpm 9, and introduces a concurrency group to cancel superseded runs per ref/event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e750ce9f42c5b9d10a288486d152bbbe5dceed49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->