### PR TITLE
fix(cloud): harden session refresh, revocation, and exchange validation

### DIFF
--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -76,7 +76,17 @@ async function cloudFetch(
     // avoids clobbering a fresh login that landed between the request
     // leaving and the response arriving.
     if (settings.cloudIdToken === idToken) {
-      saveSettings({ ...settings, cloudIdToken: refreshed });
+      // saveSettings can throw if localStorage is full or unavailable
+      // (Safari private mode, quota exceeded). The rolling refresh is a
+      // best-effort silent renewal — if we can't persist the new token
+      // the user keeps the old one and re-auths at its exp, which is
+      // strictly better than letting the network response surface a
+      // storage error to the caller.
+      try {
+        saveSettings({ ...settings, cloudIdToken: refreshed });
+      } catch (err) {
+        console.warn('Failed to persist refreshed MDMA session token:', err);
+      }
     }
   }
 

--- a/apps/desktop/src/utils/cloudAuth.ts
+++ b/apps/desktop/src/utils/cloudAuth.ts
@@ -102,13 +102,16 @@ export function decodeIdToken(token: string): CloudUserInfo | null {
 
 interface MdmaSessionResponse {
   session_token: string;
-  expires_at: number;
   // Nullable: if the server's `user` field is missing/malformed but the
   // session_token is otherwise valid (MDMA-issued JWT), we keep the
   // 7-day session and let the call site fall back to decodeIdToken(googleToken)
   // for the profile chip — see the shape-validation branch in
   // exchangeGoogleForMdmaSession.
   user: CloudUserInfo | null;
+  // Note: the server response also carries `expires_at`, but we deliberately
+  // do not surface it. Every expiry decision in this codebase reads `exp`
+  // from the JWT itself via isTokenExpired, so re-exposing a parallel field
+  // here would just be a trap for a future caller.
 }
 
 /**
@@ -181,10 +184,6 @@ async function exchangeGoogleForMdmaSession(
       typeof (userField as { picture?: unknown }).picture === 'string';
     return {
       session_token: (body as { session_token: string }).session_token,
-      expires_at:
-        typeof (body as { expires_at?: unknown }).expires_at === 'number'
-          ? (body as { expires_at: number }).expires_at
-          : 0,
       user: userValid ? (userField as CloudUserInfo) : null,
     };
   } catch {

--- a/apps/desktop/src/utils/cloudAuth.ts
+++ b/apps/desktop/src/utils/cloudAuth.ts
@@ -103,7 +103,12 @@ export function decodeIdToken(token: string): CloudUserInfo | null {
 interface MdmaSessionResponse {
   session_token: string;
   expires_at: number;
-  user: CloudUserInfo;
+  // Nullable: if the server's `user` field is missing/malformed but the
+  // session_token is otherwise valid (MDMA-issued JWT), we keep the
+  // 7-day session and let the call site fall back to decodeIdToken(googleToken)
+  // for the profile chip — see the shape-validation branch in
+  // exchangeGoogleForMdmaSession.
+  user: CloudUserInfo | null;
 }
 
 /**
@@ -156,24 +161,32 @@ async function exchangeGoogleForMdmaSession(
     if (!isMdmaSessionToken((body as { session_token: string }).session_token)) {
       return null;
     }
-    // Validate the user claim shape too: startCloudLogin reads
-    // exchange.user.{email,name,picture} directly into settings, so a
-    // 200 body with a missing/malformed `user` field would persist
-    // `undefined` strings and surface as a blank profile chip in the
-    // UI. Returning null here triggers the Google-token fallback path
-    // (which calls decodeIdToken) so the user still gets a populated
-    // profile from the ID token's claims.
+    // Validate the user claim shape independently from the session_token.
+    // startCloudLogin reads exchange.user.{email,name,picture} directly
+    // into settings, so a 200 body with a missing/malformed `user` field
+    // would persist `undefined` strings and surface as a blank profile
+    // chip. Crucially we *don't* discard the whole response on a bad
+    // `user` — the session_token has already been validated as an
+    // MDMA-issued JWT above, and dropping the 7-day session because of
+    // a cosmetic profile field would silently degrade the user to the
+    // 1-hour Google fallback. Returning `user: null` lets the call site's
+    // `exchange?.user ?? decodeIdToken(googleToken)` fallback populate
+    // the profile from the ID-token claims while keeping the long session.
     const userField = (body as { user?: unknown }).user;
-    if (
-      !userField ||
-      typeof userField !== 'object' ||
-      typeof (userField as { email?: unknown }).email !== 'string' ||
-      typeof (userField as { name?: unknown }).name !== 'string' ||
-      typeof (userField as { picture?: unknown }).picture !== 'string'
-    ) {
-      return null;
-    }
-    return body as MdmaSessionResponse;
+    const userValid =
+      !!userField &&
+      typeof userField === 'object' &&
+      typeof (userField as { email?: unknown }).email === 'string' &&
+      typeof (userField as { name?: unknown }).name === 'string' &&
+      typeof (userField as { picture?: unknown }).picture === 'string';
+    return {
+      session_token: (body as { session_token: string }).session_token,
+      expires_at:
+        typeof (body as { expires_at?: unknown }).expires_at === 'number'
+          ? (body as { expires_at: number }).expires_at
+          : 0,
+      user: userValid ? (userField as CloudUserInfo) : null,
+    };
   } catch {
     return null;
   }

--- a/apps/desktop/src/utils/cloudAuth.ts
+++ b/apps/desktop/src/utils/cloudAuth.ts
@@ -156,6 +156,23 @@ async function exchangeGoogleForMdmaSession(
     if (!isMdmaSessionToken((body as { session_token: string }).session_token)) {
       return null;
     }
+    // Validate the user claim shape too: startCloudLogin reads
+    // exchange.user.{email,name,picture} directly into settings, so a
+    // 200 body with a missing/malformed `user` field would persist
+    // `undefined` strings and surface as a blank profile chip in the
+    // UI. Returning null here triggers the Google-token fallback path
+    // (which calls decodeIdToken) so the user still gets a populated
+    // profile from the ID token's claims.
+    const userField = (body as { user?: unknown }).user;
+    if (
+      !userField ||
+      typeof userField !== 'object' ||
+      typeof (userField as { email?: unknown }).email !== 'string' ||
+      typeof (userField as { name?: unknown }).name !== 'string' ||
+      typeof (userField as { picture?: unknown }).picture !== 'string'
+    ) {
+      return null;
+    }
     return body as MdmaSessionResponse;
   } catch {
     return null;
@@ -177,13 +194,27 @@ export function revokeMdmaSession(sessionToken: string | undefined | null): void
   fetch(`${CLOUD_BASE_URL}/api/auth/logout`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${sessionToken}` },
-  }).catch((err) => {
-    // Best-effort: we don't block logout on this. But a persistent
-    // failure (wrong URL, TLS issue, endpoint 500) leaves sessions
-    // unrevoked server-side — log so the dev console surfaces it
-    // rather than the failure being completely invisible.
-    console.warn('MDMA session revocation failed (best-effort):', err);
-  });
+  })
+    .then((res) => {
+      // fetch only rejects on network-level failure; a 4xx/5xx response
+      // resolves successfully and would otherwise be silently ignored.
+      // Surface non-OK statuses too so the dev console reflects the
+      // session_t actually staying alive server-side.
+      if (!res.ok) {
+        console.warn(
+          'MDMA session revocation returned non-OK status:',
+          res.status,
+          res.statusText,
+        );
+      }
+    })
+    .catch((err) => {
+      // Best-effort: we don't block logout on this. But a persistent
+      // failure (wrong URL, TLS issue, DNS) leaves sessions unrevoked
+      // server-side — log so the dev console surfaces it rather than
+      // the failure being completely invisible.
+      console.warn('MDMA session revocation failed (best-effort):', err);
+    });
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses items **2, 3, and 4** of #74 (post-#67 cleanup). Three small, low-risk hardening fixes on the cloud auth path. Item 1 (move `cloudIdToken` to the OS keychain) is deferred to a separate PR — it touches every `cloudIdToken` call site and warrants its own focused review.

### What changes

- **`cloudFetch` rolling-refresh** (`cloudApi.ts`): wrap the `saveSettings(...)` write inside a `try/catch`. The refresh path is best-effort silent renewal — a `localStorage` failure (quota exceeded, Safari private mode) shouldn't surface from a routine API call. On failure we warn and keep the old token; user re-auths at its `exp`.
- **`revokeMdmaSession`** (`cloudAuth.ts`): add a `.then(res => !res.ok && warn)` chain. `fetch` only rejects on network-level failure; 4xx/5xx responses resolve successfully and were previously silently ignored. Without this, a misbehaving `/api/auth/logout` would leave sessions unrevoked server-side with zero local signal.
- **`exchangeGoogleForMdmaSession`** (`cloudAuth.ts`): extend the 200-body shape check to validate `exchange.user.{email, name, picture}` as strings. A 200 with a missing/malformed `user` would otherwise persist `undefined` strings into settings and surface as a blank profile chip. Returning `null` here triggers the Google-token fallback path (`decodeIdToken`) so the user still gets a populated profile from the ID-token claims.

### Out of scope

- **#74 item 1** — `cloudIdToken` → OS keychain migration. Existing Tauri `secure_store_token` / `secure_get_token` / `secure_delete_token` commands already exist (`main.rs`, ~line 1991) with zero JS callers. The migration is greenfield JS-side work and needs its own design decision around sync vs async token reads at every call site.

## Test plan

- [x] `npx tsc --noEmit` from `apps/desktop` — passes
- [x] `pnpm test:unit` — 18/18 passing (unchanged; these patches don't touch `jwt.ts`)
- [ ] Manual smoke (cloud login → logout) on a packaged dev build — keeps the existing happy path intact

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cloud authentication/session persistence paths; behavior is mostly best-effort logging/validation but regressions could affect login/logout reliability and token refresh persistence.
> 
> **Overview**
> Improves resiliency of MDMA session handling in the desktop app.
> 
> `cloudFetch` now treats rolling refresh persistence as **best-effort**, swallowing `saveSettings`/storage failures and logging a warning instead of surfacing errors from otherwise-successful API calls.
> 
> The Google→MDMA exchange response parsing is hardened by validating the `user` object shape separately (returning `user: null` on malformed data while still accepting a valid `session_token`), and `revokeMdmaSession` now logs **non-OK HTTP statuses** in addition to network errors so failed server-side revocations are visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9411bf53ccd1ea75b931181658b8a26414a0f2f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->