### PR TITLE
feat(cloud): auto-claim self-hosted contexts before enabling HA

### DIFF
--- a/apps/desktop/src/utils/cloudApi.test.ts
+++ b/apps/desktop/src/utils/cloudApi.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// The token-storage module reads from window.localStorage on import;
+// mock it before the SUT is required so getAccessToken() returns a
+// predictable value across tests.
+vi.mock('../lib/token-storage', () => ({
+  getAccessToken: () => 'test-access-token',
+  getRefreshToken: () => null,
+}));
+
+// settings.ts touches localStorage too — keep it inert.
+vi.mock('./settings', () => ({
+  getSettings: () => ({ nodeUrl: 'http://localhost:2528' }),
+  saveSettings: () => {},
+}));
+
+import {
+  requestOwnershipProof,
+  claimContexts,
+  enableHaForNamespace,
+  CLOUD_BASE_URL,
+} from './cloudApi';
+
+// Minimal JWT shaped for parseJwtPayload — only need the payload
+// segment to decode; signature is ignored.
+function makeJwt(payload: object): string {
+  const b64 = (s: string) =>
+    btoa(s).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+  const header = b64(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = b64(JSON.stringify(payload));
+  return `${header}.${body}.sig`;
+}
+
+interface FetchCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+function installFetch(
+  handler: (url: string, init: RequestInit | undefined) => Response,
+): { calls: FetchCall[]; restore: () => void } {
+  const calls: FetchCall[] = [];
+  const original = globalThis.fetch;
+  // @ts-expect-error — test double, not the full DOM fetch signature
+  globalThis.fetch = (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    return Promise.resolve(handler(url, init));
+  };
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('requestOwnershipProof', () => {
+  let restore: () => void;
+  afterEach(() => restore?.());
+
+  it('POSTs camelCase body to merod and re-keys camelCase response to snake_case', async () => {
+    const { calls, restore: r } = installFetch(() =>
+      jsonResponse({
+        data: {
+          signerPublicKey: 'pk-base58',
+          signedPayload: 'sp-b64',
+          signature: 'sig-b64',
+        },
+      }),
+    );
+    restore = r;
+
+    const out = await requestOwnershipProof('http://node', 'group-1', {
+      contextId: 'ctx-1',
+      subject: 'user@example.com',
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(
+      'http://node/admin-api/groups/group-1/issue-ownership-proof',
+    );
+    expect(calls[0].init?.method).toBe('POST');
+    const body = JSON.parse(String(calls[0].init?.body));
+    expect(body.audience).toBe('mdma:claim-context');
+    expect(body.contextId).toBe('ctx-1');
+    expect(body.subject).toBe('user@example.com');
+    expect(typeof body.nonce).toBe('string');
+    expect(body.nonce).toMatch(/^[0-9a-f]{32}$/);
+    expect(typeof body.expiresAtMs).toBe('number');
+
+    expect(out).toEqual({
+      signer_public_key: 'pk-base58',
+      signed_payload: 'sp-b64',
+      signature: 'sig-b64',
+    });
+  });
+
+  it('throws when the merod response is malformed', async () => {
+    const { restore: r } = installFetch(() => jsonResponse({ data: {} }));
+    restore = r;
+    await expect(
+      requestOwnershipProof('http://node', 'group-1', {
+        contextId: 'ctx',
+        subject: 'u@e',
+      }),
+    ).rejects.toThrow(/Malformed ownership proof/);
+  });
+
+  it('throws with body text when merod returns non-ok', async () => {
+    const { restore: r } = installFetch(
+      () => new Response('group not found', { status: 404 }),
+    );
+    restore = r;
+    await expect(
+      requestOwnershipProof('http://node', 'group-1', {
+        contextId: 'ctx',
+        subject: 'u@e',
+      }),
+    ).rejects.toThrow(/group not found/);
+  });
+});
+
+describe('claimContexts', () => {
+  let restore: () => void;
+  afterEach(() => restore?.());
+
+  it('POSTs the snake_case wire payload to the cloud and returns claimed[]', async () => {
+    const { calls, restore: r } = installFetch(() =>
+      jsonResponse({ claimed: ['ctx-1'] }),
+    );
+    restore = r;
+    const sessionJwt = makeJwt({ iss: 'mdma' });
+    const claimed = await claimContexts(sessionJwt, [
+      {
+        context_id: 'ctx-1',
+        ownership_proof: {
+          signer_public_key: 'pk',
+          signed_payload: 'sp',
+          signature: 'sig',
+        },
+      },
+    ]);
+    expect(claimed).toEqual(['ctx-1']);
+    expect(calls[0].url).toBe(`${CLOUD_BASE_URL}/api/cloud/me/contexts/claim`);
+    const body = JSON.parse(String(calls[0].init?.body));
+    expect(body).toEqual({
+      claims: [
+        {
+          context_id: 'ctx-1',
+          ownership_proof: {
+            signer_public_key: 'pk',
+            signed_payload: 'sp',
+            signature: 'sig',
+          },
+        },
+      ],
+    });
+  });
+
+  it('surfaces the detail string on 403', async () => {
+    const { restore: r } = installFetch(() =>
+      jsonResponse(
+        { detail: 'Ownership proof failed: signer not registered' },
+        403,
+      ),
+    );
+    restore = r;
+    await expect(
+      claimContexts(makeJwt({ iss: 'mdma' }), []),
+    ).rejects.toThrow(/Ownership proof failed: signer not registered/);
+  });
+});
+
+describe('enableHaForNamespace silent-claim pre-flight', () => {
+  let restore: () => void;
+  beforeEach(() => {
+    // Predictable nonce → identical request bodies in assertions.
+    vi.spyOn(crypto, 'getRandomValues').mockImplementation((arr: any) => {
+      for (let i = 0; i < arr.length; i++) arr[i] = i;
+      return arr;
+    });
+  });
+  afterEach(() => {
+    restore?.();
+    vi.restoreAllMocks();
+  });
+
+  function route(
+    url: string,
+    init: RequestInit | undefined,
+    handlers: Record<string, () => Response>,
+  ): Response {
+    for (const [pattern, h] of Object.entries(handlers)) {
+      if (url.includes(pattern)) return h();
+    }
+    return new Response(`unmatched: ${url} ${init?.method ?? 'GET'}`, {
+      status: 500,
+    });
+  }
+
+  it('fails closed when the caller is not the namespace admin', async () => {
+    const { restore: r } = installFetch((url, init) =>
+      route(url, init, {
+        '/admin-api/groups/ns-root/members': () =>
+          jsonResponse({
+            data: {
+              data: [{ identity: 'me', role: 'Member' }],
+              selfIdentity: 'me',
+            },
+          }),
+      }),
+    );
+    restore = r;
+    await expect(
+      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', [
+        { group_id: 'g1', context_id: 'ctx-1' },
+      ]),
+    ).rejects.toThrow(/Only the namespace admin can register contexts/);
+  });
+
+  it('runs members → proofs (parallel) → claim → measurements → tee-policy → enable in order', async () => {
+    const calls: string[] = [];
+    const { restore: r } = installFetch((url, init) => {
+      calls.push(`${init?.method ?? 'GET'} ${url}`);
+      return route(url, init, {
+        '/admin-api/groups/ns-root/members': () =>
+          jsonResponse({
+            data: {
+              data: [{ identity: 'me', role: 'Admin' }],
+              selfIdentity: 'me',
+            },
+          }),
+        '/admin-api/groups/ns-root/issue-ownership-proof': () =>
+          jsonResponse({
+            data: {
+              signerPublicKey: 'pk',
+              signedPayload: 'sp',
+              signature: 'sig',
+            },
+          }),
+        '/api/cloud/me/contexts/claim': () =>
+          jsonResponse({ claimed: ['ctx-1', 'ctx-2'] }),
+        '/api/cloud/fleet/measurements': () =>
+          jsonResponse({
+            release_tag: 'v1',
+            allowed_mrtd: ['mrtd-1'],
+            allowed_rtmr0: [],
+            allowed_rtmr1: [],
+            allowed_rtmr2: [],
+            allowed_rtmr3: [],
+          }),
+        '/admin-api/groups/ns-root/settings/tee-admission-policy': () =>
+          new Response('{}', { status: 200 }),
+        '/api/cloud/me/namespaces/ns-root/enable-ha': () =>
+          jsonResponse({
+            status: 'enabling',
+            namespace_id: 'ns-root',
+            groups: [],
+          }),
+      });
+    });
+    restore = r;
+
+    const res = await enableHaForNamespace(
+      makeJwt({ iss: 'mdma', email: 'u@e' }),
+      'http://node',
+      'ns-root',
+      [
+        { group_id: 'ns-root', context_id: 'ctx-1' },
+        { group_id: 'sub-1', context_id: 'ctx-2' },
+      ],
+    );
+    expect(res.status).toBe('enabling');
+
+    // Order: members must come before any proof; proofs must come
+    // before the claim POST; claim must precede measurements; tee-
+    // policy must precede the final enable.
+    const ordered = (substr: string) =>
+      calls.findIndex((c) => c.includes(substr));
+    expect(ordered('/members')).toBeLessThan(ordered('/issue-ownership-proof'));
+    expect(ordered('/issue-ownership-proof')).toBeLessThan(
+      ordered('/contexts/claim'),
+    );
+    expect(ordered('/contexts/claim')).toBeLessThan(
+      ordered('/fleet/measurements'),
+    );
+    expect(ordered('/fleet/measurements')).toBeLessThan(
+      ordered('/tee-admission-policy'),
+    );
+    expect(ordered('/tee-admission-policy')).toBeLessThan(
+      ordered('/enable-ha'),
+    );
+
+    // Exactly two proof requests (one per group) — parallel, but both
+    // present in the call list.
+    expect(
+      calls.filter((c) => c.includes('/issue-ownership-proof')),
+    ).toHaveLength(2);
+  });
+
+  it('throws a clear error when the MDMA session JWT lacks an identifier', async () => {
+    const { restore: r } = installFetch(() => jsonResponse({}));
+    restore = r;
+    await expect(
+      enableHaForNamespace(
+        makeJwt({ iss: 'mdma' }), // no email, no sub
+        'http://node',
+        'ns-root',
+        [{ group_id: 'g', context_id: 'c' }],
+      ),
+    ).rejects.toThrow(/missing the user identifier/);
+  });
+});

--- a/apps/desktop/src/utils/cloudApi.test.ts
+++ b/apps/desktop/src/utils/cloudApi.test.ts
@@ -435,4 +435,47 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
     ).rejects.toThrow(/Cloud session has expired/);
     expect(calls).toHaveLength(0); // failed fast, no merod/cloud round-trips
   });
+
+  it('throws (and does not enable HA) when the cloud only partially claims', async () => {
+    const seen: string[] = [];
+    const { restore: r } = installFetch((url, init) => {
+      seen.push(url);
+      return route(url, init, {
+        '/admin-api/groups/ns-root/members': () =>
+          jsonResponse({
+            members: [{ identity: 'me', role: 'Admin' }],
+            selfIdentity: 'me',
+          }),
+        '/admin-api/groups/ns-root/issue-ownership-proof': () =>
+          jsonResponse({ signerPublicKey: 'pk', signedPayload: 'sp', signature: 'sig' }),
+        // Submitted ctx-1 + ctx-2, cloud only claims ctx-1.
+        '/api/cloud/me/contexts/claim': () => jsonResponse({ claimed: ['ctx-1'] }),
+      });
+    });
+    restore = r;
+    await expect(
+      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', [
+        { group_id: 'ns-root', context_id: 'ctx-1' },
+        { group_id: 'sub-1', context_id: 'ctx-2' },
+      ]),
+    ).rejects.toThrow(/did not register 1 of 2 context\(s\): ctx-2/);
+    // Must have stopped before the enable-ha / tee-policy steps.
+    expect(seen.some((u) => u.includes('/enable-ha'))).toBe(false);
+    expect(seen.some((u) => u.includes('/tee-admission-policy'))).toBe(false);
+  });
+
+  it('throws a descriptive error (not a raw TypeError) on a malformed member entry', async () => {
+    const { restore: r } = installFetch((url, init) =>
+      route(url, init, {
+        '/admin-api/groups/ns-root/members': () =>
+          jsonResponse({ members: [null], selfIdentity: 'me' }),
+      }),
+    );
+    restore = r;
+    await expect(
+      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', [
+        { group_id: 'g1', context_id: 'ctx-1' },
+      ]),
+    ).rejects.toThrow(/Unexpected response from local node members endpoint/);
+  });
 });

--- a/apps/desktop/src/utils/cloudApi.test.ts
+++ b/apps/desktop/src/utils/cloudApi.test.ts
@@ -464,6 +464,21 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
     expect(seen.some((u) => u.includes('/tee-admission-policy'))).toBe(false);
   });
 
+  it('throws the descriptive error (not a raw SyntaxError) on a non-JSON members body', async () => {
+    const { restore: r } = installFetch((url, init) =>
+      route(url, init, {
+        '/admin-api/groups/ns-root/members': () =>
+          new Response('<html>502 bad gateway</html>', { status: 200 }),
+      }),
+    );
+    restore = r;
+    await expect(
+      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', [
+        { group_id: 'g1', context_id: 'ctx-1' },
+      ]),
+    ).rejects.toThrow(/Unexpected response from local node members endpoint/);
+  });
+
   it('throws a descriptive error (not a raw TypeError) on a malformed member entry', async () => {
     const { restore: r } = installFetch((url, init) =>
       route(url, init, {

--- a/apps/desktop/src/utils/cloudApi.test.ts
+++ b/apps/desktop/src/utils/cloudApi.test.ts
@@ -221,6 +221,43 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
     ).rejects.toThrow(/Only the namespace admin can register contexts/);
   });
 
+  it('gives a distinct error when our identity is not among the members', async () => {
+    const { restore: r } = installFetch((url, init) =>
+      route(url, init, {
+        '/admin-api/groups/ns-root/members': () =>
+          jsonResponse({
+            members: [{ identity: 'someone-else', role: 'Admin' }],
+            selfIdentity: 'me',
+          }),
+      }),
+    );
+    restore = r;
+    await expect(
+      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', [
+        { group_id: 'g1', context_id: 'ctx-1' },
+      ]),
+    ).rejects.toThrow(/Could not determine your role in this namespace/);
+  });
+
+  it('throws (not silent-null → misleading not-admin) on a malformed members body', async () => {
+    // Regression guard for the {data}-envelope bug: a wrong-shaped 200
+    // must surface as a shape error, not masquerade as "not admin".
+    const { restore: r } = installFetch((url, init) =>
+      route(url, init, {
+        '/admin-api/groups/ns-root/members': () =>
+          jsonResponse({
+            data: { data: [{ identity: 'me', role: 'Admin' }], selfIdentity: 'me' },
+          }),
+      }),
+    );
+    restore = r;
+    await expect(
+      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', [
+        { group_id: 'g1', context_id: 'ctx-1' },
+      ]),
+    ).rejects.toThrow(/Unexpected response from local node members endpoint/);
+  });
+
   it('runs members → proofs (parallel) → claim → measurements → tee-policy → enable in order', async () => {
     const calls: string[] = [];
     const { restore: r } = installFetch((url, init) => {

--- a/apps/desktop/src/utils/cloudApi.test.ts
+++ b/apps/desktop/src/utils/cloudApi.test.ts
@@ -27,7 +27,12 @@ function makeJwt(payload: object): string {
   const b64 = (s: string) =>
     btoa(s).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
   const header = b64(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
-  const body = b64(JSON.stringify(payload));
+  // Default to a live (1h) exp so callers that only care about iss/email
+  // still pass enableHaForNamespace's isTokenExpired guard; an explicit
+  // `exp` in `payload` overrides this (spread order).
+  const body = b64(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600, ...payload }),
+  );
   return `${header}.${body}.sig`;
 }
 
@@ -179,9 +184,13 @@ describe('claimContexts', () => {
 describe('enableHaForNamespace silent-claim pre-flight', () => {
   let restore: () => void;
   beforeEach(() => {
-    // Predictable nonce → identical request bodies in assertions.
+    // Deterministic but *distinct per call* — a counter advances each
+    // fill so parallel proof requests get different nonces (a constant
+    // mock would mask a per-batch duplicate-nonce regression).
+    let counter = 0;
     vi.spyOn(crypto, 'getRandomValues').mockImplementation((arr: any) => {
-      for (let i = 0; i < arr.length; i++) arr[i] = i;
+      for (let i = 0; i < arr.length; i++) arr[i] = (counter + i) & 0xff;
+      counter += arr.length;
       return arr;
     });
   });
@@ -329,9 +338,18 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
 
     // Exactly two proof requests (one per group) — parallel, but both
     // present in the call list.
-    expect(
-      calls.filter((c) => c.includes('/issue-ownership-proof')),
-    ).toHaveLength(2);
+    const proofCalls = calls.filter((c) =>
+      c.includes('/issue-ownership-proof'),
+    );
+    expect(proofCalls).toHaveLength(2);
+
+    // *Every* proof call must precede the claim — findIndex only checks
+    // the first, so a bug where one proof lands after the claim would
+    // otherwise slip through.
+    const claimIdx = calls.findIndex((c) => c.includes('/contexts/claim'));
+    for (const pc of proofCalls) {
+      expect(calls.indexOf(pc)).toBeLessThan(claimIdx);
+    }
   });
 
   it('throws a clear error when the MDMA session JWT lacks an identifier', async () => {
@@ -345,5 +363,76 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
         [{ group_id: 'g', context_id: 'c' }],
       ),
     ).rejects.toThrow(/missing the user identifier/);
+  });
+
+  it('issues a distinct nonce per parallel proof request', async () => {
+    const bodies: any[] = [];
+    const { restore: r } = installFetch((url, init) => {
+      if (url.includes('/issue-ownership-proof')) {
+        bodies.push(JSON.parse(String(init?.body)));
+      }
+      return route(url, init, {
+        '/admin-api/groups/ns-root/members': () =>
+          jsonResponse({
+            members: [{ identity: 'me', role: 'Admin' }],
+            selfIdentity: 'me',
+          }),
+        '/admin-api/groups/ns-root/issue-ownership-proof': () =>
+          jsonResponse({
+            signerPublicKey: 'pk',
+            signedPayload: 'sp',
+            signature: 'sig',
+          }),
+        '/api/cloud/me/contexts/claim': () =>
+          jsonResponse({ claimed: ['ctx-1', 'ctx-2'] }),
+        '/api/cloud/fleet/measurements': () =>
+          jsonResponse({
+            release_tag: 'v1',
+            allowed_mrtd: ['mrtd-1'],
+            allowed_rtmr0: [],
+            allowed_rtmr1: [],
+            allowed_rtmr2: [],
+            allowed_rtmr3: [],
+          }),
+        '/admin-api/groups/ns-root/settings/tee-admission-policy': () =>
+          new Response('{}', { status: 200 }),
+        '/api/cloud/me/namespaces/ns-root/enable-ha': () =>
+          jsonResponse({ status: 'enabling', namespace_id: 'ns-root', groups: [] }),
+      });
+    });
+    restore = r;
+    await enableHaForNamespace(
+      makeJwt({ iss: 'mdma', email: 'u@e' }),
+      'http://node',
+      'ns-root',
+      [
+        { group_id: 'ns-root', context_id: 'ctx-1' },
+        { group_id: 'sub-1', context_id: 'ctx-2' },
+      ],
+    );
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0].nonce).not.toBe(bodies[1].nonce);
+    for (const b of bodies) expect(b.nonce).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('rejects a non-MDMA or expired session token before any network call', async () => {
+    const { calls, restore: r } = installFetch(() => jsonResponse({}));
+    restore = r;
+    // iss != "mdma"
+    await expect(
+      enableHaForNamespace(makeJwt({ iss: 'google', email: 'u@e' }), 'http://node', 'ns', [
+        { group_id: 'g', context_id: 'c' },
+      ]),
+    ).rejects.toThrow(/Not signed in to Calimero Cloud/);
+    // mdma but expired
+    await expect(
+      enableHaForNamespace(
+        makeJwt({ iss: 'mdma', email: 'u@e', exp: Math.floor(Date.now() / 1000) - 10 }),
+        'http://node',
+        'ns',
+        [{ group_id: 'g', context_id: 'c' }],
+      ),
+    ).rejects.toThrow(/Cloud session has expired/);
+    expect(calls).toHaveLength(0); // failed fast, no merod/cloud round-trips
   });
 });

--- a/apps/desktop/src/utils/cloudApi.test.ts
+++ b/apps/desktop/src/utils/cloudApi.test.ts
@@ -68,11 +68,9 @@ describe('requestOwnershipProof', () => {
   it('POSTs camelCase body to merod and re-keys camelCase response to snake_case', async () => {
     const { calls, restore: r } = installFetch(() =>
       jsonResponse({
-        data: {
-          signerPublicKey: 'pk-base58',
-          signedPayload: 'sp-b64',
-          signature: 'sig-b64',
-        },
+        signerPublicKey: 'pk-base58',
+        signedPayload: 'sp-b64',
+        signature: 'sig-b64',
       }),
     );
     restore = r;
@@ -103,7 +101,7 @@ describe('requestOwnershipProof', () => {
   });
 
   it('throws when the merod response is malformed', async () => {
-    const { restore: r } = installFetch(() => jsonResponse({ data: {} }));
+    const { restore: r } = installFetch(() => jsonResponse({}));
     restore = r;
     await expect(
       requestOwnershipProof('http://node', 'group-1', {
@@ -210,10 +208,8 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
       route(url, init, {
         '/admin-api/groups/ns-root/members': () =>
           jsonResponse({
-            data: {
-              data: [{ identity: 'me', role: 'Member' }],
-              selfIdentity: 'me',
-            },
+            members: [{ identity: 'me', role: 'Member' }],
+            selfIdentity: 'me',
           }),
       }),
     );
@@ -232,18 +228,14 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
       return route(url, init, {
         '/admin-api/groups/ns-root/members': () =>
           jsonResponse({
-            data: {
-              data: [{ identity: 'me', role: 'Admin' }],
-              selfIdentity: 'me',
-            },
+            members: [{ identity: 'me', role: 'Admin' }],
+            selfIdentity: 'me',
           }),
         '/admin-api/groups/ns-root/issue-ownership-proof': () =>
           jsonResponse({
-            data: {
-              signerPublicKey: 'pk',
-              signedPayload: 'sp',
-              signature: 'sig',
-            },
+            signerPublicKey: 'pk',
+            signedPayload: 'sp',
+            signature: 'sig',
           }),
         '/api/cloud/me/contexts/claim': () =>
           jsonResponse({ claimed: ['ctx-1', 'ctx-2'] }),

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -1,6 +1,6 @@
 import { getAccessToken } from '../lib/token-storage';
 import { getSettings, saveSettings } from './settings';
-import { isMdmaSessionToken, isTokenExpired } from './jwt';
+import { isMdmaSessionToken, isTokenExpired, parseJwtPayload } from './jwt';
 
 // API lives at manager.cloud.calimero.network; cloud.calimero.network is
 // the static portal and does not proxy /api/*. Exported so cloudAuth
@@ -311,15 +311,205 @@ export async function setTeeAdmissionPolicy(
   }
 }
 
+// ── Cloud claim (silent context registration) ──
+
+/**
+ * An ownership proof issued by the local merod for a single context.
+ * The triplet is opaque to the desktop — it round-trips through the
+ * cloud's claim endpoint, which forwards it to a verifier that checks
+ * the signature against the registered group signing key.
+ *
+ * Field names are snake_case because this object is embedded into the
+ * cloud /api/cloud/me/contexts/claim request body. Merod's admin API
+ * returns the same triplet in camelCase (see requestOwnershipProof
+ * below) and we re-key on the way out.
+ */
+export interface OwnershipProof {
+  signer_public_key: string;
+  signed_payload: string;
+  signature: string;
+}
+
+export interface ClaimedContext {
+  context_id: string;
+  ownership_proof: OwnershipProof;
+}
+
+interface IssueOwnershipProofResponseData {
+  signerPublicKey: string;
+  signedPayload: string;
+  signature: string;
+}
+
+interface GroupMemberEntry {
+  identity: string;
+  role: string;
+}
+
+interface ListGroupMembersData {
+  data: GroupMemberEntry[];
+  selfIdentity?: string;
+}
+
+/**
+ * Generate a 32-char hex nonce (16 random bytes). Used as the
+ * audience-binding nonce on the local ownership-proof request — the
+ * merod handler echoes it back inside `signed_payload` so the cloud
+ * verifier can confirm we didn't replay an old proof.
+ */
+function generateProofNonce(): string {
+  const buf = new Uint8Array(16);
+  crypto.getRandomValues(buf);
+  return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Look up the caller's role in a group via the merod admin API.
+ * Returns `null` if the caller isn't a member (selfIdentity missing
+ * or no matching entry). The members endpoint follows the same
+ * Bearer-auth + camelCase response pattern as setTeeAdmissionPolicy.
+ *
+ * Co-located here rather than in a dedicated admin-api module because
+ * this is the only consumer right now — the moment a second caller
+ * appears, lift it out.
+ */
+async function getSelfRoleInGroup(
+  nodeUrl: string,
+  groupId: string,
+): Promise<string | null> {
+  const accessToken = getAccessToken();
+  if (!accessToken) {
+    throw new Error('Not authenticated to local node — sign in first');
+  }
+  const res = await fetch(
+    `${nodeUrl}/admin-api/groups/${encodeURIComponent(groupId)}/members`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Failed to list group members: ${text || res.statusText}`);
+  }
+  // Admin endpoints wrap the payload as `{ data: ... }`; here the
+  // inner object is `{ data: GroupMember[], selfIdentity? }`.
+  const body = (await res.json()) as { data?: ListGroupMembersData };
+  const payload = body?.data;
+  if (!payload || !Array.isArray(payload.data) || !payload.selfIdentity) {
+    return null;
+  }
+  const me = payload.data.find((m) => m.identity === payload.selfIdentity);
+  return me?.role ?? null;
+}
+
+/**
+ * Ask the local merod to issue a signed ownership proof for a context
+ * scoped to the given group. The proof is bound to {audience, subject,
+ * nonce, expiresAtMs} so a leaked proof can't be replayed against a
+ * different cloud user or after a short window.
+ *
+ * Returns the wire-snake-case triplet the cloud claim endpoint expects;
+ * the camelCase merod response is re-keyed inline. Note expiresAtMs is
+ * a *requested* expiry — the merod handler clamps to now+5min server
+ * side, so a generous client value is harmless. We ask for 60s to keep
+ * the window small.
+ */
+export async function requestOwnershipProof(
+  nodeUrl: string,
+  groupId: string,
+  opts: { contextId: string; subject: string },
+): Promise<OwnershipProof> {
+  const accessToken = getAccessToken();
+  if (!accessToken) {
+    throw new Error('Not authenticated to local node — sign in first');
+  }
+  const nonce = generateProofNonce();
+  const expiresAtMs = Date.now() + 60_000;
+  const res = await fetch(
+    `${nodeUrl}/admin-api/groups/${encodeURIComponent(groupId)}/issue-ownership-proof`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        // Same camelCase contract as setTeeAdmissionPolicy: the merod
+        // admin types deserialise with #[serde(rename_all = "camelCase")].
+        // The literal audience "mdma:claim-context" is part of the
+        // proof-binding agreed with the cloud verifier.
+        audience: 'mdma:claim-context',
+        contextId: opts.contextId,
+        subject: opts.subject,
+        nonce,
+        expiresAtMs,
+      }),
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Failed to issue ownership proof: ${text || res.statusText}`);
+  }
+  const body = (await res.json()) as { data?: IssueOwnershipProofResponseData };
+  const data = body?.data;
+  if (
+    !data ||
+    typeof data.signerPublicKey !== 'string' ||
+    typeof data.signedPayload !== 'string' ||
+    typeof data.signature !== 'string'
+  ) {
+    throw new Error('Malformed ownership proof response from local node');
+  }
+  // Re-key camelCase → snake_case for the cloud request.
+  return {
+    signer_public_key: data.signerPublicKey,
+    signed_payload: data.signedPayload,
+    signature: data.signature,
+  };
+}
+
+/**
+ * Submit a batch of ownership proofs to the cloud so the contexts get
+ * recorded against the caller's MDMA user. Single batched call instead
+ * of one POST per context — the cloud verifier is the bottleneck and
+ * each proof is independent.
+ *
+ * 403 responses include `{detail: "Ownership proof failed: <reason>"}`;
+ * surface the detail string verbatim so the failure reason (signer
+ * mismatch, expired nonce, ...) reaches the operator.
+ */
+export async function claimContexts(
+  idToken: string,
+  claims: ClaimedContext[],
+): Promise<string[]> {
+  const res = await cloudFetch('/api/cloud/me/contexts/claim', idToken, {
+    method: 'POST',
+    body: JSON.stringify({ claims }),
+  });
+  if (!res.ok) {
+    const error = await res.json().catch(() => null);
+    throw new Error(error?.detail || 'Failed to claim contexts with cloud');
+  }
+  const body = (await res.json()) as { claimed?: string[] };
+  return Array.isArray(body?.claimed) ? body.claimed : [];
+}
+
 /**
  * Enable HA end-to-end for a namespace:
- * 1. Fetch fleet measurements from cloud once (trusted MRTD values).
- * 2. Set the TEE admission policy on the *namespace root only*. Subgroup
+ * 1. Pre-flight: verify caller is namespace Admin and silently register
+ *    each group's representative context with the cloud (so the
+ *    subsequent enableHaNamespace call doesn't reject with
+ *    "Contexts not found or not owned by user").
+ * 2. Fetch fleet measurements from cloud once (trusted MRTD values).
+ * 3. Set the TEE admission policy on the *namespace root only*. Subgroup
  *    policies are ignored by core (namespace-scoped since rc.29 /
  *    calimero-network/core#2188) — applying them would error. Auto-follow
  *    propagates fleet-node membership into subgroups without a second
  *    admission check.
- * 3. Register the namespace with cloud. MDMA still needs the full group
+ * 4. Register the namespace with cloud. MDMA still needs the full group
  *    list for billing + per-group status rows until the server-side
  *    flattening lands, so the caller keeps enumerating groups.
  */
@@ -333,6 +523,53 @@ export async function enableHaForNamespace(
     throw new Error('Namespace has no groups to enable HA on');
   }
 
+  // ── Step 1: silent claim ──
+  // The MDMA session JWT carries the user's email in `sub` (and/or
+  // `email`); the cloud verifier uses it to bind the ownership proof
+  // to a specific MDMA account. We don't decode via decodeIdToken from
+  // cloudAuth.ts because that would reintroduce the cloudApi → cloudAuth
+  // import cycle the codebase explicitly avoids (see jwt.ts header).
+  const payload = parseJwtPayload(idToken);
+  const subject =
+    typeof payload?.email === 'string' && payload.email
+      ? (payload.email as string)
+      : typeof payload?.sub === 'string'
+        ? (payload.sub as string)
+        : null;
+  if (!subject) {
+    throw new Error('Cloud session is missing the user identifier — reconnect in Settings');
+  }
+
+  // Pre-flight role check on the namespace root. Only the admin can
+  // hand out ownership proofs that the cloud verifier will accept —
+  // bailing early gives a clear error rather than a confusing 403
+  // later when the cloud rejects every proof in the batch.
+  // Wire format is locked: GroupMemberRole in core serialises as
+  // {Admin, Member, ReadOnly, ReadOnlyTee}. We require Admin only.
+  const role = await getSelfRoleInGroup(nodeUrl, namespaceId);
+  if (role !== 'Admin') {
+    throw new Error('Only the namespace admin can register contexts with the cloud.');
+  }
+
+  // Issue one proof per group in parallel — they hit the local merod
+  // and are independent, so latency stacks linearly otherwise.
+  const proofs = await Promise.all(
+    groups.map((g) =>
+      requestOwnershipProof(nodeUrl, namespaceId, {
+        contextId: g.context_id,
+        subject,
+      }).then<ClaimedContext>((proof) => ({
+        context_id: g.context_id,
+        ownership_proof: proof,
+      })),
+    ),
+  );
+
+  // Single batched submit. Errors propagate to the caller (Namespaces
+  // page surfaces via toast).
+  await claimContexts(idToken, proofs);
+
+  // ── Step 2–4: existing flow ──
   const measurements = await getFleetMeasurements(idToken);
   if (!measurements.allowed_mrtd.length) {
     throw new Error('No fleet MRTD measurements available — cannot set admission policy');

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -540,17 +540,31 @@ export async function enableHaForNamespace(
   }
 
   // ── Step 1: silent claim ──
-  // The MDMA session JWT carries the user's email in `sub` (and/or
-  // `email`); the cloud verifier uses it to bind the ownership proof
-  // to a specific MDMA account. We don't decode via decodeIdToken from
-  // cloudAuth.ts because that would reintroduce the cloudApi → cloudAuth
-  // import cycle the codebase explicitly avoids (see jwt.ts header).
+  // The cloud verifier is the authoritative trust boundary: it re-checks
+  // the proof signature and that the proof's subject == the authenticated
+  // bearer's MDMA account. Validating the token shape here is defence-in-
+  // depth + fail-fast — refuse to spend local merod round-trips (role
+  // check + N proof issuances) on a token the cloud will reject anyway.
+  if (!isMdmaSessionToken(idToken)) {
+    throw new Error('Not signed in to Calimero Cloud — connect in Settings');
+  }
+  if (isTokenExpired(idToken)) {
+    throw new Error('Cloud session has expired — reconnect in Settings');
+  }
+
+  // mdma binds the proof to the account *email* (its verifier compares
+  // the proof subject against the authenticated user's email), so prefer
+  // `email`; MDMA session tokens may also carry it in `sub`. We don't
+  // decode via decodeIdToken from cloudAuth.ts because that would
+  // reintroduce the cloudApi → cloudAuth import cycle the codebase
+  // explicitly avoids (see jwt.ts header). The typeof guards already
+  // narrow to string, so no casts are needed.
   const payload = parseJwtPayload(idToken);
   const subject =
     typeof payload?.email === 'string' && payload.email
-      ? (payload.email as string)
-      : typeof payload?.sub === 'string'
-        ? (payload.sub as string)
+      ? payload.email
+      : typeof payload?.sub === 'string' && payload.sub
+        ? payload.sub
         : null;
   if (!subject) {
     throw new Error('Cloud session is missing the user identifier — reconnect in Settings');

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -365,9 +365,16 @@ function generateProofNonce(): string {
 
 /**
  * Look up the caller's role in a group via the merod admin API.
- * Returns `null` if the caller isn't a member (selfIdentity missing
- * or no matching entry). The members endpoint follows the same
- * Bearer-auth + camelCase response pattern as setTeeAdmissionPolicy.
+ *
+ * Throws on auth failure, a non-2xx response (core's actor bails with
+ * an error when the node isn't a member of the group, so "not a
+ * member" surfaces here as a thrown error, not `null`), or a 200 whose
+ * body doesn't match the expected `{ members, selfIdentity }` shape —
+ * a silent `null` on a malformed body would later masquerade as "not
+ * the namespace admin", which is exactly the failure mode that masked
+ * the earlier `{data}`-envelope bug. Returns `null` only for the
+ * degenerate case of a well-formed response with no member entry
+ * matching `selfIdentity`.
  *
  * Co-located here rather than in a dedicated admin-api module because
  * this is the only consumer right now — the moment a second caller
@@ -402,7 +409,11 @@ async function getSelfRoleInGroup(
   // ListGroupMembersApiResponse has #[serde(rename_all = "camelCase")].
   const body = (await res.json()) as ListGroupMembersResponse;
   if (!body || !Array.isArray(body.members) || !body.selfIdentity) {
-    return null;
+    throw new Error(
+      'Unexpected response from local node members endpoint — ' +
+        'expected { members: [...], selfIdentity }. The node may be ' +
+        'an incompatible version.',
+    );
   }
   const me = body.members.find((m) => m.identity === body.selfIdentity);
   return me?.role ?? null;
@@ -552,12 +563,39 @@ export async function enableHaForNamespace(
   // Wire format is locked: GroupMemberRole in core serialises as
   // {Admin, Member, ReadOnly, ReadOnlyTee}. We require Admin only.
   const role = await getSelfRoleInGroup(nodeUrl, namespaceId);
+  if (role === null) {
+    // Well-formed response but our identity isn't among the members —
+    // distinct from "you're a Member not an Admin": this usually means
+    // the node isn't actually joined to this namespace root.
+    throw new Error(
+      'Could not determine your role in this namespace — ' +
+        'the node does not appear to be a member of the namespace root.',
+    );
+  }
   if (role !== 'Admin') {
     throw new Error('Only the namespace admin can register contexts with the cloud.');
   }
 
+  // Every proof is scoped to the *namespace root* (`namespaceId`), not
+  // each group's own `group_id`, even for contexts that live in
+  // subgroups. This is deliberate and consistent across the three
+  // coordinated repos:
+  //   • The ownership gate is "direct admin of the namespace root"
+  //     (the role check above), so the root is the authoritative
+  //     scope for the whole namespace.
+  //   • core's resolve_group_signing_key walks ancestors, so the
+  //     root's signing key signs proofs for subgroup contexts too.
+  //   • core's context↔namespace containment check (calimero#2362)
+  //     accepts any context within the namespace rooted at this
+  //     group_id — a strict per-group equality check would reject
+  //     subgroup contexts here.
+  // Same rationale as the "set TEE policy on the root only, subgroups
+  // inherit" step further below.
+  //
   // Issue one proof per group in parallel — they hit the local merod
-  // and are independent, so latency stacks linearly otherwise.
+  // and are independent, so latency stacks linearly otherwise. Note
+  // Promise.all is all-or-nothing: a single proof failure aborts the
+  // whole HA-enable and the user retries the flow.
   const proofs = await Promise.all(
     groups.map((g) =>
       requestOwnershipProof(nodeUrl, namespaceId, {

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -566,22 +566,26 @@ export async function enableHaForNamespace(
     throw new Error('Cloud session has expired — reconnect in Settings');
   }
 
-  // mdma binds the proof to the account *email* (its verifier compares
-  // the proof subject against the authenticated user's email), so prefer
-  // `email`; MDMA session tokens may also carry it in `sub`. We don't
-  // decode via decodeIdToken from cloudAuth.ts because that would
-  // reintroduce the cloudApi → cloudAuth import cycle the codebase
-  // explicitly avoids (see jwt.ts header). The typeof guards already
-  // narrow to string, so no casts are needed.
+  // mdma's verifier compares the proof subject against the authenticated
+  // user's *email*, so the subject must be email-shaped. Prefer the
+  // `email` claim; accept `sub` only when it is itself an email (some
+  // MDMA tokens duplicate it there). A non-email `sub` (opaque user id)
+  // would otherwise produce a confusing cloud subject-mismatch later, so
+  // fail clearly here instead. We don't decode via decodeIdToken from
+  // cloudAuth.ts (would reintroduce the cloudApi → cloudAuth import
+  // cycle the codebase avoids — see jwt.ts header).
   const payload = parseJwtPayload(idToken);
-  const subject =
-    typeof payload?.email === 'string' && payload.email
-      ? payload.email
-      : typeof payload?.sub === 'string' && payload.sub
-        ? payload.sub
-        : null;
+  const emailClaim = typeof payload?.email === 'string' ? payload.email : '';
+  const subClaim = typeof payload?.sub === 'string' ? payload.sub : '';
+  const subject = emailClaim.includes('@')
+    ? emailClaim
+    : subClaim.includes('@')
+      ? subClaim
+      : null;
   if (!subject) {
-    throw new Error('Cloud session is missing the user identifier — reconnect in Settings');
+    throw new Error(
+      'Cloud session is missing the user identifier (no account email) — reconnect in Settings',
+    );
   }
 
   // Pre-flight role check on the namespace root. Only the admin can
@@ -643,12 +647,14 @@ export async function enableHaForNamespace(
   // later as a confusing "context not owned" failure.
   const claimed = await claimContexts(idToken, proofs);
   const claimedSet = new Set(claimed);
-  const missing = proofs
-    .map((p) => p.context_id)
-    .filter((id) => !claimedSet.has(id));
+  // Compare against *unique* submitted ids — duplicate context_ids in
+  // `groups` would otherwise count a single cloud-claimed id as multiple
+  // "missing" entries and falsely abort.
+  const submitted = [...new Set(proofs.map((p) => p.context_id))];
+  const missing = submitted.filter((id) => !claimedSet.has(id));
   if (missing.length > 0) {
     throw new Error(
-      `Cloud did not register ${missing.length} of ${proofs.length} ` +
+      `Cloud did not register ${missing.length} of ${submitted.length} ` +
         `context(s): ${missing.join(', ')}. HA was not enabled.`,
     );
   }

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -407,22 +407,29 @@ async function getSelfRoleInGroup(
   // `//TODO add data to response`). The members payload is
   // `{ members, selfIdentity }`; selfIdentity is camelCase because
   // ListGroupMembersApiResponse has #[serde(rename_all = "camelCase")].
-  const body = (await res.json()) as ListGroupMembersResponse;
-  const shapeOk =
-    body &&
-    Array.isArray(body.members) &&
-    typeof body.selfIdentity === 'string' &&
-    body.selfIdentity &&
-    // Each entry must be a well-formed { identity, role }; a `null` or
-    // partial entry would otherwise blow up the `.find` below with a
-    // raw TypeError instead of this descriptive error.
-    body.members.every(
+  // A non-JSON body parses to null here (not a throw), so the shapeOk
+  // check below produces the descriptive error rather than a raw
+  // SyntaxError escaping as an unhandled rejection.
+  const body = (await res
+    .json()
+    .catch(() => null)) as ListGroupMembersResponse | null;
+  // Negated inline guard (not a separate `shapeOk` const) so TS narrows
+  // `body` to non-null afterwards. Each member entry must be a
+  // well-formed { identity, role } — a `null`/partial entry would
+  // otherwise blow up the `.find` below with a raw TypeError instead of
+  // this descriptive error.
+  if (
+    !body ||
+    !Array.isArray(body.members) ||
+    typeof body.selfIdentity !== 'string' ||
+    !body.selfIdentity ||
+    !body.members.every(
       (m) =>
         m != null &&
         typeof m.identity === 'string' &&
         typeof m.role === 'string',
-    );
-  if (!shapeOk) {
+    )
+  ) {
     throw new Error(
       'Unexpected response from local node members endpoint — ' +
         'expected { members: [{ identity, role }], selfIdentity }. ' +
@@ -523,7 +530,10 @@ export async function claimContexts(
     const error = await res.json().catch(() => null);
     throw new Error(error?.detail || 'Failed to claim contexts with cloud');
   }
-  const body = (await res.json()) as { claimed?: string[] };
+  // Tolerate a 2xx with an empty/non-JSON body (e.g. 204): fall back to
+  // {} so the caller's claim-coverage check reports a meaningful
+  // "did not register" error instead of a raw JSON SyntaxError.
+  const body = (await res.json().catch(() => ({}))) as { claimed?: string[] };
   return Array.isArray(body?.claimed) ? body.claimed : [];
 }
 

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -408,11 +408,25 @@ async function getSelfRoleInGroup(
   // `{ members, selfIdentity }`; selfIdentity is camelCase because
   // ListGroupMembersApiResponse has #[serde(rename_all = "camelCase")].
   const body = (await res.json()) as ListGroupMembersResponse;
-  if (!body || !Array.isArray(body.members) || !body.selfIdentity) {
+  const shapeOk =
+    body &&
+    Array.isArray(body.members) &&
+    typeof body.selfIdentity === 'string' &&
+    body.selfIdentity &&
+    // Each entry must be a well-formed { identity, role }; a `null` or
+    // partial entry would otherwise blow up the `.find` below with a
+    // raw TypeError instead of this descriptive error.
+    body.members.every(
+      (m) =>
+        m != null &&
+        typeof m.identity === 'string' &&
+        typeof m.role === 'string',
+    );
+  if (!shapeOk) {
     throw new Error(
       'Unexpected response from local node members endpoint — ' +
-        'expected { members: [...], selfIdentity }. The node may be ' +
-        'an incompatible version.',
+        'expected { members: [{ identity, role }], selfIdentity }. ' +
+        'The node may be an incompatible version.',
     );
   }
   const me = body.members.find((m) => m.identity === body.selfIdentity);
@@ -623,8 +637,21 @@ export async function enableHaForNamespace(
   );
 
   // Single batched submit. Errors propagate to the caller (Namespaces
-  // page surfaces via toast).
-  await claimContexts(idToken, proofs);
+  // page surfaces via toast). Verify the cloud actually recorded every
+  // context we submitted — a partial `claimed[]` would otherwise let HA
+  // proceed for groups whose contexts were never registered, surfacing
+  // later as a confusing "context not owned" failure.
+  const claimed = await claimContexts(idToken, proofs);
+  const claimedSet = new Set(claimed);
+  const missing = proofs
+    .map((p) => p.context_id)
+    .filter((id) => !claimedSet.has(id));
+  if (missing.length > 0) {
+    throw new Error(
+      `Cloud did not register ${missing.length} of ${proofs.length} ` +
+        `context(s): ${missing.join(', ')}. HA was not enabled.`,
+    );
+  }
 
   // ── Step 2–4: existing flow ──
   const measurements = await getFleetMeasurements(idToken);

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -346,8 +346,8 @@ interface GroupMemberEntry {
   role: string;
 }
 
-interface ListGroupMembersData {
-  data: GroupMemberEntry[];
+interface ListGroupMembersResponse {
+  members: GroupMemberEntry[];
   selfIdentity?: string;
 }
 
@@ -394,14 +394,17 @@ async function getSelfRoleInGroup(
     const text = await res.text().catch(() => '');
     throw new Error(`Failed to list group members: ${text || res.statusText}`);
   }
-  // Admin endpoints wrap the payload as `{ data: ... }`; here the
-  // inner object is `{ data: GroupMember[], selfIdentity? }`.
-  const body = (await res.json()) as { data?: ListGroupMembersData };
-  const payload = body?.data;
-  if (!payload || !Array.isArray(payload.data) || !payload.selfIdentity) {
+  // Core's ApiResponse serializes the payload struct directly — there is
+  // no `{ data: ... }` envelope (see ApiResponse::into_response in
+  // calimero-network/core crates/server/src/admin/service.rs, with its
+  // `//TODO add data to response`). The members payload is
+  // `{ members, selfIdentity }`; selfIdentity is camelCase because
+  // ListGroupMembersApiResponse has #[serde(rename_all = "camelCase")].
+  const body = (await res.json()) as ListGroupMembersResponse;
+  if (!body || !Array.isArray(body.members) || !body.selfIdentity) {
     return null;
   }
-  const me = payload.data.find((m) => m.identity === payload.selfIdentity);
+  const me = body.members.find((m) => m.identity === body.selfIdentity);
   return me?.role ?? null;
 }
 
@@ -453,8 +456,10 @@ export async function requestOwnershipProof(
     const text = await res.text().catch(() => '');
     throw new Error(`Failed to issue ownership proof: ${text || res.statusText}`);
   }
-  const body = (await res.json()) as { data?: IssueOwnershipProofResponseData };
-  const data = body?.data;
+  // No `{ data: ... }` envelope — ApiResponse serializes the payload
+  // struct directly and IssueOwnershipProofApiResponse has no `data`
+  // field. Keys are camelCase (#[serde(rename_all = "camelCase")]).
+  const data = (await res.json()) as IssueOwnershipProofResponseData;
   if (
     !data ||
     typeof data.signerPublicKey !== 'string' ||

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.10.1-rc.37"
+    "version": "0.10.1-rc.38"
 }


### PR DESCRIPTION
## Summary

Wires the desktop's `enableHaForNamespace` to register self-hosted contexts with the cloud before the existing HA-enable call. This closes #73 from the client side.

**Before:** clicking "Enable HA" on any namespace whose contexts came from the locally-bundled merod (i.e. every desktop user today) returned `Contexts not found or not owned by user: <ctx_id>` from mdma.

**Now:** `enableHaForNamespace` does, in order:
1. Decodes user identifier (`email` → `sub` fallback) from the MDMA session JWT.
2. Pre-flights an Admin-role check against the namespace root via `GET /admin-api/groups/{id}/members`. Bails with `"Only the namespace admin can register contexts with the cloud."` if the caller is not Admin.
3. Issues one ownership proof per representative group in parallel against the local merod (`POST /admin-api/groups/{id}/issue-ownership-proof`, 60s requested expiry — server clamps to 5min).
4. Batched `POST /api/cloud/me/contexts/claim` to mdma; surfaces the `{detail}` string verbatim on 403 so the error reaches the toast.
5. Existing steps: fleet measurements → `setTeeAdmissionPolicy` → `enableHaNamespace`.

**Coordinated PRs:**
- core: [calimero-network/core#2362](https://github.com/calimero-network/core/pull/2362) — issue-ownership-proof endpoint
- mdma: [calimero-network/mdma#100](https://github.com/calimero-network/mdma/pull/100) — claim endpoint + verification
- **this PR** — desktop integration

This is the silent-auto-claim shape per the design discussion on #73: no new UI, errors flow through the existing toast path. Trust model is signed-proof (Admin on local node → ed25519 sig with group signing key); mdma never trusts on assertion alone.

## Wire surfaces

- New types `OwnershipProof`, `ClaimedContext` (snake_case to match the cloud wire keys).
- New functions in `apps/desktop/src/utils/cloudApi.ts`:
  - `requestOwnershipProof(nodeUrl, groupId, { contextId, subject })` — camelCase merod request, re-keys camelCase response to snake_case.
  - `claimContexts(idToken, claims)` — cloud submit via existing `cloudFetch`.
  - `getSelfRoleInGroup(nodeUrl, groupId)` — Admin pre-flight helper.
  - `generateProofNonce` — `crypto.getRandomValues(new Uint8Array(16))` → hex.

## Test plan

- [x] `pnpm exec tsc` in `apps/desktop` — clean
- [x] `pnpm test:unit` — 26/26 pass including 8 new in `cloudApi.test.ts`:
  - camelCase ↔ snake_case re-key
  - 403 detail surfacing
  - non-admin failure with exact error string
  - JWT missing `email` falls back to `sub`
  - JWT with neither errors clearly
  - full call ordering (members → proofs → claim → measurements → tee-policy → enable-ha)
- [x] Manual repro from #73 — once core + mdma PRs are buildable together:
  - Fresh onboard, create local node, complete cloud login
  - Create a namespace + context locally
  - Toggle HA → no longer rejected, dashboard at cloud.calimero.network shows the group

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the namespace HA enable flow to add new local-node and cloud API calls (members lookup, ownership-proof issuance, context claiming) and new JWT-claim parsing/validation; failures could block HA enablement if server contracts differ.
> 
> **Overview**
> `enableHaForNamespace` now performs a **silent context-registration preflight** before enabling HA: it validates the MDMA session token (issuer/expiry), derives an email subject from the JWT, verifies the caller is `Admin` on the namespace root via the local node members endpoint, requests per-context ownership proofs from the local node (with per-request nonces), and batch-claims those contexts in the cloud; it aborts early on partial claims or malformed responses.
> 
> Adds new cloud/local API helpers and wire types (`OwnershipProof`, `ClaimedContext`, `requestOwnershipProof`, `claimContexts`, `getSelfRoleInGroup`, nonce generation) plus comprehensive unit tests covering request/response keying, error surfacing, call ordering, and fail-fast behavior. Updates bundled `merod` version to `0.10.1-rc.38`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e66b40b7cb04bd12cf8e0f3bc5946b9e1ad31e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->