### PR TITLE
spike: enable HA on a namespace with no context

### DIFF
--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -108,7 +108,10 @@ async function findRepresentativeHaGroup(
   // re-probe it in the fallback.
   const subgroups = allGroups.filter((g) => g.groupId !== namespaceId);
   if (!subgroups.length) {
-    throw new Error("This namespace has no groups");
+    // SPIKE: allow HA-enable on a namespace with no context
+    // A fresh namespace has only the root group and no contexts. Don't
+    // throw — fall through to the root-group-only representative below.
+    return { group_id: namespaceId, context_id: "" };
   }
 
   for (let i = 0; i < subgroups.length; i += PROBE_BATCH_SIZE) {
@@ -137,7 +140,12 @@ async function findRepresentativeHaGroup(
     if (found) return found;
   }
 
-  throw new Error("No group in this namespace has a context yet");
+  // SPIKE: allow HA-enable on a namespace with no context
+  // No group has a context yet. Instead of throwing (which gated the
+  // Enable-HA button), return a root-group-only representative. The root
+  // group id == namespaceId; core admits a ReadOnlyTee fleet member there
+  // with zero contexts and auto-follows contexts created later.
+  return { group_id: namespaceId, context_id: "" };
 }
 
 export default function Namespaces() {

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -559,9 +559,14 @@ export async function enableHaForNamespace(
   namespaceId: string,
   groups: NamespaceHaGroup[],
 ): Promise<EnableHaNamespaceResponse> {
-  if (groups.length === 0) {
-    throw new Error('Namespace has no groups to enable HA on');
-  }
+  // SPIKE: allow HA-enable on a namespace with no context
+  // When the namespace has no groups, or no group has a real context yet,
+  // there is nothing to take an ownership proof for / claim with the cloud.
+  // Core can still admit a ReadOnlyTee fleet member at the root group
+  // (group_id == namespaceId) with zero contexts and auto-follow contexts
+  // created later, so skip the claim block entirely and register the
+  // namespace with a single root-group-only entry.
+  const hasRealContext = groups.some((g) => !!g.context_id);
 
   // ── Step 1: silent claim ──
   // The cloud verifier is the authoritative trust boundary: it re-checks
@@ -618,6 +623,11 @@ export async function enableHaForNamespace(
     throw new Error('Only the namespace admin can register contexts with the cloud.');
   }
 
+  // SPIKE: allow HA-enable on a namespace with no context
+  // Skip the ownership-proof + claimContexts block when there is nothing
+  // to claim. The Admin role check above still gates the operation, and
+  // the fleet-measurement + admission-policy steps below still run.
+  if (hasRealContext) {
   // Every proof is scoped to the *namespace root* (`namespaceId`), not
   // each group's own `group_id`, even for contexts that live in
   // subgroups. This is deliberate and consistent across the three
@@ -668,6 +678,7 @@ export async function enableHaForNamespace(
         `context(s): ${missing.join(', ')}. HA was not enabled.`,
     );
   }
+  } // SPIKE: allow HA-enable on a namespace with no context (end claim block)
 
   // ── Step 2–4: existing flow ──
   const measurements = await getFleetMeasurements(idToken);
@@ -679,7 +690,15 @@ export async function enableHaForNamespace(
   // there and only there — subgroups inherit it via resolve-to-root.
   await setTeeAdmissionPolicy(nodeUrl, namespaceId, measurements.allowed_mrtd);
 
-  return enableHaNamespace(idToken, namespaceId, groups);
+  // SPIKE: allow HA-enable on a namespace with no context
+  // With no real context, register the namespace with one root-group-only
+  // entry (group_id == namespaceId == the root group id, empty context_id).
+  // Core admits a ReadOnlyTee fleet member at the root and auto-follows
+  // contexts created later.
+  const haGroups: NamespaceHaGroup[] = hasRealContext
+    ? groups
+    : [{ group_id: namespaceId, context_id: '' }];
+  return enableHaNamespace(idToken, namespaceId, haGroups);
 }
 
 export { CloudSessionExpiredError };


### PR DESCRIPTION
**Spike fix.** The desktop blocked enabling HA on a namespace with no context: `findRepresentativeHaGroup` threw ("This namespace has no groups" / "No group in this namespace has a context yet"), gating the Enable-HA button, and `enableHaForNamespace` threw on empty groups and required a per-context ownership proof. But core admits a `ReadOnlyTee` fleet member at the **root group** (`group_id == namespaceId`; the root group id and the namespace id are the same value) with **zero contexts**, then auto-follows contexts created later.

**Cuts (2 files):**
- `apps/desktop/src/pages/Namespaces.tsx` `findRepresentativeHaGroup`: instead of throwing when there is no subgroup / no context, return a root-group-only representative `{ group_id: namespaceId, context_id: "" }` so the button is reachable.
- `apps/desktop/src/utils/cloudApi.ts` `enableHaForNamespace`: drop the `groups.length===0` throw; when no group has a real `context_id`, skip the ownership-proof + `claimContexts` block entirely (the namespace **Admin** check + `getFleetMeasurements` + `setTeeAdmissionPolicy(namespaceId)` still run), and POST `enableHaNamespace` with one root-group-only entry `{ group_id: namespaceId, context_id: "" }`.

Identical behaviour when real contexts exist. `tsc --noEmit` clean.

Throwaway spike for review/visibility — not for merge as-is. Paired with the mdma `spike/ha-no-context` PR (calimero-network/mdma#115; server tolerates the empty-`context_id` entry and stores the root group id as the `HaRequest.context_id` placeholder).