### PR TITLE
chore: bump tauri app to v0.0.35 and merod core to 0.10.1-rc.39

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.34"
+    "version": "0.0.35"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.10.1-rc.38"
+    "version": "0.10.1-rc.39"
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version bumps only; behavior changes, if any, come from the updated `merod` binary version rather than code changes in this repo.
> 
> **Overview**
> Bumps the Tauri desktop app package version from `0.0.34` to `0.0.35`.
> 
> Updates `merod-config.json` to use `merod` core `0.10.1-rc.39` (from `0.10.1-rc.38`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe134044440a45ae5c64f7e9fecb72a1cf8cbce3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->