### PR TITLE
fix: rebuild all

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,8 +24,8 @@
     "test:e2e:install": "playwright install chromium"
   },
   "dependencies": {
-    "@calimero-network/mero-js": "^1.4.0",
-    "@calimero-network/mero-react": "^1.1.0",
+    "@calimero-network/mero-js": "^2.2.0",
+    "@calimero-network/mero-react": "^2.4.0",
     "@tauri-apps/api": "^1.5.0",
     "@tauri-apps/plugin-autostart": "^2.5.1",
     "ansi-to-html": "^0.7.2",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.34",
+  "version": "0.0.36",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.5", features = [ "system-tray", "updater", "process-relaunch", "shell-open", "window-all", "dialog-all", "icon-png"] }
+tauri = { version = "1.5", features = [ "http-all", "system-tray", "updater", "process-relaunch", "shell-open", "window-all", "dialog-all", "icon-png"] }
 tauri-plugin-autostart = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.35"
+    "version": "0.0.36"
   },
   "tauri": {
     "allowlist": {

--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -655,19 +655,12 @@
   background: var(--accent-light);
 }
 
-.app-card-mini-wrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-}
-
 .app-card-mini {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-  padding: 18px;
+  gap: 10px;
+  padding: 20px 14px 16px;
   background: var(--gradient-surface), var(--surface-glass);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
@@ -677,21 +670,7 @@
   width: 100%;
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-}
-
-.app-card-shortcut-link {
-  font-size: 11px;
-  color: var(--text-tertiary);
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 2px 0;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-
-.app-card-shortcut-link:hover {
-  color: var(--accent-primary);
+  position: relative;
 }
 
 .app-card-mini:hover {
@@ -708,12 +687,25 @@
 
 .app-card-mini .app-name {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   width: 100%;
+}
+
+.app-card-open-hint {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-weight: 400;
+  letter-spacing: 0.3px;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.app-card-mini:hover .app-card-open-hint {
+  opacity: 1;
 }
 
 /* ── Empty State ── */
@@ -757,6 +749,37 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
+}
+
+.btn-browse-marketplace {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 22px;
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), border-color 0.2s, box-shadow 0.2s;
+  letter-spacing: 0.2px;
+}
+
+.btn-browse-marketplace:hover {
+  border-color: var(--border-hover);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-sm);
+}
+
+.btn-browse-marketplace:hover .browse-icon {
+  transform: translateX(3px);
+  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.btn-browse-marketplace .browse-icon {
+  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .node-info h3 {

--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -161,7 +161,8 @@
   background: var(--header-glass);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  padding: 14px 24px;
+  height: var(--header-height);
+  padding: 0 24px;
   border-bottom: 1px solid var(--border-color);
   flex-shrink: 0;
   position: relative;

--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -502,6 +502,60 @@
   transform: translateY(0) scale(0.98);
 }
 
+/* ── Danger modifier — overrides green defaults from .button ── */
+.button.button-danger {
+  background: var(--error);
+  color: #fff;
+  border-color: var(--error);
+}
+
+.button.button-danger:hover:not(:disabled) {
+  background: #dc2626;
+  border-color: #dc2626;
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.35);
+}
+
+.button.button-danger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+/* ── Google Sign-In button ── */
+.google-signin-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 20px;
+  background: #fff;
+  color: #3c4043;
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: box-shadow 0.15s, background 0.15s;
+  letter-spacing: 0.01em;
+}
+
+.google-signin-btn:hover:not(:disabled) {
+  background: #f8f9fa;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+
+.google-signin-btn:active:not(:disabled) {
+  background: #f1f3f4;
+}
+
+.google-signin-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* ── Error ── */
 .error {
   margin-top: 16px;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -343,14 +343,13 @@ function App() {
     });
   }, []);
 
+  // Health-only check — no app loading. Keeps the status indicator up to date
+  // without triggering re-renders of the app list on every tick.
   const checkConnection = useCallback(async () => {
     try {
       setError(null);
-      
-      // Check health endpoint (admin API)
       const healthResponse = await apiClient.node.healthCheck();
       if (healthResponse.error) {
-        // If 401, show login
         if (healthResponse.error.code === '401') {
           setShowLogin(true);
           setConnected(false);
@@ -362,14 +361,9 @@ function App() {
         updateTrayIcon(false);
         return;
       }
-      
       setConnected(true);
       setError(null);
       updateTrayIcon(true);
-
-      // Load contexts and apps after successful connection
-        await loadContexts();
-      await loadInstalledApps();
     } catch (err) {
       setConnected(false);
       const errorMessage = parseTauriError(err);
@@ -377,7 +371,7 @@ function App() {
       console.error("Connection error:", err);
       updateTrayIcon(false);
     }
-  }, [loadContexts, loadInstalledApps, updateTrayIcon]);
+  }, [updateTrayIcon]);
 
   const handleRestartNode = useCallback(async () => {
     const settings = getSettings();
@@ -407,32 +401,25 @@ function App() {
     }
   }, []);
 
-  const handleCreateDesktopShortcut = useCallback(async (appName: string, frontendUrl: string) => {
-    try {
-      await invoke("create_desktop_shortcut", { appName, frontendUrl });
-      toast.success("Desktop shortcut created on your Desktop");
-    } catch (err) {
-      toast.error(parseTauriError(err, "Failed to create desktop shortcut"));
-    }
-  }, [toast]);
 
-  // Auto-check node status every 5 seconds (runs on all main app pages for global indicator)
-  // Skip when on login, settings, or onboarding - those screens don't need the periodic check,
-  // and it would redirect back to login on 401 while user is intentionally on those screens
+
+  // Health-check interval — lightweight, just updates the connected indicator.
+  // Skip on login/settings/onboarding screens.
   useEffect(() => {
     if (showLogin || showSettings || showOnboarding) return;
-
-    // Initial check
     checkConnection();
-
-    // Set up interval to check every 5 seconds
-    const interval = setInterval(() => {
-      checkConnection();
-    }, 5000);
-
-    // Cleanup interval on unmount
+    const interval = setInterval(checkConnection, 10000);
     return () => clearInterval(interval);
   }, [checkConnection, showLogin, showSettings, showOnboarding]);
+
+  // Load apps + contexts only when the user is on the home page.
+  // Fires once on navigation — not on every health-check tick.
+  useEffect(() => {
+    if (showLogin || showSettings || showOnboarding) return;
+    if (currentPage !== 'home') return;
+    loadContexts().catch(() => {});
+    loadInstalledApps().catch(() => {});
+  }, [currentPage, showLogin, showSettings, showOnboarding, loadContexts, loadInstalledApps]);
 
   // When launched from a desktop shortcut (--open-app-url / --open-app-name): open app, focus it, then hide main window
   useEffect(() => {
@@ -944,39 +931,23 @@ function App() {
                 }
                 
                 return (
-                  <div
+                  <button
                     key={`${app?.id != null && String(app.id) !== '' ? String(app.id) : 'app'}-${index}`}
-                    className="app-card-mini-wrapper"
+                    type="button"
+                    onClick={() => {
+                      if (frontendUrl) {
+                        handleOpenAppFrontend(frontendUrl, appName);
+                      } else {
+                        setCurrentPage('installed');
+                      }
+                    }}
+                    className="app-card-mini"
+                    title={frontendUrl ? `Open ${appName}` : `View ${appName} details`}
                   >
-                    <button
-                      type="button"
-                      onClick={() => {
-                        if (frontendUrl) {
-                          handleOpenAppFrontend(frontendUrl, appName);
-                        } else {
-                          setCurrentPage('installed');
-                        }
-                      }}
-                      className="app-card-mini"
-                      title={frontendUrl ? `Open ${appName}` : `View ${appName} details`}
-                    >
-                      <Package className="app-icon" size={20} />
-                      <span className="app-name">{appName}</span>
-                    </button>
-                    {frontendUrl && (
-                      <button
-                        type="button"
-                        className="app-card-shortcut-link"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleCreateDesktopShortcut(appName, frontendUrl);
-                        }}
-                        title="Create desktop shortcut"
-                      >
-                        Shortcut
-                      </button>
-                    )}
-                  </div>
+                    <Package className="app-icon" size={28} />
+                    <span className="app-name">{appName}</span>
+                    {frontendUrl && <span className="app-card-open-hint">Open</span>}
+                  </button>
                 );
               })}
             </div>
@@ -989,11 +960,11 @@ function App() {
             <Package size={48} className="empty-icon" />
             <h3>No Applications Installed</h3>
             <p>Get started by browsing the marketplace and installing your first app.</p>
-            <button 
-              onClick={() => setCurrentPage('marketplace')} 
-              className="button button-primary"
+            <button
+              onClick={() => setCurrentPage('marketplace')}
+              className="btn-browse-marketplace"
             >
-              <ShoppingCart size={16} />
+              <ShoppingCart size={16} className="browse-icon" />
               Browse Marketplace
             </button>
           </div>

--- a/apps/desktop/src/components/Icons.tsx
+++ b/apps/desktop/src/components/Icons.tsx
@@ -1,0 +1,30 @@
+export {
+  Home,
+  Layers,        // Namespaces
+  Package,       // Applications
+  Store,         // Marketplace
+  Server,        // Nodes
+  Settings2 as SettingsIcon,
+  ShieldCheck,   // High Availability
+  ChevronRight,
+  ChevronLeft,
+  ChevronDown,
+  ArrowRight,
+  ArrowLeft,
+  Check,
+  CheckCircle2,
+  Download,
+  Upload,
+  RefreshCw,
+  Trash2,
+  Pencil,
+  Plus,
+  X,
+  Search,
+  Copy,
+  ExternalLink,
+  MoreHorizontal,
+  AlertTriangle,
+  Info,
+  Loader2,
+} from "lucide-react";

--- a/apps/desktop/src/components/Sidebar.css
+++ b/apps/desktop/src/components/Sidebar.css
@@ -13,8 +13,12 @@
 }
 
 .sidebar-header {
-  padding: 12px 20px;
+  height: var(--header-height);
+  padding: 0 20px;
   border-bottom: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 .sidebar-logo {

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { getSettings } from "../utils/settings";
-import { Home, Globe, Package, ShoppingCart, Settings as SettingsIcon, Server } from "lucide-react";
+import { Home, Layers, Package, Store, SettingsIcon, Server } from "./Icons";
 import calimeroLogo from "../assets/calimero-logo.svg";
 import "./Sidebar.css";
 
@@ -18,9 +18,9 @@ export default function Sidebar({ currentPage, onNavigate, onOpenSettings, nodeD
   const navItems = [
     { id: 'home' as const, label: 'Home', icon: Home },
     ...(developerMode || nodeDisconnected ? [{ id: 'nodes' as const, label: 'Nodes', icon: Server }] : []),
-    ...(developerMode ? [{ id: 'namespaces' as const, label: 'Namespaces', icon: Globe }] : []),
+    ...(developerMode ? [{ id: 'namespaces' as const, label: 'Namespaces', icon: Layers }] : []),
     { id: 'installed' as const, label: 'Applications', icon: Package },
-    { id: 'marketplace' as const, label: 'Marketplace', icon: ShoppingCart },
+    { id: 'marketplace' as const, label: 'Marketplace', icon: Store },
   ];
 
   return (

--- a/apps/desktop/src/components/Skeleton.css
+++ b/apps/desktop/src/components/Skeleton.css
@@ -1,7 +1,11 @@
 .skeleton {
-  background: var(--surface-glass-soft);
+  background: rgba(255, 255, 255, 0.07);
   position: relative;
   overflow: hidden;
+}
+
+[data-theme="light"] .skeleton {
+  background: rgba(0, 0, 0, 0.07);
 }
 
 .skeleton-pulse {
@@ -23,7 +27,7 @@
   background: linear-gradient(
     90deg,
     transparent,
-    rgba(255, 255, 255, 0.05),
+    rgba(255, 255, 255, 0.12),
     transparent
   );
   animation: skeleton-wave 1.5s ease-in-out infinite;

--- a/apps/desktop/src/components/UsernamePasswordForm.tsx
+++ b/apps/desktop/src/components/UsernamePasswordForm.tsx
@@ -13,7 +13,7 @@ function validateUsername(value: string): string | null {
 }
 
 function validatePassword(value: string): string | null {
-  if (!value) return 'Password is required';
+  if (!value || !value.trim()) return 'Password is required';
   if (value.length < MIN_PASSWORD_LENGTH) return `Password must be at least ${MIN_PASSWORD_LENGTH} characters`;
   return null;
 }
@@ -66,7 +66,7 @@ export function UsernamePasswordForm({
     onSubmit(username.trim(), password);
   };
 
-  const isEmpty = !username.trim() || !password;
+  const isEmpty = !username.trim() || !password.trim();
 
   const containerStyle: React.CSSProperties = { maxWidth: 420, width: '100%' };
   const cardStyle: React.CSSProperties = isDark

--- a/apps/desktop/src/components/UsernamePasswordForm.tsx
+++ b/apps/desktop/src/components/UsernamePasswordForm.tsx
@@ -66,7 +66,7 @@ export function UsernamePasswordForm({
     onSubmit(username.trim(), password);
   };
 
-  const displayError = usernameError || passwordError || error;
+  const isEmpty = !username.trim() || !password;
 
   const containerStyle: React.CSSProperties = { maxWidth: 420, width: '100%' };
   const cardStyle: React.CSSProperties = isDark
@@ -81,11 +81,6 @@ export function UsernamePasswordForm({
         <h2 style={{ marginTop: 0, marginBottom: '24px', fontSize: '18px', fontWeight: 600, color: isDark ? DARK.text : 'var(--text-primary)' }}>Sign in</h2>
         <form onSubmit={handleSubmit}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
-            {displayError && (
-              <div style={{ padding: '12px 16px', background: 'rgba(248, 113, 113, 0.15)', color: isDark ? DARK.error : 'var(--error)', borderRadius: '8px', fontSize: '14px', border: `1px solid ${isDark ? DARK.error : 'var(--error)'}` }}>
-                {displayError}
-              </div>
-            )}
             <div>
               <label htmlFor="username" style={{ display: 'block', marginBottom: '8px', fontSize: '13px', fontWeight: 500, color: isDark ? '#e2e8f0' : 'var(--text-primary)' }}>
                 Username <span style={{ color: isDark ? DARK.error : 'var(--error)' }}>*</span>
@@ -100,15 +95,20 @@ export function UsernamePasswordForm({
               <input id="password" type="password" value={password} onChange={(e) => { setPassword(e.target.value); setPasswordError(null); }} onBlur={() => setPasswordError(validatePassword(password))} placeholder={`At least ${MIN_PASSWORD_LENGTH} characters`} disabled={loading} autoComplete="current-password" autoCorrect="off" autoCapitalize="off" spellCheck={false} style={{ width: '100%', padding: '14px 16px', border: `1px solid ${passwordError ? (isDark ? DARK.error : 'var(--error)') : isDark ? DARK.border : 'var(--border-color)'}`, borderRadius: '10px', fontSize: '15px', boxSizing: 'border-box', background: isDark ? DARK.bgInput : 'var(--bg-tertiary)', color: isDark ? DARK.text : 'var(--text-primary)' }} />
               {passwordError && <p style={{ margin: '6px 0 0 0', fontSize: '12px', color: isDark ? DARK.error : 'var(--error)' }}>{passwordError}</p>}
             </div>
-            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px', marginTop: '8px' }}>
-              {onBack && (
-                <button type="button" onClick={onBack} disabled={loading} style={{ padding: '12px 24px', background: isDark ? DARK.bgButton : 'var(--bg-tertiary)', color: isDark ? DARK.text : 'var(--text-primary)', border: `1px solid ${isDark ? '#475569' : 'var(--border-color)'}`, borderRadius: '10px', fontSize: '15px', fontWeight: 500, cursor: loading ? 'not-allowed' : 'pointer', opacity: loading ? 0.6 : 1 }}>
-                  Back
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', marginTop: '8px' }}>
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
+                {onBack && (
+                  <button type="button" onClick={onBack} disabled={loading} style={{ padding: '12px 24px', background: isDark ? DARK.bgButton : 'var(--bg-tertiary)', color: isDark ? DARK.text : 'var(--text-primary)', border: `1px solid ${isDark ? '#475569' : 'var(--border-color)'}`, borderRadius: '10px', fontSize: '15px', fontWeight: 500, cursor: loading ? 'not-allowed' : 'pointer', opacity: loading ? 0.6 : 1 }}>
+                    Back
+                  </button>
+                )}
+                <button type="submit" disabled={loading || isEmpty || !!usernameError || !!passwordError} style={{ padding: '12px 24px', background: loading || isEmpty || !!usernameError || !!passwordError ? (isDark ? DARK.bgButton : 'var(--bg-tertiary)') : (isDark ? DARK.bgButtonPrimary : 'var(--accent-primary)'), color: loading || isEmpty || !!usernameError || !!passwordError ? (isDark ? DARK.textMuted : 'var(--text-tertiary)') : '#09090b', border: 'none', borderRadius: '10px', fontSize: '15px', fontWeight: 600, cursor: loading || isEmpty || !!usernameError || !!passwordError ? 'not-allowed' : 'pointer', opacity: loading ? 0.6 : 1 }}>
+                  {loading ? 'Signing In...' : 'Sign In'}
                 </button>
+              </div>
+              {error && !usernameError && !passwordError && (
+                <p style={{ margin: 0, fontSize: '13px', color: isDark ? DARK.error : 'var(--error)', textAlign: 'right' }}>{error}</p>
               )}
-              <button type="submit" disabled={loading || !!validateUsername(username) || !!validatePassword(password)} style={{ padding: '12px 24px', background: loading || !!validateUsername(username) || !!validatePassword(password) ? (isDark ? DARK.bgButton : 'var(--bg-tertiary)') : (isDark ? DARK.bgButtonPrimary : 'var(--accent-primary)'), color: loading || !!validateUsername(username) || !!validatePassword(password) ? (isDark ? DARK.textMuted : 'var(--text-tertiary)') : '#09090b', border: 'none', borderRadius: '10px', fontSize: '15px', fontWeight: 600, cursor: loading || !!validateUsername(username) || !!validatePassword(password) ? 'not-allowed' : 'pointer', opacity: loading ? 0.6 : 1 }}>
-                {loading ? 'Signing In...' : 'Sign In'}
-              </button>
             </div>
           </div>
         </form>

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -39,6 +39,7 @@
   --header-glass: rgba(13, 17, 23, 0.78);
   --button-glass: rgba(165, 255, 17, 0.06);
   --button-glass-hover: rgba(165, 255, 17, 0.1);
+  --header-height: 56px;
   --radius-sm: 6px;
   --radius-md: 10px;
   --radius-lg: 16px;

--- a/apps/desktop/src/pages/ConfirmAction.css
+++ b/apps/desktop/src/pages/ConfirmAction.css
@@ -72,7 +72,7 @@
   justify-content: flex-end;
 }
 
-.button {
+.confirm-actions .button {
   padding: 10px 20px;
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -82,25 +82,28 @@
   transition: all 0.15s;
 }
 
-.button-secondary {
-  background: var(--button-glass);
-  color: var(--text-primary);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+.confirm-actions .button-secondary {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border-color);
 }
 
-.button-secondary:hover {
-  background: var(--button-glass-hover);
-  border-color: var(--border-hover);
+.confirm-actions .button-secondary:hover {
+  background: var(--accent-light);
+  border-color: var(--accent-dim);
+  color: var(--accent-primary);
 }
 
-.button-danger {
+.confirm-actions .button-danger {
   background: var(--error);
   color: white;
   border-color: var(--error);
 }
 
-.button-danger:hover {
+.confirm-actions .button-danger:hover {
   background: #dc2626;
   border-color: #dc2626;
+  color: white;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
 }

--- a/apps/desktop/src/pages/InstalledApps.css
+++ b/apps/desktop/src/pages/InstalledApps.css
@@ -1,5 +1,5 @@
 .installed-apps-page {
-  padding: 20px;
+  padding: 24px;
   max-width: 1400px;
   margin: 0 auto;
   animation: fadeUp 0.4s ease-out;
@@ -10,16 +10,45 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 24px;
-  padding-bottom: 16px;
-  border-bottom: 1px solid var(--border-color);
 }
 
-.installed-apps-header h2 {
-  margin: 0;
+.installed-apps-header h1 {
+  margin: 0 0 4px 0;
   font-size: 24px;
   font-weight: 700;
   color: var(--text-primary);
   letter-spacing: -0.4px;
+}
+
+.installed-apps-header p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.installed-refresh-btn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s;
+  flex-shrink: 0;
+}
+
+.installed-refresh-btn:hover:not(:disabled) {
+  border-color: var(--border-hover);
+  color: var(--text-primary);
+}
+
+.installed-refresh-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .installed-apps-main {
@@ -33,12 +62,6 @@
   border-radius: var(--radius-md);
   margin-bottom: 16px;
   border: 1px solid rgba(239, 68, 68, 0.2);
-}
-
-.loading {
-  text-align: center;
-  padding: 40px;
-  color: var(--text-secondary);
 }
 
 .empty-state {
@@ -60,6 +83,8 @@
 .empty-state a:hover {
   text-decoration: underline;
 }
+
+/* ── Table cells ── */
 
 .table-cell-name {
   display: flex;
@@ -91,48 +116,103 @@
 
 .table-cell-actions {
   display: flex;
-  gap: 8px;
+  gap: 6px;
   align-items: center;
+  justify-content: flex-end;
 }
 
-.button-small {
-  padding: 6px 12px;
-  font-size: 12px;
-}
+/* ── Open button ── */
 
-.button {
-  padding: 8px 16px;
-  border: 1px solid rgba(165, 255, 17, 0.18);
+.btn-open {
+  padding: 5px 12px;
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
-  background: var(--button-glass);
-  color: var(--accent-primary);
-  cursor: pointer;
-  font-size: 14px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
   font-weight: 500;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
 }
 
-.button:hover:not(:disabled) {
-  background: var(--button-glass-hover);
-  border-color: rgba(165, 255, 17, 0.28);
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-sm);
+.btn-open:hover {
+  border-color: var(--accent-dim);
+  color: var(--accent-primary);
+  background: var(--accent-light);
 }
 
-.button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+/* ── Three-dot more menu ── */
+
+.app-actions-more {
+  position: relative;
 }
 
-.button-danger {
-  background: var(--error);
-  color: white;
-  border-color: var(--error);
+.btn-more {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: var(--text-tertiary);
+  cursor: pointer;
+  transition: all 0.15s;
+  flex-shrink: 0;
 }
 
-.button-danger:hover:not(:disabled) {
-  background: #dc2626;
-  border-color: #dc2626;
+.btn-more:hover {
+  border-color: var(--border-color);
+  color: var(--text-secondary);
+  background: var(--surface-glass-soft);
+}
+
+.app-actions-dropdown {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: 9999;
+  min-width: 160px;
+  padding: 4px;
+  animation: fadeIn 0.1s ease-out;
+}
+
+.dropdown-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 10px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s;
+  text-align: left;
+  color: var(--text-secondary);
+}
+
+.dropdown-item:hover {
+  background: var(--surface-glass-soft);
+  color: var(--text-primary);
+}
+
+.dropdown-item-danger {
+  color: var(--error);
+}
+
+.dropdown-item-danger:hover {
+  background: rgba(239, 68, 68, 0.08);
+  color: var(--error);
+}
+
+.dropdown-divider {
+  height: 1px;
+  background: var(--border-color);
+  margin: 4px 0;
 }

--- a/apps/desktop/src/pages/InstalledApps.tsx
+++ b/apps/desktop/src/pages/InstalledApps.tsx
@@ -1,18 +1,18 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { apiClient } from "../lib/mero-client";
 import { useToast } from "../contexts/ToastContext";
 import DataTable from "../components/DataTable";
 import ContextMenu from "../components/ContextMenu";
-import { SkeletonTable } from "../components/Skeleton";
+import Skeleton from "../components/Skeleton";
 import { decodeMetadata, openAppFrontend, parseTauriError } from "../utils/appUtils";
-import { invoke } from "@tauri-apps/api/tauri";
+import { RefreshCw, MoreHorizontal, Trash2, Copy } from "lucide-react";
 import "./InstalledApps.css";
 
 interface InstalledApplication {
   id: string;
   name?: string;
   version?: string;
-  metadata: number[] | string; // Can be array of bytes or base64 string
+  metadata: number[] | string;
   blob?: {
     bytecode: string;
     compiled: string;
@@ -27,12 +27,30 @@ export interface InstalledAppsProps {
   clientReady?: boolean;
 }
 
+const SKELETON_MIN_MS = 1000;
+
 const InstalledApps: React.FC<InstalledAppsProps> = ({ onAuthRequired, onConfirmUninstall, clientReady = true }) => {
   const toast = useToast();
   const [apps, setApps] = useState<InstalledApplication[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; app: InstalledApplication } | null>(null);
+  const [openMenuAppId, setOpenMenuAppId] = useState<string | null>(null);
+  const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!openMenuAppId) return;
+    const close = () => setOpenMenuAppId(null);
+    document.addEventListener('click', close);
+    return () => document.removeEventListener('click', close);
+  }, [openMenuAppId]);
 
   useEffect(() => {
     if (clientReady) {
@@ -43,44 +61,47 @@ const InstalledApps: React.FC<InstalledAppsProps> = ({ onAuthRequired, onConfirm
   const loadInstalledApps = async () => {
     setLoading(true);
     setError(null);
+    const start = Date.now();
 
     try {
       const response = await apiClient.node.listApplications();
-      
+
       if (response.error) {
-        // If 401, trigger login redirect
         if (response.error.code === '401') {
           console.warn("📦 InstalledApps: 401 Unauthorized - token may be expired");
           onAuthRequired?.();
           return;
         }
-        setError(response.error.message);
-        setApps([]);
+        if (mountedRef.current) {
+          setError(response.error.message);
+          setApps([]);
+        }
         return;
       }
 
       if (response.data) {
-        // The client now returns { data: apps[] } where apps is already extracted
-        const appsList = Array.isArray(response.data) 
-          ? response.data 
-          : [];
-        setApps(appsList);
+        const appsList = Array.isArray(response.data) ? response.data : [];
+        if (mountedRef.current) setApps(appsList);
       } else {
-        console.warn("📦 No data in response");
-        setApps([]);
+        if (mountedRef.current) setApps([]);
       }
     } catch (err: any) {
-      // Check for 401 in error object
       if (err?.status === 401 || err?.code === '401') {
-        console.warn("📦 InstalledApps: 401 Unauthorized - triggering login");
         onAuthRequired?.();
         return;
       }
-      setError(parseTauriError(err, "Failed to load installed applications"));
-      console.error("Failed to load installed apps:", err);
-      setApps([]);
+      if (mountedRef.current) {
+        setError(parseTauriError(err, "Failed to load installed applications"));
+        setApps([]);
+      }
     } finally {
-      setLoading(false);
+      // Ensure skeleton shows for at least SKELETON_MIN_MS
+      const elapsed = Date.now() - start;
+      const remaining = SKELETON_MIN_MS - elapsed;
+      if (remaining > 0) {
+        await new Promise((r) => setTimeout(r, remaining));
+      }
+      if (mountedRef.current) setLoading(false);
     }
   };
 
@@ -93,29 +114,23 @@ const InstalledApps: React.FC<InstalledAppsProps> = ({ onAuthRequired, onConfirm
             toast.error(`Failed to uninstall: ${response.error.message}`);
             return;
           }
-
-          toast.success(`Application "${appName}" uninstalled successfully`);
-          // Reload the list
+          toast.success(`"${appName}" uninstalled`);
           await loadInstalledApps();
         } catch (err) {
-          toast.error(`Failed to uninstall application: ${parseTauriError(err, "Unknown error")}`);
-          console.error("Uninstall error:", err);
+          toast.error(`Failed to uninstall: ${parseTauriError(err, "Unknown error")}`);
         }
       });
     } else {
-      // Fallback if onConfirmUninstall is not provided
       try {
         const response = await apiClient.node.uninstallApplication(appId);
         if (response.error) {
           toast.error(`Failed to uninstall: ${response.error.message}`);
           return;
         }
-
-        toast.success(`Application "${appName}" uninstalled successfully`);
+        toast.success(`"${appName}" uninstalled`);
         await loadInstalledApps();
       } catch (err) {
-        toast.error(`Failed to uninstall application: ${err instanceof Error ? err.message : "Unknown error"}`);
-        console.error("Uninstall error:", err);
+        toast.error(`Failed to uninstall: ${err instanceof Error ? err.message : "Unknown error"}`);
       }
     }
   };
@@ -124,18 +139,6 @@ const InstalledApps: React.FC<InstalledAppsProps> = ({ onAuthRequired, onConfirm
     await openAppFrontend(frontendUrl, appName, (error) => {
       toast.error(`Failed to open frontend: ${error.message}`);
     });
-  };
-
-  const handleCreateDesktopShortcut = async (appName: string, frontendUrl: string) => {
-    try {
-      await invoke<string>("create_desktop_shortcut", {
-        appName,
-        frontendUrl,
-      });
-      toast.success("Desktop shortcut created on your Desktop");
-    } catch (err) {
-      toast.error(parseTauriError(err, "Failed to create desktop shortcut"));
-    }
   };
 
   const handleRowContextMenu = useCallback((e: React.MouseEvent, app: InstalledApplication) => {
@@ -147,39 +150,34 @@ const InstalledApps: React.FC<InstalledAppsProps> = ({ onAuthRequired, onConfirm
   return (
     <div className="installed-apps-page">
       <header className="installed-apps-header">
-        <h2>Installed Applications</h2>
-        <button onClick={loadInstalledApps} className="button" disabled={loading}>
-          {loading ? "Loading..." : "Refresh"}
+        <div>
+          <h1>Applications</h1>
+          <p>Manage your installed applications</p>
+        </div>
+        <button
+          onClick={loadInstalledApps}
+          className="installed-refresh-btn"
+          disabled={loading}
+          title="Refresh"
+        >
+          <RefreshCw size={15} className={loading ? 'spinning' : ''} />
         </button>
       </header>
 
       <main className="installed-apps-main">
         {error && (
-          <div className="error-message">
-            {error}
-          </div>
+          <div className="error-message">{error}</div>
         )}
 
         {contextMenu && (() => {
           const metadata = decodeMetadata(contextMenu.app.metadata);
           const appName = metadata?.name || contextMenu.app.name || contextMenu.app.id;
           const frontendUrl = metadata?.links?.frontend;
-          const items = [];
+          const items: { label: string; onClick: () => void; danger?: boolean }[] = [];
           if (frontendUrl) {
-            items.push({
-              label: 'Open',
-              onClick: () => handleOpenFrontend(frontendUrl, appName),
-            });
-            items.push({
-              label: 'Create desktop shortcut',
-              onClick: () => handleCreateDesktopShortcut(appName, frontendUrl),
-            });
+            items.push({ label: 'Open', onClick: () => handleOpenFrontend(frontendUrl, appName) });
           }
-          items.push({
-            label: 'Uninstall',
-            onClick: () => handleUninstall(contextMenu.app.id, appName),
-            danger: true,
-          });
+          items.push({ label: 'Uninstall', onClick: () => handleUninstall(contextMenu.app.id, appName), danger: true });
           return (
             <ContextMenu
               x={contextMenu.x}
@@ -191,7 +189,45 @@ const InstalledApps: React.FC<InstalledAppsProps> = ({ onAuthRequired, onConfirm
         })()}
 
         {loading ? (
-          <SkeletonTable rows={5} columns={5} showHeader={true} />
+          <div className="data-table-container data-table-compact">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th style={{ width: '25%' }}>Name</th>
+                  <th style={{ width: '12%' }}>Version</th>
+                  <th style={{ width: '10%' }}>Size</th>
+                  <th style={{ width: '33%' }}>Description</th>
+                  <th style={{ width: '20%' }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <tr key={i}>
+                    <td>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+                        <Skeleton variant="text" width={`${55 + (i % 3) * 12}%`} height="13px" />
+                        <Skeleton variant="text" width={`${35 + (i % 4) * 8}%`} height="11px" />
+                      </div>
+                    </td>
+                    <td><Skeleton variant="text" width={`${40 + (i % 3) * 15}%`} height="13px" /></td>
+                    <td><Skeleton variant="text" width={`${50 + (i % 2) * 20}%`} height="13px" /></td>
+                    <td>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+                        <Skeleton variant="text" width={`${70 + (i % 3) * 10}%`} height="13px" />
+                        <Skeleton variant="text" width={`${45 + (i % 4) * 10}%`} height="13px" />
+                      </div>
+                    </td>
+                    <td>
+                      <div style={{ display: 'flex', gap: '6px', justifyContent: 'flex-end' }}>
+                        <Skeleton variant="rectangular" width="52px" height="26px" borderRadius="6px" />
+                        <Skeleton variant="rectangular" width="28px" height="26px" borderRadius="6px" />
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         ) : (
           <DataTable
             data={apps}
@@ -222,7 +258,7 @@ const InstalledApps: React.FC<InstalledAppsProps> = ({ onAuthRequired, onConfirm
                 key: 'version',
                 label: 'Version',
                 sortable: true,
-                width: '15%',
+                width: '12%',
                 sortValue: (app) => {
                   const metadata = decodeMetadata(app.metadata);
                   return metadata?.version || app.version || "Unknown";
@@ -236,28 +272,25 @@ const InstalledApps: React.FC<InstalledAppsProps> = ({ onAuthRequired, onConfirm
                 key: 'size',
                 label: 'Size',
                 sortable: true,
-                width: '12%',
-                sortValue: (app) => app.size ?? 0, // Sort by raw byte value
+                width: '10%',
+                sortValue: (app) => app.size ?? 0,
                 render: (app) => {
                   if (!app.size) return '—';
                   const sizeKB = app.size / 1024;
-                  if (sizeKB < 1024) {
-                    return `${sizeKB.toFixed(2)} KB`;
-                  }
-                  return `${(sizeKB / 1024).toFixed(2)} MB`;
+                  return sizeKB < 1024 ? `${sizeKB.toFixed(2)} KB` : `${(sizeKB / 1024).toFixed(2)} MB`;
                 },
               },
               {
                 key: 'description',
                 label: 'Description',
                 sortable: false,
-                width: '28%',
+                width: '33%',
                 render: (app) => {
                   const metadata = decodeMetadata(app.metadata);
                   return metadata?.description ? (
                     <div className="table-cell-description" title={metadata.description}>
-                      {metadata.description.length > 60
-                        ? `${metadata.description.substring(0, 60)}...`
+                      {metadata.description.length > 80
+                        ? `${metadata.description.substring(0, 80)}...`
                         : metadata.description}
                     </div>
                   ) : (
@@ -267,62 +300,70 @@ const InstalledApps: React.FC<InstalledAppsProps> = ({ onAuthRequired, onConfirm
               },
               {
                 key: 'actions',
-                label: 'Actions',
+                label: '',
                 sortable: false,
                 width: '20%',
                 render: (app) => {
-              const metadata = decodeMetadata(app.metadata);
-              const appName = metadata?.name || app.name || app.id;
-              const frontendUrl = metadata?.links?.frontend;
-              
-              return (
+                  const metadata = decodeMetadata(app.metadata);
+                  const appName = metadata?.name || app.name || app.id;
+                  const frontendUrl = metadata?.links?.frontend;
+
+                  return (
                     <div className="table-cell-actions">
-                    {frontendUrl && (
-                      <>
+                      {frontendUrl && (
                         <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleOpenFrontend(frontendUrl, appName);
-                          }}
-                          className="button button-primary button-small"
-                          title={`Open ${appName} frontend`}
+                          onClick={(e) => { e.stopPropagation(); handleOpenFrontend(frontendUrl, appName); }}
+                          className="btn-open"
                         >
                           Open
                         </button>
+                      )}
+                      <div className="app-actions-more" onClick={(e) => e.stopPropagation()}>
                         <button
+                          className="btn-more"
+                          title="More options"
                           onClick={(e) => {
-                            e.stopPropagation();
-                            handleCreateDesktopShortcut(appName, frontendUrl);
+                            const rect = e.currentTarget.getBoundingClientRect();
+                            setMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+                            setOpenMenuAppId(openMenuAppId === app.id ? null : app.id);
                           }}
-                          className="button button-secondary button-small"
-                          title="Create a desktop shortcut that opens this app"
                         >
-                          Shortcut
+                          <MoreHorizontal size={15} />
                         </button>
-                      </>
-                    )}
-                    <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleUninstall(app.id, appName);
-                        }}
-                        className="button button-danger button-small"
-                    >
-                      Uninstall
-                    </button>
-                </div>
-              );
+                        {openMenuAppId === app.id && menuPos && (
+                          <div
+                            className="app-actions-dropdown"
+                            style={{ position: 'fixed', top: menuPos.top, right: menuPos.right }}
+                          >
+                            <button
+                              className="dropdown-item"
+                              onClick={() => { setOpenMenuAppId(null); navigator.clipboard.writeText(app.id); toast.success('ID copied'); }}
+                            >
+                              <Copy size={13} />
+                              Copy ID
+                            </button>
+                            <div className="dropdown-divider" />
+                            <button
+                              className="dropdown-item dropdown-item-danger"
+                              onClick={() => { setOpenMenuAppId(null); handleUninstall(app.id, appName); }}
+                            >
+                              <Trash2 size={13} />
+                              Uninstall
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  );
                 },
               },
             ]}
-            keyExtractor={(app, index) =>
-              app.id || app.name || app.source || `installed-${index}`
-            }
+            keyExtractor={(app, index) => app.id || app.name || app.source || `installed-${index}`}
             emptyMessage={
               <div className="empty-state">
                 <p>No applications installed.</p>
                 <p>Visit the <a href="#marketplace">Marketplace</a> to install applications.</p>
-          </div>
+              </div>
             }
           />
         )}
@@ -332,4 +373,3 @@ const InstalledApps: React.FC<InstalledAppsProps> = ({ onAuthRequired, onConfirm
 };
 
 export default InstalledApps;
-

--- a/apps/desktop/src/pages/InstalledApps.tsx
+++ b/apps/desktop/src/pages/InstalledApps.tsx
@@ -53,9 +53,8 @@ const InstalledApps: React.FC<InstalledAppsProps> = ({ onAuthRequired, onConfirm
   }, [openMenuAppId]);
 
   useEffect(() => {
-    if (clientReady) {
-      loadInstalledApps();
-    }
+    if (!clientReady) { setLoading(false); return; }
+    loadInstalledApps();
   }, [clientReady]);
 
   const loadInstalledApps = async () => {

--- a/apps/desktop/src/pages/Marketplace.css
+++ b/apps/desktop/src/pages/Marketplace.css
@@ -594,8 +594,9 @@
 }
 
 .modal-close:hover {
-  background: var(--surface-glass);
-  color: var(--text-primary);
+  background: var(--accent-light);
+  color: var(--accent-primary);
+  border-color: var(--accent-dim);
 }
 
 .modal-header {
@@ -679,6 +680,12 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   flex: 1;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
 }
 
 .modal-meta-link:hover {
@@ -700,3 +707,18 @@
   font-size: 14px;
   font-weight: 600;
 }
+
+/* Close button in modal: green accent */
+.modal-actions .button-secondary {
+  background: var(--accent-light);
+  color: var(--accent-primary);
+  border: 1px solid var(--accent-dim);
+}
+
+.modal-actions .button-secondary:hover {
+  background: var(--accent-primary);
+  color: #111;
+  border-color: var(--accent-primary);
+  transform: translateY(-1px);
+}
+

--- a/apps/desktop/src/pages/Marketplace.css
+++ b/apps/desktop/src/pages/Marketplace.css
@@ -19,10 +19,40 @@
   letter-spacing: -0.4px;
 }
 
+.marketplace-header-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
 .marketplace-header p {
   margin: 0;
   color: var(--text-secondary);
   font-size: 14px;
+}
+
+.explore-registry-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.explore-registry-btn:hover {
+  border-color: var(--accent-dim);
+  color: var(--accent-primary);
+  background: var(--accent-light);
 }
 
 .marketplace-main {
@@ -99,26 +129,65 @@
   gap: 12px;
   align-items: center;
   flex-wrap: wrap;
+  justify-content: space-between;
 }
 
-.filter-select {
-  padding: 8px 12px;
+.filter-pills {
+  display: flex;
+  gap: 6px;
+}
+
+.filter-pill {
+  height: 32px;
+  padding: 0 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+}
+
+.filter-pill:hover {
+  border-color: var(--border-hover);
+  color: var(--text-primary);
+}
+
+.filter-pill.active {
+  background: var(--accent-light);
+  border-color: var(--accent-dim);
+  color: var(--accent-primary);
+  font-weight: 600;
+}
+
+.refresh-btn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
-  font-size: 13px;
-  background: var(--surface-glass-soft);
-  color: var(--text-primary);
+  color: var(--text-secondary);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all 0.15s;
+  flex-shrink: 0;
 }
 
-.filter-select:focus {
-  outline: none;
-  border-color: var(--accent-primary);
-}
-
-.filter-select:hover {
+.refresh-btn:hover:not(:disabled) {
   border-color: var(--border-hover);
+  color: var(--text-primary);
+}
+
+.refresh-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .error-message {
@@ -183,6 +252,7 @@
   flex-direction: column;
   transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
+  cursor: pointer;
   min-width: 0;
   max-width: 100%;
   width: 100%;
@@ -391,6 +461,31 @@
   font-weight: 500;
 }
 
+/* Install icon: hidden by default, slides in on hover */
+.install-icon-wrap {
+  display: flex;
+  align-items: center;
+  width: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: width 0.18s ease, opacity 0.15s ease;
+  flex-shrink: 0;
+}
+
+.app-card-actions .button-primary:hover:not(:disabled) .install-icon-wrap,
+.modal-actions .button-primary:hover:not(:disabled) .install-icon-wrap {
+  width: 16px;
+  opacity: 1;
+}
+
+/* Fix install button hover: solid fill with good text contrast */
+.app-card-actions .button-primary:hover:not(:disabled),
+.modal-actions .button-primary:hover:not(:disabled) {
+  background: var(--accent-primary);
+  color: #111;
+  border-color: var(--accent-primary);
+}
+
 .button-success {
   background: var(--success);
   color: white;
@@ -434,12 +529,174 @@
     align-items: stretch;
   }
 
-  .filter-select {
-    width: 100%;
+  .filter-pills {
+    flex-wrap: wrap;
   }
 
   .apps-grid {
     grid-template-columns: 1fr !important;
     max-width: 100%;
   }
+}
+
+/* ── App Detail Modal ── */
+.app-detail-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+  padding: 24px;
+  animation: fadeIn 0.15s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.app-detail-modal {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-xl);
+  padding: 32px;
+  width: 100%;
+  max-width: 520px;
+  position: relative;
+  animation: modalSlideUp 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: var(--shadow-xl);
+}
+
+@keyframes modalSlideUp {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.modal-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: var(--surface-glass-soft);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+}
+
+.modal-close:hover {
+  background: var(--surface-glass);
+  color: var(--text-primary);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 20px;
+}
+
+.modal-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: var(--radius-lg);
+  flex-shrink: 0;
+}
+
+.modal-title {
+  flex: 1;
+  min-width: 0;
+}
+
+.modal-title h2 {
+  margin: 0 0 6px 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.3px;
+}
+
+.modal-description {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0 0 24px 0;
+}
+
+.modal-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  background: var(--surface-glass-soft);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  margin-bottom: 24px;
+}
+
+.modal-meta-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-size: 13px;
+  min-width: 0;
+}
+
+.modal-meta-label {
+  color: var(--text-tertiary);
+  font-weight: 500;
+  flex-shrink: 0;
+  width: 90px;
+}
+
+.modal-meta-value {
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.modal-meta-value.mono {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 12px;
+}
+
+.modal-meta-link {
+  color: var(--accent-primary);
+  text-decoration: none;
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.modal-meta-link:hover {
+  text-decoration: underline;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.modal-actions .button {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 11px 20px;
+  font-size: 14px;
+  font-weight: 600;
 }

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/tauri";
 import { getSettings } from "../utils/settings";
 import { fetchAppsFromAllRegistries, recordDownload, type AppSummary } from "../utils/registry";
 import { apiClient } from "../lib/mero-client";
@@ -12,7 +13,7 @@ import {
 import { truncateText } from "../utils/string";
 import { useToast } from "../contexts/ToastContext";
 import Skeleton from "../components/Skeleton";
-import { Search, RefreshCw, Package, Download, CheckCircle2, X } from "lucide-react";
+import { Search, RefreshCw, Package, Download, CheckCircle2, X, ExternalLink } from "lucide-react";
 import bs58 from "bs58";
 import "./Marketplace.css";
 
@@ -36,6 +37,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
   const [installingAppId, setInstallingAppId] = useState<string | null>(null);
   // Track whether a background refresh is in progress (no skeleton shown)
   const [refreshing, setRefreshing] = useState(false);
+  const [selectedApp, setSelectedApp] = useState<MarketplaceApp | null>(null);
   const mountedRef = useRef(true);
 
   // Cleanup on unmount
@@ -385,17 +387,10 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
       // Record download with registry (fire-and-forget)
       recordDownload(app.registry, app.id, app.latest_version);
 
-      // Reload installed apps and refetch marketplace so download count updates
-      const installed = await loadInstalledApps();
-      await loadMarketplaceApps(installed, true);
-      // Also explicitly mark this app as installed immediately for instant UI feedback
-      setApps((prevApps) =>
-        prevApps.map((a) =>
-          a.id === app.id || a.name === app.name
-            ? { ...a, installed: true }
-            : a
-        )
-      );
+      // Update just the changed card — no full reload, no flicker.
+      // loadInstalledApps updates installedAppIds, which the sync useEffect
+      // uses to flip installed:true on the affected card only.
+      await loadInstalledApps();
     } catch (err) {
       console.error("📦 Marketplace: Install exception:", err);
       const msg = truncateText(err instanceof Error ? err.message : "Unknown error", 120);
@@ -406,11 +401,28 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
   };
 
 
+  const registryUrl = useMemo(() => {
+    const reg = getSettings().registries?.[0];
+    if (!reg) return null;
+    try { return new URL(reg).origin; } catch { return reg.replace(/\/$/, ''); }
+  }, []);
+
   return (
     <div className="marketplace-page">
       <header className="marketplace-header">
         <h1>Application Marketplace</h1>
-        <p>Browse and install applications from configured registries</p>
+        <div className="marketplace-header-row">
+          <p>Browse and install applications from configured registries</p>
+          {registryUrl && (
+            <button
+              className="explore-registry-btn"
+              onClick={() => invoke('open_url_in_browser', { url: registryUrl })}
+            >
+              <ExternalLink size={13} />
+              Explore Registry on web
+            </button>
+          )}
+        </div>
       </header>
 
       <main className="marketplace-main">
@@ -436,24 +448,25 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
           </div>
           
           <div className="marketplace-filters">
-            <select
-              value={filterInstalled}
-              onChange={(e) => setFilterInstalled(e.target.value as any)}
-              className="filter-select"
-            >
-              <option value="all">All Apps</option>
-              <option value="installed">Installed</option>
-              <option value="not-installed">Not Installed</option>
-            </select>
-            
-            <button 
-              onClick={handleForceRefresh} 
-              className="button button-secondary"
+            <div className="filter-pills">
+              {(['all', 'installed', 'not-installed'] as const).map((f) => (
+                <button
+                  key={f}
+                  className={`filter-pill${filterInstalled === f ? ' active' : ''}`}
+                  onClick={() => setFilterInstalled(f)}
+                >
+                  {f === 'all' ? 'All' : f === 'installed' ? 'Installed' : 'Not Installed'}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={handleForceRefresh}
+              className="refresh-btn"
               disabled={loading || refreshing}
-              title="Refresh applications"
+              title="Refresh"
             >
-              <RefreshCw size={16} className={loading || refreshing ? 'spinning' : ''} />
-          </button>
+              <RefreshCw size={15} className={loading || refreshing ? 'spinning' : ''} />
+            </button>
           </div>
         </div>
 
@@ -468,17 +481,25 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
             {Array.from({ length: 6 }).map((_, index) => (
               <div key={index} className="app-card skeleton-card">
                 <div className="app-card-header">
-                  <Skeleton variant="text" width="60%" height="20px" />
-                  <Skeleton variant="rectangular" width="70px" height="24px" borderRadius="12px" />
+                  <Skeleton variant="rectangular" width="40px" height="40px" borderRadius="10px" />
+                  <div className="app-title-section">
+                    <Skeleton variant="text" width="70%" height="16px" />
+                    <Skeleton variant="text" width="40%" height="12px" />
+                  </div>
                 </div>
-                <div className="app-card-body">
-                  <Skeleton variant="text" width="80%" height="14px" />
-                  <Skeleton variant="text" width="50%" height="14px" />
-                  <Skeleton variant="text" width="70%" height="14px" />
-                  <Skeleton variant="text" width="60%" height="14px" />
+                <div className="app-card-description">
+                  <Skeleton variant="text" width="100%" height="13px" />
+                  <div style={{ marginTop: 6 }}><Skeleton variant="text" width="85%" height="13px" /></div>
+                  <div style={{ marginTop: 6 }}><Skeleton variant="text" width="60%" height="13px" /></div>
                 </div>
-                <div className="skeleton-card-actions">
-                  <Skeleton variant="rectangular" width="100px" height="36px" borderRadius="4px" />
+                <div className="app-card-footer">
+                  <div className="app-meta">
+                    <Skeleton variant="text" width="80%" height="12px" />
+                    <div style={{ marginTop: 4 }}><Skeleton variant="text" width="60%" height="12px" /></div>
+                  </div>
+                </div>
+                <div className="app-card-actions">
+                  <Skeleton variant="rectangular" width="100%" height="38px" borderRadius="10px" />
                 </div>
               </div>
             ))}
@@ -500,40 +521,39 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
         ) : (
           <div className="apps-grid">
             {filteredAndSortedApps.map((app, index) => {
-              // Shorten developer pubkey for display
               const shortPubkey = app.developer_pubkey && app.developer_pubkey.length > 12
                 ? `${app.developer_pubkey.slice(0, 6)}...${app.developer_pubkey.slice(-4)}`
                 : app.developer_pubkey;
-              
+              const description = app.description || "No description available.";
+
               return (
-              <div key={`${app.developer_pubkey}-${app.name}-${index}`} className="app-card" data-testid="app-card">
-                <div className="app-card-header">
+                <div
+                  key={`${app.developer_pubkey}-${app.name}-${index}`}
+                  className="app-card"
+                  data-testid="app-card"
+                  onClick={() => setSelectedApp(app)}
+                >
+                  <div className="app-card-header">
                     <div className="app-icon-wrapper">
                       <Package className="app-icon" size={20} />
                     </div>
                     <div className="app-title-section">
-                  <h3>{app.alias || app.name}</h3>
+                      <h3>{app.alias || app.name}</h3>
                       {app.latest_version && (
                         <span className="app-version-badge">v{app.latest_version}</span>
                       )}
                     </div>
-                  {app.installed && (
+                    {app.installed && (
                       <CheckCircle2 className="installed-icon" size={18} />
                     )}
                   </div>
-                  
-                  {app.description && (
-                    <div className="app-card-description">
-                      <p>{app.description}</p>
-                    </div>
-                  )}
+
+                  <div className="app-card-description">
+                    <p>{description}</p>
+                  </div>
 
                   <div className="app-card-footer">
                     <div className="app-meta">
-                      <div className="app-meta-row">
-                        <span className="app-meta-label">Package:</span>
-                        <span className="app-meta-value" title={app.id}>{app.id}</span>
-                      </div>
                       <div className="app-meta-row">
                         <span className="app-meta-label">Author:</span>
                         <span className="app-meta-value">
@@ -546,17 +566,17 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
                       </div>
                     </div>
                   </div>
-                  
-                <div className="app-card-actions">
-                  {app.installed ? (
+
+                  <div className="app-card-actions" onClick={(e) => e.stopPropagation()}>
+                    {app.installed ? (
                       <button className="button button-success" disabled>
                         <CheckCircle2 size={16} />
-                      Installed
-                    </button>
-                  ) : (
-                    <button
-                      onClick={() => handleInstall(app)}
-                      className="button button-primary"
+                        Installed
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => handleInstall(app)}
+                        className="button button-primary"
                         disabled={installingAppId === app.id}
                       >
                         {installingAppId === app.id ? (
@@ -566,19 +586,101 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
                           </>
                         ) : (
                           <>
-                            <Download size={16} />
-                      Install
+                            <span className="install-icon-wrap"><Download size={16} /></span>
+                            Install
                           </>
                         )}
-                    </button>
-                  )}
+                      </button>
+                    )}
+                  </div>
                 </div>
-              </div>
               );
             })}
           </div>
         )}
       </main>
+
+      {selectedApp && (
+        <div className="app-detail-overlay" onClick={() => setSelectedApp(null)}>
+          <div className="app-detail-modal" onClick={(e) => e.stopPropagation()}>
+            <button className="modal-close" onClick={() => setSelectedApp(null)}>
+              <X size={18} />
+            </button>
+            <div className="modal-header">
+              <div className="app-icon-wrapper modal-icon">
+                <Package size={28} className="app-icon" />
+              </div>
+              <div className="modal-title">
+                <h2>{selectedApp.alias || selectedApp.name}</h2>
+                {selectedApp.latest_version && (
+                  <span className="app-version-badge">v{selectedApp.latest_version}</span>
+                )}
+              </div>
+              {selectedApp.installed && (
+                <CheckCircle2 className="installed-icon" size={22} />
+              )}
+            </div>
+            <p className="modal-description">
+              {selectedApp.description || "No description available."}
+            </p>
+            <div className="modal-meta">
+              <div className="modal-meta-row">
+                <span className="modal-meta-label">Package ID</span>
+                <span className="modal-meta-value mono">{selectedApp.id}</span>
+              </div>
+              <div className="modal-meta-row">
+                <span className="modal-meta-label">Author</span>
+                <span className="modal-meta-value">
+                  {selectedApp.author || (
+                    selectedApp.developer_pubkey
+                      ? `${selectedApp.developer_pubkey.slice(0, 8)}...${selectedApp.developer_pubkey.slice(-6)}`
+                      : '—'
+                  )}
+                </span>
+              </div>
+              <div className="modal-meta-row">
+                <span className="modal-meta-label">Downloads</span>
+                <span className="modal-meta-value">{(selectedApp.downloads ?? 0).toLocaleString()}</span>
+              </div>
+              <div className="modal-meta-row">
+                <span className="modal-meta-label">Registry</span>
+                <a
+                  href={(() => { try { return `${new URL(selectedApp.registry).origin}/apps/${selectedApp.id}`; } catch { return `${selectedApp.registry.replace(/\/$/, '')}/apps/${selectedApp.id}`; } })()}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="modal-meta-link"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  View on Registry
+                </a>
+              </div>
+            </div>
+            <div className="modal-actions">
+              {selectedApp.installed ? (
+                <button className="button button-success" disabled>
+                  <CheckCircle2 size={16} />
+                  Installed
+                </button>
+              ) : (
+                <button
+                  onClick={() => { handleInstall(selectedApp); setSelectedApp(null); }}
+                  className="button button-primary"
+                  disabled={installingAppId === selectedApp.id}
+                >
+                  {installingAppId === selectedApp.id ? (
+                    <><RefreshCw size={16} className="spinning" /> Installing...</>
+                  ) : (
+                    <><span className="install-icon-wrap"><Download size={16} /></span>Install</>
+                  )}
+                </button>
+              )}
+              <button className="button button-secondary" onClick={() => setSelectedApp(null)}>
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -644,15 +644,16 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
               </div>
               <div className="modal-meta-row">
                 <span className="modal-meta-label">Registry</span>
-                <a
-                  href={(() => { try { return `${new URL(selectedApp.registry).origin}/apps/${selectedApp.id}`; } catch { return `${selectedApp.registry.replace(/\/$/, '')}/apps/${selectedApp.id}`; } })()}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <button
                   className="modal-meta-link"
-                  onClick={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    const url = (() => { try { return `${new URL(selectedApp.registry).origin}/apps/${selectedApp.id}`; } catch { return `${selectedApp.registry.replace(/\/$/, '')}/apps/${selectedApp.id}`; } })();
+                    invoke('open_url_in_browser', { url });
+                  }}
                 >
                   View on Registry
-                </a>
+                </button>
               </div>
             </div>
             <div className="modal-actions">

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -391,6 +391,8 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
       // loadInstalledApps updates installedAppIds, which the sync useEffect
       // uses to flip installed:true on the affected card only.
       await loadInstalledApps();
+      // Refresh the open modal so it shows "Installed" instead of "Install".
+      setSelectedApp((prev) => prev?.id === app.id ? { ...prev, installed: true } : prev);
     } catch (err) {
       console.error("📦 Marketplace: Install exception:", err);
       const msg = truncateText(err instanceof Error ? err.message : "Unknown error", 120);

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -648,7 +648,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
                   className="modal-meta-link"
                   onClick={(e) => {
                     e.stopPropagation();
-                    const url = (() => { try { return `${new URL(selectedApp.registry).origin}/apps/${selectedApp.id}`; } catch { return `${selectedApp.registry.replace(/\/$/, '')}/apps/${selectedApp.id}`; } })();
+                    const url = (() => { try { return `${new URL(selectedApp.registry).origin}/apps/${encodeURIComponent(selectedApp.id)}`; } catch { return `${selectedApp.registry.replace(/\/$/, '')}/apps/${encodeURIComponent(selectedApp.id)}`; } })();
                     invoke('open_url_in_browser', { url });
                   }}
                 >
@@ -664,7 +664,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
                 </button>
               ) : (
                 <button
-                  onClick={() => { handleInstall(selectedApp); setSelectedApp(null); }}
+                  onClick={() => handleInstall(selectedApp)}
                   className="button button-primary"
                   disabled={installingAppId === selectedApp.id}
                 >

--- a/apps/desktop/src/pages/Namespaces.css
+++ b/apps/desktop/src/pages/Namespaces.css
@@ -109,8 +109,8 @@
 }
 
 .ns-modal-close:hover {
-  background: var(--bg-hover, rgba(255, 255, 255, 0.06));
-  color: var(--text-primary);
+  background: var(--accent-light);
+  color: var(--accent-primary);
 }
 
 .ns-modal-body {
@@ -192,11 +192,15 @@
   background: transparent;
   color: var(--text-secondary);
   font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
+  transition: all 0.15s;
 }
 
 .ns-modal-cancel:hover:not(:disabled) {
-  color: var(--text-primary);
+  background: rgba(239, 68, 68, 0.08);
+  border-color: rgba(239, 68, 68, 0.4);
+  color: var(--error);
 }
 
 .ns-modal-cancel:disabled {
@@ -397,6 +401,20 @@
   -webkit-backdrop-filter: blur(12px);
 }
 
+.stat-card.stat-card-clickable {
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.stat-card.stat-card-clickable:hover {
+  border-color: var(--accent-dim);
+  background: var(--accent-light), var(--surface-glass);
+}
+
+.stat-card.stat-card-clickable:hover .stat-label {
+  color: var(--accent-primary);
+}
+
 .stat-value {
   font-size: 1.5rem;
   font-weight: 700;
@@ -508,13 +526,83 @@
 }
 
 .ns-member-item {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--surface-glass-soft);
+  overflow: hidden;
+  transition: border-color 0.15s;
+}
+
+.ns-member-clickable {
+  cursor: default;
+}
+
+.ns-member-item.ns-member-expanded {
+  border-color: var(--accent-dim);
+}
+
+.ns-member-row {
   display: flex;
   align-items: center;
   gap: 12px;
   padding: 10px 14px;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  background: var(--surface-glass-soft);
+  cursor: pointer;
+  user-select: none;
+}
+
+.ns-member-row:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.member-chevron {
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+  transition: transform 0.2s;
+}
+
+.member-chevron.member-chevron-open {
+  transform: rotate(90deg);
+}
+
+.ns-member-detail {
+  padding: 10px 14px 12px;
+  border-top: 1px solid var(--border-color);
+  background: rgba(0, 0, 0, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ns-member-detail-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.ns-member-detail-label {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 500;
+  min-width: 90px;
+  padding-top: 1px;
+}
+
+.ns-member-detail-value {
+  font-size: 12px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+}
+
+.ns-member-full-id {
+  word-break: break-all;
+  line-height: 1.5;
+  font-size: 11px;
+  color: var(--text-secondary);
 }
 
 .member-info {
@@ -651,4 +739,147 @@
 .ha-toggle-btn.ha-enabled:hover:not(:disabled) {
   border-color: var(--error);
   color: var(--error);
+}
+
+/* ─── HA Section redesign ─── */
+.ns-ha-section {
+  background: var(--surface-glass-soft);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 16px;
+}
+
+.ns-ha-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.ns-ha-icon {
+  color: var(--accent-primary);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.ns-ha-header h2 {
+  margin: 0 0 4px 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  border: none;
+  padding: 0;
+}
+
+.ns-ha-header .ha-description {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.ha-badge-wrap {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.ha-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.ha-badge-enabled {
+  background: rgba(34, 197, 94, 0.12);
+  color: var(--success);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+}
+
+.ha-badge-disabled {
+  background: var(--surface-glass-soft);
+  color: var(--text-tertiary);
+  border: 1px solid var(--border-color);
+}
+
+.ha-cloud-required-banner {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border-color);
+  font-size: 12px;
+  color: var(--text-tertiary);
+  line-height: 1.4;
+}
+
+.ha-cloud-banner-icon {
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+.ha-cloud-required-banner strong {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.ha-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0;
+  background: none;
+  border: none;
+}
+
+/* ─── Modal field extras ─── */
+.ns-modal-field-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.ns-char-counter {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.ns-optional {
+  color: var(--text-tertiary);
+  font-weight: 400;
+}
+
+.ns-modal-textarea {
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary, rgba(255, 255, 255, 0.03));
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  resize: vertical;
+  min-height: 64px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.ns-modal-textarea:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+}
+
+.ns-modal-textarea.ns-input-error {
+  border-color: var(--error);
+}
+
+.ns-field-error {
+  font-size: 11px;
+  color: var(--error);
+  margin-top: -2px;
 }

--- a/apps/desktop/src/pages/Namespaces.css
+++ b/apps/desktop/src/pages/Namespaces.css
@@ -211,18 +211,8 @@
 .ns-header {
   display: flex;
   align-items: center;
-  gap: 16px;
-  margin-bottom: 24px;
-  padding-bottom: 16px;
-  border-bottom: 1px solid var(--border-color);
-}
-
-.ns-header h1 {
-  margin: 0;
-  font-size: 24px;
-  font-weight: 700;
-  color: var(--text-primary);
-  letter-spacing: -0.4px;
+  margin-bottom: 20px;
+  min-height: 32px;
 }
 
 .ns-header-id {
@@ -232,27 +222,60 @@
   font-family: 'JetBrains Mono', 'Fira Code', monospace;
   font-size: 12px;
   color: var(--text-tertiary);
-  margin-top: 2px;
+  margin-top: 4px;
 }
 
 .ns-back {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 12px;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  background: var(--surface-glass-soft);
+  padding: 0;
+  border: none;
+  background: none;
   color: var(--text-secondary);
   cursor: pointer;
   font-size: 13px;
-  transition: all 0.2s;
+  font-family: inherit;
+  transition: color 0.15s;
   white-space: nowrap;
 }
 
 .ns-back:hover {
-  border-color: var(--accent-dim);
+  background: none;
+  color: var(--accent-primary);
+}
+
+/* ─── Page top content section ─── */
+.ns-page-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.ns-page-top-left {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.ns-page-top-left h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
   color: var(--text-primary);
+  letter-spacing: -0.4px;
+}
+
+.ns-page-top-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
 .ns-main {
@@ -419,6 +442,8 @@
   font-size: 1.5rem;
   font-weight: 700;
   color: var(--text-primary);
+  word-break: break-word;
+  line-height: 1.2;
 }
 
 .stat-label {
@@ -612,10 +637,29 @@
   gap: 2px;
 }
 
+.member-name-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .member-name {
   font-weight: 500;
   color: var(--text-primary);
   font-size: 14px;
+}
+
+.ns-me-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  background: var(--accent-light);
+  color: var(--accent-primary);
+  letter-spacing: 0.03em;
+  flex-shrink: 0;
 }
 
 .member-id {
@@ -882,4 +926,366 @@
   font-size: 11px;
   color: var(--error);
   margin-top: -2px;
+}
+
+/* ─── Action buttons ─── */
+.ns-danger-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border: none;
+  background: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+  flex-shrink: 0;
+}
+
+.ns-danger-icon-btn:hover {
+  color: var(--error, #ef4444);
+  background: rgba(239, 68, 68, 0.08);
+}
+
+.ns-invite-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 13px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-glass-soft);
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.ns-invite-btn:hover {
+  border-color: var(--accent-dim);
+  color: var(--accent-primary);
+}
+
+.ns-danger-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 13px;
+  border-radius: 8px;
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  background: rgba(239, 68, 68, 0.06);
+  color: var(--error, #ef4444);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.ns-danger-btn:hover {
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.4);
+}
+
+/* ─── Namespace card actions ─── */
+.ns-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* ─── Delete confirm modal ─── */
+.ns-delete-warning {
+  background: rgba(239, 68, 68, 0.06);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ns-delete-name {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 14px;
+  margin: 0;
+}
+
+.ns-delete-msg {
+  color: var(--text-secondary);
+  font-size: 13px;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.ns-delete-final {
+  color: var(--error, #ef4444);
+  font-size: 12px;
+  font-weight: 500;
+  margin: 0;
+}
+
+.ns-delete-confirm-btn {
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: none;
+  background: var(--error, #ef4444);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  transition: opacity 0.15s;
+}
+
+.ns-delete-confirm-btn:hover:not(:disabled) {
+  opacity: 0.88;
+}
+
+.ns-delete-confirm-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ─── Invite modal ─── */
+.ns-modal-wide {
+  width: min(560px, calc(100vw - 32px));
+}
+
+.ns-invite-payload {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary, rgba(255, 255, 255, 0.03));
+  color: var(--text-secondary);
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 11px;
+  line-height: 1.6;
+  resize: none;
+  box-sizing: border-box;
+  word-break: break-all;
+}
+
+.ns-invite-payload:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+}
+
+/* ─── App select dropdown (Create Namespace modal) ─── */
+.ns-app-select-wrapper {
+  position: relative;
+}
+
+.ns-app-select-trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--bg-secondary, rgba(255, 255, 255, 0.03));
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--text-primary);
+  transition: border-color 0.15s, box-shadow 0.15s;
+  text-align: left;
+  box-sizing: border-box;
+}
+
+.ns-app-select-trigger:hover:not(:disabled) {
+  border-color: var(--border-hover);
+}
+
+.ns-app-select-trigger.open {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 2px var(--accent-light);
+}
+
+.ns-app-select-trigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ns-app-select-name {
+  flex: 1;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ns-app-select-chevron {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+  transition: transform 0.2s ease;
+}
+
+.ns-app-select-chevron.open {
+  transform: rotate(180deg);
+  color: var(--accent-primary);
+}
+
+.ns-app-select-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: #0d1117;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  z-index: 300;
+  overflow: hidden;
+  animation: nodeDropdownIn 0.15s ease-out;
+}
+
+[data-theme="light"] .ns-app-select-menu {
+  background: #ffffff;
+}
+
+.ns-app-select-option {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border-color);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--text-primary);
+  text-align: left;
+  transition: background 0.12s;
+  box-sizing: border-box;
+}
+
+.ns-app-select-option:last-child {
+  border-bottom: none;
+}
+
+.ns-app-select-option:hover {
+  background: var(--accent-light);
+}
+
+.ns-app-select-option.selected {
+  background: rgba(165, 255, 17, 0.06);
+}
+
+[data-theme="light"] .ns-app-select-option.selected {
+  background: rgba(106, 171, 0, 0.06);
+}
+
+.ns-app-select-option-name {
+  flex: 1;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ns-app-select-option.selected .ns-app-select-option-name {
+  color: var(--accent-primary);
+}
+
+.ns-app-select-option-id {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+.ns-app-select-check {
+  color: var(--accent-primary);
+  flex-shrink: 0;
+}
+
+/* ─── Three-dot actions menu ─── */
+.ns-actions-menu-wrapper {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.ns-actions-menu-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-glass-soft);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s;
+  padding: 0;
+  font-family: inherit;
+}
+
+.ns-actions-menu-btn:hover,
+.ns-actions-menu-btn.open {
+  border-color: var(--border-hover);
+  background: var(--surface-glass);
+  color: var(--text-primary);
+}
+
+.ns-actions-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 180px;
+  background: #0d1117;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  z-index: 200;
+  overflow: hidden;
+  animation: nodeDropdownIn 0.15s ease-out;
+}
+
+[data-theme="light"] .ns-actions-menu {
+  background: #ffffff;
+}
+
+.ns-actions-menu-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 14px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border-color);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--text-primary);
+  text-align: left;
+  transition: background 0.12s;
+  box-sizing: border-box;
+}
+
+.ns-actions-menu-item:last-child {
+  border-bottom: none;
+}
+
+.ns-actions-menu-item:hover {
+  background: var(--accent-light);
+}
+
+.ns-actions-menu-item-danger {
+  color: var(--error, #ef4444);
+}
+
+.ns-actions-menu-item-danger:hover {
+  background: rgba(239, 68, 68, 0.08) !important;
+  color: var(--error, #ef4444);
 }

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -80,7 +80,7 @@ export default function Namespaces() {
 
   const activeNsId = view.type === "namespace" || view.type === "group" ? view.ns.namespaceId : null;
   const activeGroupId = view.type === "group" ? view.groupId : null;
-  const activeNsRootId = view.type === "namespace" ? view.ns.namespaceId : null;
+  const activeNsRootId = (view.type === "namespace" || view.type === "group") ? view.ns.namespaceId : null;
 
   const { namespaces, loading, error, refetch: refetchNamespaces } = useNamespaces();
   const { groups: nsGroups, loading: nsLoadingGroups, error: nsGroupsError, refetch: refetchNsGroups } = useNamespaceGroups(activeNsId) as any;
@@ -92,7 +92,8 @@ export default function Namespaces() {
   const [nsMembersVersion, setNsMembersVersion] = useState(0);
 
   useEffect(() => {
-    if (!activeNsRootId) { setNsMembers([]); return; }
+    if (view.type !== "namespace" || !activeNsRootId) { setNsMembers([]); return; }
+    const controller = new AbortController();
     const settings = getSettings();
     const token = getAccessToken();
     if (!settings.nodeUrl || !token) return;
@@ -100,15 +101,17 @@ export default function Namespaces() {
     // TODO: replace with mero.admin.listGroupMembers once mero-react hook parsing is fixed
     fetch(`${settings.nodeUrl}/admin-api/groups/${encodeURIComponent(activeNsRootId)}/members`, {
       headers: { Authorization: `Bearer ${token}` },
+      signal: controller.signal,
     })
       .then((r) => r.json())
       .then((json) => {
         const members = json?.members ?? json?.data?.members ?? [];
         setNsMembers(Array.isArray(members) ? members : []);
       })
-      .catch(() => { setNsMembers([]); })
+      .catch((e) => { if (e?.name !== 'AbortError') setNsMembers([]); })
       .finally(() => setNsMembersLoading(false));
-  }, [activeNsRootId, nsMembersVersion]);
+    return () => controller.abort();
+  }, [activeNsRootId, nsMembersVersion, view.type]);
 
   const { contexts: groupContexts, refetch: refetchGroupContexts } = useGroupContexts(activeGroupId);
   const { contexts: nsRootContexts, refetch: refetchNsRootContexts } = useGroupContexts(
@@ -220,7 +223,7 @@ export default function Namespaces() {
         groupId: namespaceId,
         serviceName: serviceName.trim() || undefined,
         initializationParams: Array.from(new TextEncoder().encode(argsJson)),
-        alias: alias?.trim() || undefined,
+        name: alias?.trim() || undefined,
       });
       if (!result) throw new Error('createContext returned null');
       saveContextKey(result.contextId, result.memberPublicKey, applicationId);
@@ -228,7 +231,7 @@ export default function Namespaces() {
       setCtxModalOpen(null);
       await Promise.all([refetchGroupContexts?.(), refetchNsRootContexts?.()]);
     } catch (e: any) {
-      toast.error(`Failed to create context: ${e?.bodyText ?? e?.message ?? String(e)}`);
+      toast.error(`Failed to create context: ${parseApiError(e)}`);
     } finally {
       setCreatingContext(false);
     }

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -8,11 +8,10 @@ import {
   useGroupContexts,
   useSubgroups,
   useCreateNamespace,
-  useCreateContext,
   type Namespace,
 } from "@calimero-network/mero-react";
 import { useToast } from "../contexts/ToastContext";
-import { ArrowLeft, Users, Box, Layers, Copy, ChevronRight, Shield, Globe, Plus, X, Play } from "lucide-react";
+import { ChevronLeft, Users, Box, Layers, Copy, ChevronRight, Shield, Globe, Plus, X, Play } from "lucide-react";
 import { apiClient } from "../lib/mero-client";
 import { saveContextKey, getContextKey } from "../utils/contextKeys";
 import { decodeMetadata, openAppFrontend } from "../utils/appUtils";
@@ -70,21 +69,43 @@ export default function Namespaces() {
   // Current namespace/group IDs for hooks
   const activeNsId = view.type === "namespace" || view.type === "group" ? view.ns.namespaceId : null;
   const activeGroupId = view.type === "group" ? view.groupId : null;
+  const activeNsRootId = view.type === "namespace" ? view.ns.namespaceId : null;
 
   // Hooks
   const { namespaces, loading, error, refetch: refetchNamespaces } = useNamespaces();
   const { groups: nsGroups, loading: nsLoadingGroups, error: nsGroupsError } = useNamespaceGroups(activeNsId);
   const { groupInfo, loading: groupInfoLoading } = useGroupInfo(activeGroupId);
+  const { groupInfo: nsRootGroupInfo } = useGroupInfo(activeNsRootId);
   const { members: groupMembers } = useGroupMembers(activeGroupId);
+  const [nsMembers, setNsMembers] = useState<any[]>([]);
+  const [nsMembersLoading, setNsMembersLoading] = useState(false);
+
+  useEffect(() => {
+    if (!activeNsRootId) { setNsMembers([]); return; }
+    const settings = getSettings();
+    const token = localStorage.getItem('calimero_access_token');
+    if (!settings.nodeUrl || !token) return;
+    setNsMembersLoading(true);
+    fetch(`${settings.nodeUrl}/admin-api/groups/${activeNsRootId}/members`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => r.json())
+      .then((json) => {
+        const members = json?.members ?? json?.data?.members ?? [];
+        setNsMembers(Array.isArray(members) ? members : []);
+      })
+      .catch(() => { setNsMembers([]); })
+      .finally(() => setNsMembersLoading(false));
+  }, [activeNsRootId]);
   const { contexts: groupContexts, refetch: refetchGroupContexts } = useGroupContexts(activeGroupId);
   // Contexts that live directly in a namespace's root group (battleships-style lobby contexts)
   const { contexts: nsRootContexts, refetch: refetchNsRootContexts } = useGroupContexts(
     view.type === "namespace" ? view.ns.namespaceId : null,
   );
-  const { subgroups: groupSubgroups } = useSubgroups(activeGroupId);
+  const { subgroups: groupSubgroups = [] } = useSubgroups(activeGroupId);
 
   const { createNamespace, loading: creatingNamespace } = useCreateNamespace();
-  const { createContext, loading: creatingContext } = useCreateContext();
+  const [creatingContext, setCreatingContext] = useState(false);
 
   // Installed apps (loaded lazily for the Create-Namespace dropdown)
   const [installedApps, setInstalledApps] = useState<InstalledApp[]>([]);
@@ -92,9 +113,24 @@ export default function Namespaces() {
     readInstalledApps().then(setInstalledApps).catch(() => setInstalledApps([]));
   }, []);
 
+  const appById = installedApps.reduce<Record<string, InstalledApp>>((acc, a) => {
+    acc[a.id] = a;
+    return acc;
+  }, {});
+
+  const nsDisplayName = (ns: Namespace) => {
+    const fromList = (ns as any).name as string | undefined;
+    const fromGroupMeta = nsRootGroupInfo && ns.namespaceId === activeNsRootId
+      ? nsRootGroupInfo.metadata?.name as string | undefined
+      : undefined;
+    const fromApp = appById[ns.targetApplicationId]?.name;
+    return fromList || fromGroupMeta || fromApp || truncateId(ns.namespaceId);
+  };
+
   // Modals
   const [nsModalOpen, setNsModalOpen] = useState(false);
   const [ctxModalOpen, setCtxModalOpen] = useState<{ namespaceId: string; applicationId: string } | null>(null);
+  const [expandedMemberId, setExpandedMemberId] = useState<string | null>(null);
 
   const groupLoading = groupInfoLoading;
 
@@ -107,8 +143,8 @@ export default function Namespaces() {
       const result = await createNamespace({
         applicationId,
         upgradePolicy: "Automatic",
-        alias: alias?.trim() || undefined,
-      });
+        name: alias?.trim() || undefined,
+      } as any);
       if (!result) throw new Error("createNamespace returned null");
       try {
         await mero.admin.setDefaultCapabilities(result.namespaceId, {
@@ -130,16 +166,20 @@ export default function Namespaces() {
     applicationId: string,
     serviceName: string,
     alias: string | undefined,
+    initArgs: string,
   ) => {
+    if (!mero) return;
+    setCreatingContext(true);
     try {
-      const result = await createContext({
+      const argsJson = initArgs.trim() || '{}';
+      const result = await (mero.admin as any).createContext({
         applicationId,
         groupId: namespaceId,
         serviceName: serviceName.trim() || undefined,
-        initializationParams: [],
+        initializationParams: Array.from(new TextEncoder().encode(argsJson)),
         alias: alias?.trim() || undefined,
       });
-      if (!result) throw new Error("createContext returned null");
+      if (!result) throw new Error('createContext returned null');
       saveContextKey(result.contextId, result.memberPublicKey, applicationId);
       toast.success(`Context created: ${truncateId(result.contextId)}`);
       setCtxModalOpen(null);
@@ -148,7 +188,10 @@ export default function Namespaces() {
         refetchNsRootContexts?.(),
       ]);
     } catch (e: any) {
-      toast.error(`Failed to create context: ${e?.message ?? String(e)}`);
+      const msg = e?.bodyText ?? e?.message ?? String(e);
+      toast.error(`Failed to create context: ${msg}`);
+    } finally {
+      setCreatingContext(false);
     }
   };
 
@@ -342,8 +385,8 @@ export default function Namespaces() {
           applicationId={ctxModalOpen.applicationId}
           loading={creatingContext}
           onClose={() => setCtxModalOpen(null)}
-          onSubmit={(serviceName, alias) =>
-            onCreateContext(ctxModalOpen.namespaceId, ctxModalOpen.applicationId, serviceName, alias)
+          onSubmit={(serviceName, alias, initArgs) =>
+            onCreateContext(ctxModalOpen.namespaceId, ctxModalOpen.applicationId, serviceName, alias, initArgs)
           }
         />
       )}
@@ -399,7 +442,7 @@ export default function Namespaces() {
                   onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") openNamespace(ns); }}
                 >
                   <div className="ns-card-header">
-                    <h3>{(ns as any).alias || truncateId(ns.namespaceId)}</h3>
+                    <h3>{nsDisplayName(ns)}</h3>
                     <ChevronRight size={16} className="ns-card-chevron" />
                   </div>
                   <div className="ns-card-id" title={ns.namespaceId}>
@@ -441,10 +484,10 @@ export default function Namespaces() {
       <div className="ns-page">
         <header className="ns-header">
           <button className="ns-back" onClick={goBack}>
-            <ArrowLeft size={16} /> Back
+            <ChevronLeft size={16} /> Back
           </button>
           <div style={{ flex: 1 }}>
-            <h1>{(ns as any).alias || truncateId(ns.namespaceId)}</h1>
+            <h1>{nsDisplayName(ns)}</h1>
             <div className="ns-header-id">
               {truncateId(ns.namespaceId)}
               <button className="copy-btn" onClick={() => copyToClipboard(ns.namespaceId)} title="Copy ID">
@@ -462,16 +505,19 @@ export default function Namespaces() {
 
         <main className="ns-main">
           <div className="ns-detail-stats">
+            <button
+              className="stat-card stat-card-clickable"
+              onClick={() => document.getElementById('ns-members-section')?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+            >
+              <div className="stat-value">{nsMembersLoading ? '…' : nsMembers.length > 0 ? nsMembers.length : ((ns as any).memberCount ?? 0)}</div>
+              <div className="stat-label">Members ↓</div>
+            </button>
             <div className="stat-card">
-              <div className="stat-value">{(ns as any).memberCount ?? 0}</div>
-              <div className="stat-label">Members</div>
-            </div>
-            <div className="stat-card">
-              <div className="stat-value">{(ns as any).contextCount ?? 0}</div>
+              <div className="stat-value">{nsRootContexts.length > 0 ? nsRootContexts.length : ((ns as any).contextCount ?? 0)}</div>
               <div className="stat-label">Contexts</div>
             </div>
             <div className="stat-card">
-              <div className="stat-value">{(ns as any).subgroupCount ?? 0}</div>
+              <div className="stat-value">{nsGroups.length > 0 ? nsGroups.length : ((ns as any).subgroupCount ?? 0)}</div>
               <div className="stat-label">Groups</div>
             </div>
             <div className="stat-card">
@@ -503,7 +549,7 @@ export default function Namespaces() {
                   return (
                     <div key={c.contextId} className="ns-context-item">
                       <Box size={14} />
-                      <span className="context-name">{c.alias || truncateId(c.contextId)}</span>
+                      <span className="context-name">{c.name || truncateId(c.contextId)}</span>
                       <span className="context-id mono">{truncateId(c.contextId)}</span>
                       <button className="copy-btn" onClick={() => copyToClipboard(c.contextId)} title="Copy ID">
                         <Copy size={12} />
@@ -524,28 +570,98 @@ export default function Namespaces() {
             )}
           </div>
 
-          {isCloudEnabled() && (
-            <div className="ns-detail-section">
-              <h2><Shield size={16} style={{ marginRight: 6, verticalAlign: -2 }} />High Availability</h2>
-              <p className="ha-description">
-                Enable TEE replication to have fleet nodes automatically join and
-                replicate this namespace. Requires a Calimero Cloud account with a
-                paid plan.
-              </p>
-              <div className="ha-toggle-row">
-                <span className="ha-status">
-                  {haEnabled[ns.namespaceId] ? '✓ HA Enabled' : 'HA Disabled'}
-                </span>
-                <button
-                  className={`ha-toggle-btn ${haEnabled[ns.namespaceId] ? 'ha-enabled' : ''}`}
-                  onClick={() => toggleHa(ns)}
-                  disabled={!!haEnabling[ns.namespaceId]}
-                >
-                  {haEnabling[ns.namespaceId] ? 'Working...' : haEnabled[ns.namespaceId] ? 'Disable HA' : 'Enable HA'}
-                </button>
+          {isCloudEnabled() && (() => {
+            const cloudConnected = !!getCloudIdToken();
+            const nsHaEnabled = !!haEnabled[ns.namespaceId];
+            const nsHaEnabling = !!haEnabling[ns.namespaceId];
+            return (
+              <div className="ns-detail-section ns-ha-section">
+                <div className="ns-ha-header">
+                  <Shield size={18} className="ns-ha-icon" />
+                  <div>
+                    <h2>High Availability</h2>
+                    <p className="ha-description">
+                      Enable TEE replication to have fleet nodes automatically join and replicate
+                      your namespace data. Requires a Calimero Cloud account with a paid plan.
+                    </p>
+                  </div>
+                  <div className="ha-badge-wrap">
+                    <span className={`ha-badge ${nsHaEnabled ? 'ha-badge-enabled' : 'ha-badge-disabled'}`}>
+                      {nsHaEnabled ? 'Enabled' : 'Disabled'}
+                    </span>
+                  </div>
+                </div>
+                {!cloudConnected && !nsHaEnabled && (
+                  <div className="ha-cloud-required-banner">
+                    <Globe size={13} className="ha-cloud-banner-icon" />
+                    <span>Connect to Calimero Cloud first — <strong>Settings → Cloud</strong></span>
+                  </div>
+                )}
+                <div className="ha-toggle-row">
+                  <button
+                    className={`ha-toggle-btn ${nsHaEnabled ? 'ha-enabled' : ''}`}
+                    onClick={() => toggleHa(ns)}
+                    disabled={nsHaEnabling || (!cloudConnected && !nsHaEnabled)}
+                    title={!cloudConnected && !nsHaEnabled ? 'Connect to Calimero Cloud first (Settings → Cloud)' : undefined}
+                  >
+                    {nsHaEnabling ? 'Working...' : nsHaEnabled ? 'Disable HA' : 'Enable High Availability'}
+                  </button>
+                </div>
               </div>
-            </div>
-          )}
+            );
+          })()}
+
+          <div id="ns-members-section" className="ns-detail-section">
+            <h2><Users size={16} /> Members ({nsMembersLoading ? '…' : nsMembers.length})</h2>
+            {nsMembersLoading ? (
+              <p className="empty-hint">Loading members…</p>
+            ) : nsMembers.length === 0 ? (
+              <p className="empty-hint">No members</p>
+            ) : (
+              <div className="ns-member-list">
+                {nsMembers.map((m) => {
+                  const isExpanded = expandedMemberId === m.identity;
+                  return (
+                    <div key={m.identity} className={`ns-member-item ns-member-clickable${isExpanded ? ' ns-member-expanded' : ''}`}>
+                      <div className="ns-member-row" onClick={() => setExpandedMemberId(isExpanded ? null : m.identity)}>
+                        <div className="member-info">
+                          <span className="member-name">{m.name || truncateId(m.identity)}</span>
+                          <span className="member-id mono">{truncateId(m.identity)}</span>
+                        </div>
+                        <span className="member-role" style={{ color: roleColor(m.role) }}>
+                          {m.role}
+                        </span>
+                        <ChevronRight size={14} className={`member-chevron${isExpanded ? ' member-chevron-open' : ''}`} />
+                      </div>
+                      {isExpanded && (
+                        <div className="ns-member-detail">
+                          <div className="ns-member-detail-row">
+                            <span className="ns-member-detail-label">Full Identity</span>
+                            <div className="ns-member-detail-value">
+                              <span className="mono ns-member-full-id">{m.identity}</span>
+                              <button className="copy-btn" onClick={(e) => { e.stopPropagation(); copyToClipboard(m.identity); }} title="Copy full identity">
+                                <Copy size={12} />
+                              </button>
+                            </div>
+                          </div>
+                          <div className="ns-member-detail-row">
+                            <span className="ns-member-detail-label">Role</span>
+                            <span className="ns-member-detail-value" style={{ color: roleColor(m.role) }}>{m.role}</span>
+                          </div>
+                          {m.name && (
+                            <div className="ns-member-detail-row">
+                              <span className="ns-member-detail-label">Name</span>
+                              <span className="ns-member-detail-value">{m.name}</span>
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
 
           <div className="ns-detail-section">
             <h2>Groups</h2>
@@ -564,7 +680,7 @@ export default function Namespaces() {
                     onClick={() => openGroup(ns, g.groupId)}
                   >
                     <Layers size={16} />
-                    <span className="group-name">{(g as any).alias || truncateId(g.groupId)}</span>
+                    <span className="group-name">{(g as any).name || (g as any).metadata?.name || truncateId(g.groupId)}</span>
                     <span className="group-id mono">{truncateId(g.groupId)}</span>
                     <ChevronRight size={14} className="ns-card-chevron" />
                   </button>
@@ -587,10 +703,10 @@ export default function Namespaces() {
       <div className="ns-page">
         <header className="ns-header">
           <button className="ns-back" onClick={goBack}>
-            <ArrowLeft size={16} /> Back to {(ns as any).alias || "namespace"}
+            <ChevronLeft size={16} /> Back to {nsDisplayName(ns)}
           </button>
           <div>
-            <h1>{groupInfo?.alias || truncateId(groupId)}</h1>
+            <h1>{groupInfo?.metadata?.name || truncateId(groupId)}</h1>
             <div className="ns-header-id">
               {truncateId(groupId)}
               <button className="copy-btn" onClick={() => copyToClipboard(groupId)} title="Copy ID">
@@ -620,7 +736,7 @@ export default function Namespaces() {
                     <div className="stat-label">Upgrade Policy</div>
                   </div>
                   <div className="stat-card">
-                    <div className="stat-value" style={{ fontSize: "0.85rem" }}>{groupInfo.defaultVisibility || "—"}</div>
+                    <div className="stat-value" style={{ fontSize: "0.85rem" }}>{groupInfo.subgroupVisibility || "—"}</div>
                     <div className="stat-label">Visibility</div>
                   </div>
                 </div>
@@ -636,7 +752,7 @@ export default function Namespaces() {
                     {groupMembers.map((m) => (
                       <div key={m.identity} className="ns-member-item">
                         <div className="member-info">
-                          <span className="member-name">{(m as any).alias || truncateId(m.identity)}</span>
+                          <span className="member-name">{m.name || truncateId(m.identity)}</span>
                           <span className="member-id mono">{truncateId(m.identity)}</span>
                         </div>
                         <span className="member-role" style={{ color: roleColor(m.role) }}>
@@ -664,7 +780,7 @@ export default function Namespaces() {
                       return (
                         <div key={c.contextId} className="ns-context-item">
                           <Box size={14} />
-                          <span className="context-name">{c.alias || truncateId(c.contextId)}</span>
+                          <span className="context-name">{c.name || truncateId(c.contextId)}</span>
                           <span className="context-id mono">{truncateId(c.contextId)}</span>
                           <button className="copy-btn" onClick={() => copyToClipboard(c.contextId)} title="Copy ID">
                             <Copy size={12} />
@@ -697,7 +813,7 @@ export default function Namespaces() {
                         onClick={() => openGroup(ns, g.groupId)}
                       >
                         <Layers size={16} />
-                        <span className="group-name">{(g as any).alias || truncateId(g.groupId)}</span>
+                        <span className="group-name">{(g as any).name || (g as any).metadata?.name || truncateId(g.groupId)}</span>
                         <span className="group-id mono">{truncateId(g.groupId)}</span>
                         <ChevronRight size={14} className="ns-card-chevron" />
                       </button>
@@ -763,11 +879,15 @@ function CreateNamespaceModal({ installedApps, loading, onClose, onSubmit }: Cre
             </select>
           </label>
           <label className="ns-modal-field">
-            <span>Alias (optional)</span>
+            <div className="ns-modal-field-header">
+              <span>Alias (optional)</span>
+              <span className="ns-char-counter">{alias.length}/64</span>
+            </div>
             <input
               type="text"
               value={alias}
-              onChange={(e) => setAlias(e.target.value)}
+              onChange={(e) => setAlias(e.target.value.slice(0, 64))}
+              maxLength={64}
               placeholder="e.g. my-namespace"
             />
           </label>
@@ -793,12 +913,22 @@ interface CreateContextModalProps {
   applicationId: string;
   loading: boolean;
   onClose: () => void;
-  onSubmit: (serviceName: string, alias: string | undefined) => void;
+  onSubmit: (serviceName: string, alias: string | undefined, initArgs: string) => void;
 }
 
 function CreateContextModal({ namespaceId, applicationId, loading, onClose, onSubmit }: CreateContextModalProps) {
   const [serviceName, setServiceName] = useState("");
   const [alias, setAlias] = useState("");
+  const [initArgs, setInitArgs] = useState("");
+  const [argsError, setArgsError] = useState<string | null>(null);
+
+  const validateArgs = (val: string) => {
+    if (!val.trim()) { setArgsError(null); return; }
+    try { JSON.parse(val); setArgsError(null); }
+    catch { setArgsError("Invalid JSON"); }
+  };
+
+  const canSubmit = !argsError;
 
   return (
     <div className="ns-modal-backdrop" onClick={onClose}>
@@ -813,7 +943,8 @@ function CreateContextModal({ namespaceId, applicationId, loading, onClose, onSu
           className="ns-modal-body"
           onSubmit={(e) => {
             e.preventDefault();
-            onSubmit(serviceName, alias);
+            if (!canSubmit) return;
+            onSubmit(serviceName, alias || undefined, initArgs);
           }}
         >
           <div className="ns-modal-readonly">
@@ -821,7 +952,7 @@ function CreateContextModal({ namespaceId, applicationId, loading, onClose, onSu
             <div><strong>Application:</strong> <code>{applicationId.slice(0, 8)}…{applicationId.slice(-8)}</code></div>
           </div>
           <label className="ns-modal-field">
-            <span>Service name (optional)</span>
+            <span>Service name <span className="ns-optional">(optional)</span></span>
             <input
               type="text"
               value={serviceName}
@@ -830,7 +961,7 @@ function CreateContextModal({ namespaceId, applicationId, loading, onClose, onSu
             />
           </label>
           <label className="ns-modal-field">
-            <span>Alias (optional)</span>
+            <span>Alias <span className="ns-optional">(optional)</span></span>
             <input
               type="text"
               value={alias}
@@ -838,11 +969,24 @@ function CreateContextModal({ namespaceId, applicationId, loading, onClose, onSu
               placeholder="e.g. main-lobby"
             />
           </label>
+          <label className="ns-modal-field">
+            <span>Init arguments <span className="ns-optional">(optional JSON)</span></span>
+            <textarea
+              className={`ns-modal-textarea${argsError ? ' ns-input-error' : ''}`}
+              value={initArgs}
+              onChange={(e) => { setInitArgs(e.target.value); validateArgs(e.target.value); }}
+              onBlur={() => validateArgs(initArgs)}
+              placeholder='{}'
+              rows={3}
+              spellCheck={false}
+            />
+            {argsError && <span className="ns-field-error">{argsError}</span>}
+          </label>
           <div className="ns-modal-actions">
             <button type="button" className="ns-modal-cancel" onClick={onClose} disabled={loading}>
               Cancel
             </button>
-            <button type="submit" className="ns-action-btn" disabled={loading}>
+            <button type="submit" className="ns-action-btn" disabled={loading || !canSubmit}>
               {loading ? "Creating..." : "Create Context"}
             </button>
           </div>

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   useMero,
   useNamespaces,
@@ -11,7 +11,7 @@ import {
   type Namespace,
 } from "@calimero-network/mero-react";
 import { useToast } from "../contexts/ToastContext";
-import { ChevronLeft, Users, Box, Layers, Copy, ChevronRight, Shield, Globe, Plus, X, Play } from "lucide-react";
+import { ChevronLeft, Users, Box, Layers, Copy, ChevronRight, Shield, Globe, Plus, X, Play, Trash2, UserMinus, Link, ChevronDown, Check, MoreHorizontal, LogIn } from "lucide-react";
 import { apiClient } from "../lib/mero-client";
 import { saveContextKey, getContextKey } from "../utils/contextKeys";
 import { decodeMetadata, openAppFrontend } from "../utils/appUtils";
@@ -23,10 +23,22 @@ import {
   CloudSessionExpiredError,
 } from "../utils/cloudApi";
 import { getCloudIdToken } from "../utils/cloudAuth";
+import { getAccessToken } from "../lib/token-storage";
 import { isCloudEnabled } from "../utils/featureFlags";
 import "./Namespaces.css";
 
-// Same default as battleships: CAN_CREATE_CONTEXT (1) | CAN_INVITE_MEMBERS (2) | MANAGE_MEMBERS (8).
+function parseApiError(e: any): string {
+  if (!e) return 'Unknown error';
+  const msg: string = e?.message ?? String(e);
+  try { const p = JSON.parse(msg); if (p?.error) return String(p.error); } catch {}
+  if (e?.body?.error) return String(e.body.error);
+  if (typeof e?.bodyText === 'string') {
+    try { const p = JSON.parse(e.bodyText); if (p?.error) return String(p.error); } catch {}
+    return e.bodyText;
+  }
+  return msg;
+}
+
 const DEFAULT_NAMESPACE_CAPABILITIES = 1 | 2 | 8;
 
 interface InstalledApp {
@@ -66,27 +78,27 @@ export default function Namespaces() {
   const { mero } = useMero();
   const [view, setView] = useState<View>({ type: "list" });
 
-  // Current namespace/group IDs for hooks
   const activeNsId = view.type === "namespace" || view.type === "group" ? view.ns.namespaceId : null;
   const activeGroupId = view.type === "group" ? view.groupId : null;
   const activeNsRootId = view.type === "namespace" ? view.ns.namespaceId : null;
 
-  // Hooks
   const { namespaces, loading, error, refetch: refetchNamespaces } = useNamespaces();
-  const { groups: nsGroups, loading: nsLoadingGroups, error: nsGroupsError } = useNamespaceGroups(activeNsId);
+  const { groups: nsGroups, loading: nsLoadingGroups, error: nsGroupsError, refetch: refetchNsGroups } = useNamespaceGroups(activeNsId) as any;
   const { groupInfo, loading: groupInfoLoading } = useGroupInfo(activeGroupId);
   const { groupInfo: nsRootGroupInfo } = useGroupInfo(activeNsRootId);
-  const { members: groupMembers } = useGroupMembers(activeGroupId);
+  const { members: groupMembers, refetch: refetchGroupMembers } = useGroupMembers(activeGroupId) as any;
   const [nsMembers, setNsMembers] = useState<any[]>([]);
   const [nsMembersLoading, setNsMembersLoading] = useState(false);
+  const [nsMembersVersion, setNsMembersVersion] = useState(0);
 
   useEffect(() => {
     if (!activeNsRootId) { setNsMembers([]); return; }
     const settings = getSettings();
-    const token = localStorage.getItem('calimero_access_token');
+    const token = getAccessToken();
     if (!settings.nodeUrl || !token) return;
     setNsMembersLoading(true);
-    fetch(`${settings.nodeUrl}/admin-api/groups/${activeNsRootId}/members`, {
+    // TODO: replace with mero.admin.listGroupMembers once mero-react hook parsing is fixed
+    fetch(`${settings.nodeUrl}/admin-api/groups/${encodeURIComponent(activeNsRootId)}/members`, {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((r) => r.json())
@@ -96,18 +108,40 @@ export default function Namespaces() {
       })
       .catch(() => { setNsMembers([]); })
       .finally(() => setNsMembersLoading(false));
-  }, [activeNsRootId]);
+  }, [activeNsRootId, nsMembersVersion]);
+
   const { contexts: groupContexts, refetch: refetchGroupContexts } = useGroupContexts(activeGroupId);
-  // Contexts that live directly in a namespace's root group (battleships-style lobby contexts)
   const { contexts: nsRootContexts, refetch: refetchNsRootContexts } = useGroupContexts(
     view.type === "namespace" ? view.ns.namespaceId : null,
   );
-  const { subgroups: groupSubgroups = [] } = useSubgroups(activeGroupId);
+  const { subgroups: groupSubgroups = [], refetch: refetchSubgroups } = useSubgroups(activeGroupId) as any;
 
   const { createNamespace, loading: creatingNamespace } = useCreateNamespace();
   const [creatingContext, setCreatingContext] = useState(false);
 
-  // Installed apps (loaded lazily for the Create-Namespace dropdown)
+  // Action state
+  const [actionLoading, setActionLoading] = useState(false);
+  const [deleteNsTarget, setDeleteNsTarget] = useState<Namespace | null>(null);
+  const [deleteGroupTarget, setDeleteGroupTarget] = useState<string | null>(null);
+  const [deleteContextTarget, setDeleteContextTarget] = useState<{ contextId: string; name: string; refetch: () => void } | null>(null);
+  const [removeMemberTarget, setRemoveMemberTarget] = useState<{ groupId: string; identity: string; name: string; onSuccess: () => void } | null>(null);
+  const [inviteModal, setInviteModal] = useState<{ groupId: string; isNamespace: boolean } | null>(null);
+  const [actionsMenuOpen, setActionsMenuOpen] = useState(false);
+  const actionsMenuRef = useRef<HTMLDivElement>(null);
+  const [joinNsModal, setJoinNsModal] = useState(false);
+  const [joinCtxModal, setJoinCtxModal] = useState<{ groupId: string; refetch: () => void } | null>(null);
+
+  const [myIdentity, setMyIdentity] = useState<string | null>(null);
+  useEffect(() => {
+    try {
+      const token = getAccessToken();
+      if (!token) return;
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      const id = payload.sub || payload.identity || payload.public_key;
+      if (id) setMyIdentity(id);
+    } catch {}
+  }, []);
+
   const [installedApps, setInstalledApps] = useState<InstalledApp[]>([]);
   useEffect(() => {
     readInstalledApps().then(setInstalledApps).catch(() => setInstalledApps([]));
@@ -127,18 +161,27 @@ export default function Namespaces() {
     return fromList || fromGroupMeta || fromApp || truncateId(ns.namespaceId);
   };
 
-  // Modals
   const [nsModalOpen, setNsModalOpen] = useState(false);
   const [ctxModalOpen, setCtxModalOpen] = useState<{ namespaceId: string; applicationId: string } | null>(null);
   const [expandedMemberId, setExpandedMemberId] = useState<string | null>(null);
 
   const groupLoading = groupInfoLoading;
 
+  useEffect(() => {
+    if (!actionsMenuOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (actionsMenuRef.current && !actionsMenuRef.current.contains(e.target as Node)) {
+        setActionsMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [actionsMenuOpen]);
+
+  // ── Handlers ──
+
   const onCreateNamespace = async (applicationId: string, alias: string | undefined) => {
-    if (!mero) {
-      toast.error("Node client not ready");
-      return;
-    }
+    if (!mero) { toast.error("Node client not ready"); return; }
     try {
       const result = await createNamespace({
         applicationId,
@@ -183,13 +226,9 @@ export default function Namespaces() {
       saveContextKey(result.contextId, result.memberPublicKey, applicationId);
       toast.success(`Context created: ${truncateId(result.contextId)}`);
       setCtxModalOpen(null);
-      await Promise.all([
-        refetchGroupContexts?.(),
-        refetchNsRootContexts?.(),
-      ]);
+      await Promise.all([refetchGroupContexts?.(), refetchNsRootContexts?.()]);
     } catch (e: any) {
-      const msg = e?.bodyText ?? e?.message ?? String(e);
-      toast.error(`Failed to create context: ${msg}`);
+      toast.error(`Failed to create context: ${e?.bodyText ?? e?.message ?? String(e)}`);
     } finally {
       setCreatingContext(false);
     }
@@ -197,10 +236,7 @@ export default function Namespaces() {
 
   const handleLaunchContext = async (contextId: string, applicationId: string) => {
     const app = installedApps.find((a) => a.id === applicationId);
-    if (!app?.frontendUrl) {
-      toast.error("This application has no frontend URL");
-      return;
-    }
+    if (!app?.frontendUrl) { toast.error("This application has no frontend URL"); return; }
     const key = getContextKey(contextId);
     await openAppFrontend(app.frontendUrl, app.name, undefined, {
       applicationId,
@@ -209,16 +245,111 @@ export default function Namespaces() {
     });
   };
 
-  // HA state — keyed by namespaceId. A namespace is HA-enabled when the
-  // cloud reports ha_status === "enabled" for it (namespace-scoped — the
-  // cloud collapses HA to one record per namespace; post Phase 4 the
-  // payload also carries zero-context namespaces). `haEnabling` is a
-  // per-namespace map (not a single boolean) so toggling one namespace
-  // doesn't lock every other toggle.
+  const handleDeleteNamespace = async (ns: Namespace) => {
+    if (!mero) return;
+    setActionLoading(true);
+    try {
+      await (mero.admin as any).deleteNamespace(ns.namespaceId, {});
+      toast.success('Namespace deleted');
+      setDeleteNsTarget(null);
+      setView({ type: 'list' });
+      await refetchNamespaces();
+    } catch (e: any) {
+      toast.error(`Failed to delete namespace: ${parseApiError(e)}`);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleDeleteGroup = async (groupId: string) => {
+    if (!mero) return;
+    setActionLoading(true);
+    try {
+      await (mero.admin as any).deleteGroup(groupId, {});
+      toast.success('Group deleted');
+      setDeleteGroupTarget(null);
+      if (view.type === 'group') setView({ type: 'namespace', ns: view.ns });
+      await Promise.all([
+        refetchNsGroups?.(),
+        refetchSubgroups?.(),
+      ]);
+    } catch (e: any) {
+      toast.error(`Failed to delete group: ${parseApiError(e)}`);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleDeleteContext = async (contextId: string, refetch: () => void) => {
+    if (!mero) return;
+    setActionLoading(true);
+    try {
+      await mero.admin.deleteContext(contextId);
+      toast.success('Context deleted');
+      setDeleteContextTarget(null);
+      await Promise.all([
+        refetch(),
+        refetchNsRootContexts?.(),
+        refetchGroupContexts?.(),
+      ]);
+    } catch (e: any) {
+      toast.error(`Failed to delete context: ${parseApiError(e)}`);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleRemoveMember = async (groupId: string, identity: string, onSuccess: () => void) => {
+    if (!mero) return;
+    setActionLoading(true);
+    try {
+      await mero.admin.removeGroupMembers(groupId, { members: [identity] });
+      toast.success('Member removed');
+      setRemoveMemberTarget(null);
+      onSuccess();
+      refetchGroupMembers?.();
+    } catch (e: any) {
+      toast.error(`Failed to remove member: ${parseApiError(e)}`);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleJoinNamespace = async (invitationText: string) => {
+    if (!mero) return;
+    setActionLoading(true);
+    try {
+      const invitation = JSON.parse(atob(invitationText));
+      await (mero.admin as any).joinNamespace(invitation);
+      toast.success('Joined namespace');
+      setJoinNsModal(false);
+      await refetchNamespaces();
+    } catch (e: any) {
+      toast.error(`Failed to join namespace: ${parseApiError(e)}`);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleJoinContext = async (contextId: string, refetch: () => void) => {
+    if (!mero) return;
+    setActionLoading(true);
+    try {
+      await (mero.admin as any).joinContext(contextId.trim());
+      toast.success('Joined context');
+      setJoinCtxModal(null);
+      refetch();
+    } catch (e: any) {
+      toast.error(`Failed to join context: ${parseApiError(e)}`);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  // ── HA state — keyed by namespaceId. `haEnabling` is a per-namespace map so toggling one namespace doesn't lock every other toggle. ──
   const [haEnabling, setHaEnabling] = useState<Record<string, boolean>>({});
   const [haEnabled, setHaEnabled] = useState<Record<string, boolean>>({});
 
-  // Hydrate HA state from the cloud so toggles reflect server truth on mount.
   useEffect(() => {
     const token = getCloudIdToken();
     if (!token) return;
@@ -234,29 +365,16 @@ export default function Namespaces() {
         }
         setHaEnabled(byNamespace);
       })
-      .catch(() => {
-        // Silent — HA toggles will stay in local state until next refresh.
-      });
-    return () => {
-      cancelled = true;
-    };
+      .catch(() => {});
+    return () => { cancelled = true; };
   }, []);
 
   const toggleHa = useCallback(async (ns: Namespace) => {
     const token = getCloudIdToken();
-    if (!token) {
-      toast.error('Connect to Calimero Cloud first (Settings → Cloud)');
-      return;
-    }
+    if (!token) { toast.error('Connect to Calimero Cloud first (Settings → Cloud)'); return; }
     const settings = getSettings();
-    if (!settings.nodeUrl) {
-      toast.error('Node URL not configured');
-      return;
-    }
-    if (!mero) {
-      toast.error('Local node client is not ready yet');
-      return;
-    }
+    if (!settings.nodeUrl) { toast.error('Node URL not configured'); return; }
+    if (!mero) { toast.error('Local node client is not ready yet'); return; }
 
     const nsId = ns.namespaceId;
     const isEnabled = !!haEnabled[nsId];
@@ -268,50 +386,10 @@ export default function Namespaces() {
         setHaEnabled((prev) => ({ ...prev, [nsId]: false }));
         toast.success('HA disabled — TEE nodes will stop replicating');
       } else {
-        // Root-only, SDK-skew-safe probe. We deliberately do NOT
-        // enumerate namespace groups/subgroups here anymore:
-        //
-        //  • Namespace-proof is the HA authority for the context-less
-        //    case (Phase 1, #80). enableHaForNamespace already routes an
-        //    empty group list to requestNamespaceOwnershipProof +
-        //    enableHaNamespace(nsId, [], proof) — admin-of-root proof
-        //    authorises the whole namespace, and core auto-follow
-        //    propagates fleet membership into subgroups. Group/subgroup
-        //    enumeration was legacy context-native bookkeeping and is
-        //    being decoupled here (pulling a slice of Phase 4 forward).
-        //  • Skew safety: bundled mero-js 1.4.0's listNamespaceGroups
-        //    throws "This namespace has no groups" against a
-        //    core-master/rc.40 node, and it was only ever reached on the
-        //    context-less path — exactly the path we now hand straight
-        //    to the namespace proof. listGroupContexts(nsId) is the one
-        //    call confirmed working against core master.
-        //
-        // Intentional behavioural change (NOT a regression): a namespace
-        // whose contexts live ONLY in subgroups (root group empty) now
-        // takes the namespace-proof path instead of the per-context
-        // claim path. This is consistent with the namespace-native
-        // model — admin-of-root proof authorises the whole namespace and
-        // core auto-follow propagates fleet membership into subgroups;
-        // per-context registration via /contexts/claim remains a
-        // separate concern handled elsewhere.
-        // .catch(() => []) is intentional, NOT silent error-swallowing:
-        // bundled mero-js 1.4.0 throws on namespace/group enumeration
-        // against newer core nodes (known packaging skew), so this probe
-        // is best-effort only. On error/empty we deliberately fall
-        // through to the context-less path, which is authorised
-        // server-side by a merod-signed namespace ownership proof (Phase
-        // 1) — the canonical HA authz, not a bypass/downgrade. Phase 4
-        // decouples HA from context registration, so this fallthrough is
-        // intended. Ref: NAMESPACE_NATIVE_READMODEL_PLAN.md §4.2. The
-        // failure is now warn-logged so non-skew probe failures stay
-        // visible for diagnosis.
         const rootCtxs = await mero.admin
           .listGroupContexts(nsId)
           .catch((err: unknown) => {
-            console.warn(
-              'listGroupContexts probe failed; treating namespace as context-less and falling through to the namespace-ownership-proof path (expected under mero-js↔core skew):',
-              err,
-            );
+            console.warn('listGroupContexts probe failed; falling through to namespace-ownership-proof path:', err);
             return [] as { contextId: string }[];
           });
         const groups = rootCtxs.length
@@ -328,29 +406,17 @@ export default function Namespaces() {
         toast.error(err.message || 'Failed to toggle HA');
       }
     } finally {
-      setHaEnabling((prev) => {
-        const next = { ...prev };
-        delete next[nsId];
-        return next;
-      });
+      setHaEnabling((prev) => { const next = { ...prev }; delete next[nsId]; return next; });
     }
   }, [haEnabled, mero, toast]);
 
-  // View transitions
-  const openNamespace = (ns: Namespace) => {
-    setView({ type: "namespace", ns });
-  };
-
-  const openGroup = (ns: Namespace, groupId: string) => {
-    setView({ type: "group", ns, groupId });
-  };
-
+  // ── Nav ──
+  const openNamespace = (ns: Namespace) => { setActionsMenuOpen(false); setView({ type: "namespace", ns }); };
+  const openGroup = (ns: Namespace, groupId: string) => { setActionsMenuOpen(false); setView({ type: "group", ns, groupId }); };
   const goBack = () => {
-    if (view.type === "group") {
-      setView({ type: "namespace", ns: view.ns });
-    } else if (view.type === "namespace") {
-      setView({ type: "list" });
-    }
+    setActionsMenuOpen(false);
+    if (view.type === "group") setView({ type: "namespace", ns: view.ns });
+    else if (view.type === "namespace") setView({ type: "list" });
   };
 
   const copyToClipboard = (text: string) => {
@@ -369,6 +435,32 @@ export default function Namespaces() {
     }
   };
 
+  // ── Context row helper ──
+  const renderContextItem = (c: any, applicationId: string, _refetch: () => void) => {
+    const app = installedApps.find((a) => a.id === applicationId);
+    const canLaunch = !!app?.frontendUrl;
+    return (
+      <div key={c.contextId} className="ns-context-item">
+        <Box size={14} />
+        <span className="context-name">{c.name || truncateId(c.contextId)}</span>
+        <span className="context-id mono">{truncateId(c.contextId)}</span>
+        <button className="copy-btn" onClick={() => copyToClipboard(c.contextId)} title="Copy ID">
+          <Copy size={12} />
+        </button>
+        {canLaunch && (
+          <button
+            className="ns-launch-btn"
+            onClick={() => handleLaunchContext(c.contextId, applicationId)}
+            title={`Launch ${app?.name ?? "app"} with this context`}
+          >
+            <Play size={12} /> Launch
+          </button>
+        )}
+      </div>
+    );
+  };
+
+  // ── Modals ──
   const modalOverlay = (
     <>
       {nsModalOpen && (
@@ -390,6 +482,69 @@ export default function Namespaces() {
           }
         />
       )}
+      {deleteNsTarget && (
+        <DeleteConfirmModal
+          title="Delete Namespace"
+          warning="Deleting will also remove all subgroups, contexts and members."
+          name={nsDisplayName(deleteNsTarget)}
+          loading={actionLoading}
+          onClose={() => setDeleteNsTarget(null)}
+          onConfirm={() => handleDeleteNamespace(deleteNsTarget)}
+        />
+      )}
+      {deleteGroupTarget && (
+        <DeleteConfirmModal
+          title="Delete Group"
+          warning="Deleting will also remove all subgroups, contexts and members."
+          name={truncateId(deleteGroupTarget)}
+          loading={actionLoading}
+          onClose={() => setDeleteGroupTarget(null)}
+          onConfirm={() => handleDeleteGroup(deleteGroupTarget)}
+        />
+      )}
+      {deleteContextTarget && (
+        <DeleteConfirmModal
+          title="Delete Context"
+          warning="This context and all associated data will be permanently removed."
+          name={deleteContextTarget.name}
+          loading={actionLoading}
+          onClose={() => setDeleteContextTarget(null)}
+          onConfirm={() => handleDeleteContext(deleteContextTarget.contextId, deleteContextTarget.refetch)}
+        />
+      )}
+      {removeMemberTarget && (
+        <DeleteConfirmModal
+          title="Remove Member"
+          warning="This member will lose access to the group."
+          name={removeMemberTarget.name}
+          loading={actionLoading}
+          confirmLabel="Remove"
+          onClose={() => setRemoveMemberTarget(null)}
+          onConfirm={() => handleRemoveMember(removeMemberTarget.groupId, removeMemberTarget.identity, removeMemberTarget.onSuccess)}
+        />
+      )}
+      {inviteModal && (
+        <InviteModal
+          groupId={inviteModal.groupId}
+          isNamespace={inviteModal.isNamespace}
+          mero={mero}
+          onClose={() => setInviteModal(null)}
+        />
+      )}
+      {joinNsModal && (
+        <JoinNamespaceModal
+          loading={actionLoading}
+          onClose={() => setJoinNsModal(false)}
+          onSubmit={handleJoinNamespace}
+        />
+      )}
+      {joinCtxModal && (
+        <JoinContextModal
+          loading={actionLoading}
+          onClose={() => setJoinCtxModal(null)}
+          onSubmit={(contextId) => handleJoinContext(contextId, joinCtxModal.refetch)}
+        />
+      )}
     </>
   );
 
@@ -398,18 +553,30 @@ export default function Namespaces() {
     return (
       <>
       <div className="ns-page">
-        <header className="ns-header">
-          <h1>Namespaces</h1>
-          <button
-            className="ns-action-btn"
-            onClick={() => setNsModalOpen(true)}
-            disabled={installedApps.length === 0}
-            title={installedApps.length === 0 ? "Install an application first" : "Create a new namespace"}
-          >
-            <Plus size={14} /> Create Namespace
-          </button>
-        </header>
         <main className="ns-main">
+          <div className="ns-page-top">
+            <div className="ns-page-top-left">
+              <h1>Namespaces</h1>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <button
+                className="ns-invite-btn"
+                onClick={() => setJoinNsModal(true)}
+                title="Join an existing namespace using an invitation"
+              >
+                <LogIn size={14} /> Join Namespace
+              </button>
+              <button
+                className="ns-action-btn"
+                style={{ marginLeft: 0 }}
+                onClick={() => setNsModalOpen(true)}
+                disabled={installedApps.length === 0}
+                title={installedApps.length === 0 ? "Install an application first" : "Create a new namespace"}
+              >
+                <Plus size={14} /> Create Namespace
+              </button>
+            </div>
+          </div>
           {error && <div className="error-message">{error.message}</div>}
           {loading ? (
             <div className="loading">Loading namespaces...</div>
@@ -421,9 +588,7 @@ export default function Namespaces() {
                 Create a namespace bound to an installed application, then create a context inside it.
               </p>
               {installedApps.length === 0 ? (
-                <p style={{ fontSize: "0.85rem", opacity: 0.7 }}>
-                  Install an application first (Marketplace).
-                </p>
+                <p style={{ fontSize: "0.85rem", opacity: 0.7 }}>Install an application first (Marketplace).</p>
               ) : (
                 <button className="ns-action-btn" onClick={() => setNsModalOpen(true)} style={{ marginTop: 12 }}>
                   <Plus size={14} /> Create Namespace
@@ -486,24 +651,46 @@ export default function Namespaces() {
           <button className="ns-back" onClick={goBack}>
             <ChevronLeft size={16} /> Back
           </button>
-          <div style={{ flex: 1 }}>
-            <h1>{nsDisplayName(ns)}</h1>
-            <div className="ns-header-id">
-              {truncateId(ns.namespaceId)}
-              <button className="copy-btn" onClick={() => copyToClipboard(ns.namespaceId)} title="Copy ID">
-                <Copy size={12} />
-              </button>
-            </div>
-          </div>
-          <button
-            className="ns-action-btn"
-            onClick={() => setCtxModalOpen({ namespaceId: ns.namespaceId, applicationId: ns.targetApplicationId })}
-          >
-            <Plus size={14} /> Create Context
-          </button>
         </header>
 
         <main className="ns-main">
+          <div className="ns-page-top">
+            <div className="ns-page-top-left">
+              <h1>{nsDisplayName(ns)}</h1>
+              <div className="ns-header-id">
+                {truncateId(ns.namespaceId)}
+                <button className="copy-btn" onClick={() => copyToClipboard(ns.namespaceId)} title="Copy ID">
+                  <Copy size={12} />
+                </button>
+              </div>
+            </div>
+            <div className="ns-actions-menu-wrapper" ref={actionsMenuRef}>
+              <button
+                className={`ns-actions-menu-btn${actionsMenuOpen ? ' open' : ''}`}
+                onClick={() => setActionsMenuOpen((o) => !o)}
+                title="Actions"
+              >
+                <MoreHorizontal size={16} />
+              </button>
+              {actionsMenuOpen && (
+                <div className="ns-actions-menu">
+                  <button className="ns-actions-menu-item" onClick={() => { setActionsMenuOpen(false); setCtxModalOpen({ namespaceId: ns.namespaceId, applicationId: ns.targetApplicationId }); }}>
+                    <Plus size={13} /> Create Context
+                  </button>
+                  <button className="ns-actions-menu-item" onClick={() => { setActionsMenuOpen(false); setJoinCtxModal({ groupId: ns.namespaceId, refetch: () => refetchNsRootContexts?.() }); }}>
+                    <LogIn size={13} /> Join Context
+                  </button>
+                  <button className="ns-actions-menu-item" onClick={() => { setActionsMenuOpen(false); setInviteModal({ groupId: ns.namespaceId, isNamespace: true }); }}>
+                    <Link size={13} /> Invite
+                  </button>
+                  <button className="ns-actions-menu-item ns-actions-menu-item-danger" onClick={() => { setActionsMenuOpen(false); setDeleteNsTarget(ns); }}>
+                    <Trash2 size={13} /> Delete
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+
           <div className="ns-detail-stats">
             <button
               className="stat-card stat-card-clickable"
@@ -540,32 +727,10 @@ export default function Namespaces() {
           <div className="ns-detail-section">
             <h2><Box size={16} /> Contexts ({nsRootContexts.length})</h2>
             {nsRootContexts.length === 0 ? (
-              <p className="empty-hint">No contexts in this namespace yet. Click "Create Context" to add one.</p>
+              <p className="empty-hint">No contexts yet. Click "Create Context" to add one.</p>
             ) : (
               <div className="ns-context-list">
-                {nsRootContexts.map((c: any) => {
-                  const app = installedApps.find((a) => a.id === ns.targetApplicationId);
-                  const canLaunch = !!app?.frontendUrl;
-                  return (
-                    <div key={c.contextId} className="ns-context-item">
-                      <Box size={14} />
-                      <span className="context-name">{c.name || truncateId(c.contextId)}</span>
-                      <span className="context-id mono">{truncateId(c.contextId)}</span>
-                      <button className="copy-btn" onClick={() => copyToClipboard(c.contextId)} title="Copy ID">
-                        <Copy size={12} />
-                      </button>
-                      {canLaunch && (
-                        <button
-                          className="ns-launch-btn"
-                          onClick={() => handleLaunchContext(c.contextId, ns.targetApplicationId)}
-                          title={`Launch ${app?.name ?? "app"} with this context`}
-                        >
-                          <Play size={12} /> Launch
-                        </button>
-                      )}
-                    </div>
-                  );
-                })}
+                {nsRootContexts.map((c: any) => renderContextItem(c, ns.targetApplicationId, () => refetchNsRootContexts?.()))}
               </div>
             )}
           </div>
@@ -602,7 +767,6 @@ export default function Namespaces() {
                     className={`ha-toggle-btn ${nsHaEnabled ? 'ha-enabled' : ''}`}
                     onClick={() => toggleHa(ns)}
                     disabled={nsHaEnabling || (!cloudConnected && !nsHaEnabled)}
-                    title={!cloudConnected && !nsHaEnabled ? 'Connect to Calimero Cloud first (Settings → Cloud)' : undefined}
                   >
                     {nsHaEnabling ? 'Working...' : nsHaEnabled ? 'Disable HA' : 'Enable High Availability'}
                   </button>
@@ -625,12 +789,28 @@ export default function Namespaces() {
                     <div key={m.identity} className={`ns-member-item ns-member-clickable${isExpanded ? ' ns-member-expanded' : ''}`}>
                       <div className="ns-member-row" onClick={() => setExpandedMemberId(isExpanded ? null : m.identity)}>
                         <div className="member-info">
-                          <span className="member-name">{m.name || truncateId(m.identity)}</span>
+                          <div className="member-name-row">
+                            <span className="member-name">{m.name || truncateId(m.identity)}</span>
+                            {myIdentity && m.identity === myIdentity && <span className="ns-me-badge">you</span>}
+                          </div>
                           <span className="member-id mono">{truncateId(m.identity)}</span>
                         </div>
-                        <span className="member-role" style={{ color: roleColor(m.role) }}>
-                          {m.role}
-                        </span>
+                        <span className="member-role" style={{ color: roleColor(m.role) }}>{m.role}</span>
+                        <button
+                          className="ns-danger-icon-btn"
+                          title="Remove member"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setRemoveMemberTarget({
+                              groupId: ns.namespaceId,
+                              identity: m.identity,
+                              name: m.name || truncateId(m.identity),
+                              onSuccess: () => setNsMembersVersion((v) => v + 1),
+                            });
+                          }}
+                        >
+                          <UserMinus size={13} />
+                        </button>
                         <ChevronRight size={14} className={`member-chevron${isExpanded ? ' member-chevron-open' : ''}`} />
                       </div>
                       {isExpanded && (
@@ -673,17 +853,22 @@ export default function Namespaces() {
               <p className="empty-hint">No groups in this namespace</p>
             ) : (
               <div className="ns-group-list">
-                {nsGroups.map((g) => (
-                  <button
-                    key={g.groupId}
-                    className="ns-group-item"
-                    onClick={() => openGroup(ns, g.groupId)}
-                  >
+                {nsGroups.map((g: any) => (
+                  <div key={g.groupId} className="ns-group-item">
                     <Layers size={16} />
-                    <span className="group-name">{(g as any).name || (g as any).metadata?.name || truncateId(g.groupId)}</span>
+                    <span className="group-name" onClick={() => openGroup(ns, g.groupId)} style={{ flex: 1, cursor: 'pointer' }}>
+                      {(g as any).name || (g as any).metadata?.name || truncateId(g.groupId)}
+                    </span>
                     <span className="group-id mono">{truncateId(g.groupId)}</span>
-                    <ChevronRight size={14} className="ns-card-chevron" />
-                  </button>
+                    <button
+                      className="ns-danger-icon-btn"
+                      title="Delete group"
+                      onClick={(e) => { e.stopPropagation(); setDeleteGroupTarget(g.groupId); }}
+                    >
+                      <Trash2 size={13} />
+                    </button>
+                    <ChevronRight size={14} className="ns-card-chevron" onClick={() => openGroup(ns, g.groupId)} style={{ cursor: 'pointer' }} />
+                  </div>
                 ))}
               </div>
             )}
@@ -698,6 +883,7 @@ export default function Namespaces() {
   // ─── Group Detail View ───
   if (view.type === "group") {
     const { ns, groupId } = view;
+    const safeGroupMembers = Array.isArray(groupMembers) ? groupMembers : [];
     return (
       <>
       <div className="ns-page">
@@ -705,18 +891,43 @@ export default function Namespaces() {
           <button className="ns-back" onClick={goBack}>
             <ChevronLeft size={16} /> Back to {nsDisplayName(ns)}
           </button>
-          <div>
-            <h1>{groupInfo?.metadata?.name || truncateId(groupId)}</h1>
-            <div className="ns-header-id">
-              {truncateId(groupId)}
-              <button className="copy-btn" onClick={() => copyToClipboard(groupId)} title="Copy ID">
-                <Copy size={12} />
-              </button>
-            </div>
-          </div>
         </header>
 
         <main className="ns-main">
+          <div className="ns-page-top">
+            <div className="ns-page-top-left">
+              <h1>{groupInfo?.metadata?.name || truncateId(groupId)}</h1>
+              <div className="ns-header-id">
+                {truncateId(groupId)}
+                <button className="copy-btn" onClick={() => copyToClipboard(groupId)} title="Copy ID">
+                  <Copy size={12} />
+                </button>
+              </div>
+            </div>
+            <div className="ns-actions-menu-wrapper" ref={actionsMenuRef}>
+              <button
+                className={`ns-actions-menu-btn${actionsMenuOpen ? ' open' : ''}`}
+                onClick={() => setActionsMenuOpen((o) => !o)}
+                title="Actions"
+              >
+                <MoreHorizontal size={16} />
+              </button>
+              {actionsMenuOpen && (
+                <div className="ns-actions-menu">
+                  <button className="ns-actions-menu-item" onClick={() => { setActionsMenuOpen(false); setJoinCtxModal({ groupId, refetch: () => refetchGroupContexts?.() }); }}>
+                    <LogIn size={13} /> Join Context
+                  </button>
+                  <button className="ns-actions-menu-item" onClick={() => { setActionsMenuOpen(false); setInviteModal({ groupId, isNamespace: false }); }}>
+                    <Link size={13} /> Invite
+                  </button>
+                  <button className="ns-actions-menu-item ns-actions-menu-item-danger" onClick={() => { setActionsMenuOpen(false); setDeleteGroupTarget(groupId); }}>
+                    <Trash2 size={13} /> Delete
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+
           {groupLoading ? (
             <div className="loading">Loading group details...</div>
           ) : (
@@ -742,81 +953,76 @@ export default function Namespaces() {
                 </div>
               )}
 
-              {/* Members */}
               <div className="ns-detail-section">
-                <h2><Users size={16} /> Members ({groupMembers.length})</h2>
-                {groupMembers.length === 0 ? (
+                <h2><Users size={16} /> Members ({safeGroupMembers.length})</h2>
+                {safeGroupMembers.length === 0 ? (
                   <p className="empty-hint">No members</p>
                 ) : (
                   <div className="ns-member-list">
-                    {groupMembers.map((m) => (
+                    {safeGroupMembers.map((m: any) => (
                       <div key={m.identity} className="ns-member-item">
-                        <div className="member-info">
-                          <span className="member-name">{m.name || truncateId(m.identity)}</span>
-                          <span className="member-id mono">{truncateId(m.identity)}</span>
+                        <div className="ns-member-row">
+                          <div className="member-info">
+                            <div className="member-name-row">
+                              <span className="member-name">{m.name || truncateId(m.identity)}</span>
+                              {myIdentity && m.identity === myIdentity && <span className="ns-me-badge">you</span>}
+                            </div>
+                            <span className="member-id mono">{truncateId(m.identity)}</span>
+                          </div>
+                          <span className="member-role" style={{ color: roleColor(m.role) }}>{m.role}</span>
+                          <button className="copy-btn" onClick={() => copyToClipboard(m.identity)} title="Copy identity">
+                            <Copy size={12} />
+                          </button>
+                          <button
+                            className="ns-danger-icon-btn"
+                            title="Remove member"
+                            onClick={() => setRemoveMemberTarget({
+                              groupId,
+                              identity: m.identity,
+                              name: m.name || truncateId(m.identity),
+                              onSuccess: () => refetchGroupMembers?.(),
+                            })}
+                          >
+                            <UserMinus size={13} />
+                          </button>
                         </div>
-                        <span className="member-role" style={{ color: roleColor(m.role) }}>
-                          {m.role}
-                        </span>
-                        <button className="copy-btn" onClick={() => copyToClipboard(m.identity)} title="Copy identity">
-                          <Copy size={12} />
-                        </button>
                       </div>
                     ))}
                   </div>
                 )}
               </div>
 
-              {/* Contexts */}
               <div className="ns-detail-section">
                 <h2><Box size={16} /> Contexts ({groupContexts.length})</h2>
                 {groupContexts.length === 0 ? (
                   <p className="empty-hint">No contexts in this group</p>
                 ) : (
                   <div className="ns-context-list">
-                    {groupContexts.map((c: any) => {
-                      const app = installedApps.find((a) => a.id === ns.targetApplicationId);
-                      const canLaunch = !!app?.frontendUrl;
-                      return (
-                        <div key={c.contextId} className="ns-context-item">
-                          <Box size={14} />
-                          <span className="context-name">{c.name || truncateId(c.contextId)}</span>
-                          <span className="context-id mono">{truncateId(c.contextId)}</span>
-                          <button className="copy-btn" onClick={() => copyToClipboard(c.contextId)} title="Copy ID">
-                            <Copy size={12} />
-                          </button>
-                          {canLaunch && (
-                            <button
-                              className="ns-launch-btn"
-                              onClick={() => handleLaunchContext(c.contextId, ns.targetApplicationId)}
-                              title={`Launch ${app?.name ?? "app"} with this context`}
-                            >
-                              <Play size={12} /> Launch
-                            </button>
-                          )}
-                        </div>
-                      );
-                    })}
+                    {groupContexts.map((c: any) => renderContextItem(c, ns.targetApplicationId, () => refetchGroupContexts?.()))}
                   </div>
                 )}
               </div>
 
-              {/* Subgroups */}
               {groupSubgroups.length > 0 && (
                 <div className="ns-detail-section">
                   <h2><Layers size={16} /> Subgroups ({groupSubgroups.length})</h2>
                   <div className="ns-group-list">
-                    {groupSubgroups.map((g) => (
-                      <button
-                        key={g.groupId}
-                        className="ns-group-item"
-                        onClick={() => openGroup(ns, g.groupId)}
-                      >
+                    {groupSubgroups.map((g: any) => (
+                      <div key={g.groupId} className="ns-group-item">
                         <Layers size={16} />
-                        <span className="group-name">{(g as any).name || (g as any).metadata?.name || truncateId(g.groupId)}</span>
+                        <span className="group-name" onClick={() => openGroup(ns, g.groupId)} style={{ flex: 1, cursor: 'pointer' }}>
+                          {(g as any).name || (g as any).metadata?.name || truncateId(g.groupId)}
+                        </span>
                         <span className="group-id mono">{truncateId(g.groupId)}</span>
-                        <ChevronRight size={14} className="ns-card-chevron" />
-                      </button>
+                        <button
+                          className="ns-danger-icon-btn"
+                          title="Delete subgroup"
+                          onClick={() => setDeleteGroupTarget(g.groupId)}
+                        >
+                          <Trash2 size={13} />
+                        </button>
+                        <ChevronRight size={14} className="ns-card-chevron" onClick={() => openGroup(ns, g.groupId)} style={{ cursor: 'pointer' }} />
+                      </div>
                     ))}
                   </div>
                 </div>
@@ -845,39 +1051,65 @@ interface CreateNamespaceModalProps {
 function CreateNamespaceModal({ installedApps, loading, onClose, onSubmit }: CreateNamespaceModalProps) {
   const [applicationId, setApplicationId] = useState(installedApps[0]?.id ?? "");
   const [alias, setAlias] = useState("");
+  const [appDropdownOpen, setAppDropdownOpen] = useState(false);
+  const appDropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!appDropdownOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (appDropdownRef.current && !appDropdownRef.current.contains(e.target as Node)) {
+        setAppDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [appDropdownOpen]);
+
+  const selectedApp = installedApps.find((a) => a.id === applicationId);
 
   return (
     <div className="ns-modal-backdrop" onClick={onClose}>
       <div className="ns-modal" onClick={(e) => e.stopPropagation()} role="dialog" aria-label="Create Namespace">
         <div className="ns-modal-header">
           <h2>Create Namespace</h2>
-          <button className="ns-modal-close" onClick={onClose} aria-label="Close">
-            <X size={16} />
-          </button>
+          <button className="ns-modal-close" onClick={onClose} aria-label="Close"><X size={16} /></button>
         </div>
         <form
           className="ns-modal-body"
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (!applicationId) return;
-            onSubmit(applicationId, alias);
-          }}
+          onSubmit={(e) => { e.preventDefault(); if (!applicationId) return; onSubmit(applicationId, alias); }}
         >
-          <label className="ns-modal-field">
+          <div className="ns-modal-field">
             <span>Application</span>
-            <select
-              value={applicationId}
-              onChange={(e) => setApplicationId(e.target.value)}
-              required
-            >
-              {installedApps.length === 0 && <option value="">No applications installed</option>}
-              {installedApps.map((app) => (
-                <option key={app.id} value={app.id}>
-                  {app.name}
-                </option>
-              ))}
-            </select>
-          </label>
+            <div className="ns-app-select-wrapper" ref={appDropdownRef}>
+              <button
+                type="button"
+                className={`ns-app-select-trigger${appDropdownOpen ? ' open' : ''}`}
+                onClick={() => setAppDropdownOpen((o) => !o)}
+                disabled={installedApps.length === 0}
+              >
+                <span className="ns-app-select-name">
+                  {selectedApp ? selectedApp.name : 'No applications installed'}
+                </span>
+                <ChevronDown size={14} className={`ns-app-select-chevron${appDropdownOpen ? ' open' : ''}`} />
+              </button>
+              {appDropdownOpen && installedApps.length > 0 && (
+                <div className="ns-app-select-menu">
+                  {installedApps.map((app) => (
+                    <button
+                      key={app.id}
+                      type="button"
+                      className={`ns-app-select-option${app.id === applicationId ? ' selected' : ''}`}
+                      onClick={() => { setApplicationId(app.id); setAppDropdownOpen(false); }}
+                    >
+                      <span className="ns-app-select-option-name">{app.name}</span>
+                      <span className="ns-app-select-option-id mono">{app.id.slice(0, 8)}…</span>
+                      {app.id === applicationId && <Check size={13} className="ns-app-select-check" />}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
           <label className="ns-modal-field">
             <div className="ns-modal-field-header">
               <span>Alias (optional)</span>
@@ -895,9 +1127,7 @@ function CreateNamespaceModal({ installedApps, loading, onClose, onSubmit }: Cre
             Upgrade policy: <code>Automatic</code>. Default capabilities (create context, invite, manage members) will be applied to new members.
           </p>
           <div className="ns-modal-actions">
-            <button type="button" className="ns-modal-cancel" onClick={onClose} disabled={loading}>
-              Cancel
-            </button>
+            <button type="button" className="ns-modal-cancel" onClick={onClose} disabled={loading}>Cancel</button>
             <button type="submit" className="ns-action-btn" disabled={loading || !applicationId}>
               {loading ? "Creating..." : "Create Namespace"}
             </button>
@@ -928,24 +1158,16 @@ function CreateContextModal({ namespaceId, applicationId, loading, onClose, onSu
     catch { setArgsError("Invalid JSON"); }
   };
 
-  const canSubmit = !argsError;
-
   return (
     <div className="ns-modal-backdrop" onClick={onClose}>
       <div className="ns-modal" onClick={(e) => e.stopPropagation()} role="dialog" aria-label="Create Context">
         <div className="ns-modal-header">
           <h2>Create Context</h2>
-          <button className="ns-modal-close" onClick={onClose} aria-label="Close">
-            <X size={16} />
-          </button>
+          <button className="ns-modal-close" onClick={onClose} aria-label="Close"><X size={16} /></button>
         </div>
         <form
           className="ns-modal-body"
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (!canSubmit) return;
-            onSubmit(serviceName, alias || undefined, initArgs);
-          }}
+          onSubmit={(e) => { e.preventDefault(); if (argsError) return; onSubmit(serviceName, alias || undefined, initArgs); }}
         >
           <div className="ns-modal-readonly">
             <div><strong>Namespace:</strong> <code>{namespaceId.slice(0, 8)}…{namespaceId.slice(-8)}</code></div>
@@ -953,21 +1175,11 @@ function CreateContextModal({ namespaceId, applicationId, loading, onClose, onSu
           </div>
           <label className="ns-modal-field">
             <span>Service name <span className="ns-optional">(optional)</span></span>
-            <input
-              type="text"
-              value={serviceName}
-              onChange={(e) => setServiceName(e.target.value)}
-              placeholder="e.g. lobby"
-            />
+            <input type="text" value={serviceName} onChange={(e) => setServiceName(e.target.value)} placeholder="e.g. lobby" />
           </label>
           <label className="ns-modal-field">
             <span>Alias <span className="ns-optional">(optional)</span></span>
-            <input
-              type="text"
-              value={alias}
-              onChange={(e) => setAlias(e.target.value)}
-              placeholder="e.g. main-lobby"
-            />
+            <input type="text" value={alias} onChange={(e) => setAlias(e.target.value)} placeholder="e.g. main-lobby" />
           </label>
           <label className="ns-modal-field">
             <span>Init arguments <span className="ns-optional">(optional JSON)</span></span>
@@ -983,14 +1195,218 @@ function CreateContextModal({ namespaceId, applicationId, loading, onClose, onSu
             {argsError && <span className="ns-field-error">{argsError}</span>}
           </label>
           <div className="ns-modal-actions">
-            <button type="button" className="ns-modal-cancel" onClick={onClose} disabled={loading}>
-              Cancel
-            </button>
-            <button type="submit" className="ns-action-btn" disabled={loading || !canSubmit}>
+            <button type="button" className="ns-modal-cancel" onClick={onClose} disabled={loading}>Cancel</button>
+            <button type="submit" className="ns-action-btn" disabled={loading || !!argsError}>
               {loading ? "Creating..." : "Create Context"}
             </button>
           </div>
         </form>
+      </div>
+    </div>
+  );
+}
+
+interface DeleteConfirmModalProps {
+  title: string;
+  warning: string;
+  name: string;
+  loading: boolean;
+  confirmLabel?: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+function DeleteConfirmModal({ title, warning, name, loading, confirmLabel = "Delete", onClose, onConfirm }: DeleteConfirmModalProps) {
+  return (
+    <div className="ns-modal-backdrop" onClick={onClose}>
+      <div className="ns-modal" onClick={(e) => e.stopPropagation()} role="dialog">
+        <div className="ns-modal-header">
+          <h2>{title}</h2>
+          <button className="ns-modal-close" onClick={onClose} aria-label="Close"><X size={16} /></button>
+        </div>
+        <div className="ns-modal-body">
+          <div className="ns-delete-warning">
+            <p className="ns-delete-name">{name}</p>
+            <p className="ns-delete-msg">{warning}</p>
+            <p className="ns-delete-final">This action cannot be undone.</p>
+          </div>
+          <div className="ns-modal-actions">
+            <button className="ns-modal-cancel" onClick={onClose} disabled={loading}>Cancel</button>
+            <button className="ns-delete-confirm-btn" onClick={onConfirm} disabled={loading}>
+              {loading ? 'Deleting...' : confirmLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface JoinNamespaceModalProps {
+  loading: boolean;
+  onClose: () => void;
+  onSubmit: (invitationText: string) => void;
+}
+
+function JoinNamespaceModal({ loading, onClose, onSubmit }: JoinNamespaceModalProps) {
+  const [payload, setPayload] = useState('');
+
+  return (
+    <div className="ns-modal-backdrop" onClick={onClose}>
+      <div className="ns-modal ns-modal-wide" onClick={(e) => e.stopPropagation()} role="dialog">
+        <div className="ns-modal-header">
+          <h2>Join Namespace</h2>
+          <button className="ns-modal-close" onClick={onClose} aria-label="Close"><X size={16} /></button>
+        </div>
+        <form
+          className="ns-modal-body"
+          onSubmit={(e) => { e.preventDefault(); if (!payload.trim()) return; onSubmit(payload.trim()); }}
+        >
+          <p className="ns-modal-hint">Paste the invitation payload you received from a namespace admin.</p>
+          <label className="ns-modal-field">
+            <span>Invitation Payload</span>
+            <textarea
+              className="ns-invite-payload"
+              value={payload}
+              onChange={(e) => setPayload(e.target.value)}
+              placeholder="Paste invitation payload here..."
+              rows={4}
+              spellCheck={false}
+              autoFocus
+            />
+          </label>
+          <div className="ns-modal-actions">
+            <button type="button" className="ns-modal-cancel" onClick={onClose} disabled={loading}>Cancel</button>
+            <button type="submit" className="ns-action-btn" style={{ marginLeft: 0 }} disabled={loading || !payload.trim()}>
+              {loading ? 'Joining...' : 'Join Namespace'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+interface JoinContextModalProps {
+  loading: boolean;
+  onClose: () => void;
+  onSubmit: (contextId: string) => void;
+}
+
+function JoinContextModal({ loading, onClose, onSubmit }: JoinContextModalProps) {
+  const [contextId, setContextId] = useState('');
+
+  return (
+    <div className="ns-modal-backdrop" onClick={onClose}>
+      <div className="ns-modal" onClick={(e) => e.stopPropagation()} role="dialog">
+        <div className="ns-modal-header">
+          <h2>Join Context</h2>
+          <button className="ns-modal-close" onClick={onClose} aria-label="Close"><X size={16} /></button>
+        </div>
+        <form
+          className="ns-modal-body"
+          onSubmit={(e) => { e.preventDefault(); if (!contextId.trim()) return; onSubmit(contextId.trim()); }}
+        >
+          <p className="ns-modal-hint">Enter the ID of an existing context to join it.</p>
+          <label className="ns-modal-field">
+            <span>Context ID</span>
+            <input
+              type="text"
+              value={contextId}
+              onChange={(e) => setContextId(e.target.value)}
+              placeholder="e.g. a1b2c3d4e5f6..."
+              autoFocus
+            />
+          </label>
+          <div className="ns-modal-actions">
+            <button type="button" className="ns-modal-cancel" onClick={onClose} disabled={loading}>Cancel</button>
+            <button type="submit" className="ns-action-btn" style={{ marginLeft: 0 }} disabled={loading || !contextId.trim()}>
+              {loading ? 'Joining...' : 'Join Context'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+interface InviteModalProps {
+  groupId: string;
+  isNamespace: boolean;
+  mero: ReturnType<typeof useMero>["mero"];
+  onClose: () => void;
+}
+
+function InviteModal({ groupId, isNamespace, mero, onClose }: InviteModalProps) {
+  const toast = useToast();
+  const [loading, setLoading] = useState(false);
+  const [invitationPayload, setInvitationPayload] = useState<string | null>(null);
+
+  const handleCreate = async () => {
+    if (!mero) return;
+    setLoading(true);
+    try {
+      const result = isNamespace
+        ? await mero.admin.createNamespaceInvitation(groupId)
+        : await mero.admin.createGroupInvitation(groupId);
+      setInvitationPayload(btoa(JSON.stringify(result)));
+    } catch (e: any) {
+      toast.error(`Failed to create invitation: ${parseApiError(e)}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const copyInvitation = () => {
+    if (invitationPayload) {
+      navigator.clipboard.writeText(invitationPayload);
+      toast.success('Invitation copied to clipboard');
+    }
+  };
+
+  return (
+    <div className="ns-modal-backdrop" onClick={onClose}>
+      <div className="ns-modal ns-modal-wide" onClick={(e) => e.stopPropagation()} role="dialog">
+        <div className="ns-modal-header">
+          <h2>Create Invitation</h2>
+          <button className="ns-modal-close" onClick={onClose} aria-label="Close"><X size={16} /></button>
+        </div>
+        <div className="ns-modal-body">
+          {!invitationPayload ? (
+            <>
+              <div className="ns-modal-readonly">
+                <div><strong>{isNamespace ? 'Namespace' : 'Group'}:</strong> <code>{groupId.slice(0, 8)}…{groupId.slice(-8)}</code></div>
+              </div>
+              <p className="ns-modal-hint">Generate an invitation payload that someone can use to join this {isNamespace ? 'namespace' : 'group'}.</p>
+              <div className="ns-modal-actions">
+                <button className="ns-modal-cancel" onClick={onClose} disabled={loading}>Cancel</button>
+                <button className="ns-action-btn" onClick={handleCreate} disabled={loading}>
+                  {loading ? 'Creating...' : 'Create Invitation'}
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <p className="ns-modal-hint">Share this payload with the person you want to invite.</p>
+              <div className="ns-modal-field">
+                <span>Invitation Payload</span>
+                <textarea
+                  className="ns-invite-payload"
+                  readOnly
+                  value={invitationPayload}
+                  rows={4}
+                  onClick={(e) => (e.target as HTMLTextAreaElement).select()}
+                />
+              </div>
+              <div className="ns-modal-actions">
+                <button className="ns-modal-cancel" onClick={onClose}>Close</button>
+                <button className="ns-action-btn" onClick={copyInvitation}>
+                  <Copy size={14} /> Copy Payload
+                </button>
+              </div>
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -24,6 +24,7 @@ import {
 } from "../utils/cloudApi";
 import { getCloudIdToken } from "../utils/cloudAuth";
 import { getAccessToken } from "../lib/token-storage";
+import { parseJwtPayload } from "../utils/jwt";
 import { isCloudEnabled } from "../utils/featureFlags";
 import "./Namespaces.css";
 
@@ -96,14 +97,14 @@ export default function Namespaces() {
     const controller = new AbortController();
     const settings = getSettings();
     const token = getAccessToken();
-    if (!settings.nodeUrl || !token) return;
+    if (!settings.nodeUrl || !token) { setNsMembers([]); return; }
     setNsMembersLoading(true);
     // TODO: replace with mero.admin.listGroupMembers once mero-react hook parsing is fixed
     fetch(`${settings.nodeUrl}/admin-api/groups/${encodeURIComponent(activeNsRootId)}/members`, {
       headers: { Authorization: `Bearer ${token}` },
       signal: controller.signal,
     })
-      .then((r) => r.json())
+      .then((r) => { if (!r.ok) throw new Error(`${r.status}`); return r.json(); })
       .then((json) => {
         const members = json?.members ?? json?.data?.members ?? [];
         setNsMembers(Array.isArray(members) ? members : []);
@@ -136,13 +137,9 @@ export default function Namespaces() {
 
   const [myIdentity, setMyIdentity] = useState<string | null>(null);
   useEffect(() => {
-    try {
-      const token = getAccessToken();
-      if (!token) return;
-      const payload = JSON.parse(atob(token.split('.')[1]));
-      const id = payload.sub || payload.identity || payload.public_key;
-      if (id) setMyIdentity(id);
-    } catch {}
+    const payload = parseJwtPayload(getAccessToken());
+    const id = payload?.sub || payload?.identity || payload?.public_key;
+    if (id && typeof id === 'string') setMyIdentity(id);
   }, []);
 
   const [installedApps, setInstalledApps] = useState<InstalledApp[]>([]);
@@ -699,15 +696,15 @@ export default function Namespaces() {
               className="stat-card stat-card-clickable"
               onClick={() => document.getElementById('ns-members-section')?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
             >
-              <div className="stat-value">{nsMembersLoading ? '…' : nsMembers.length > 0 ? nsMembers.length : ((ns as any).memberCount ?? 0)}</div>
+              <div className="stat-value">{nsMembersLoading ? '…' : nsMembers.length}</div>
               <div className="stat-label">Members ↓</div>
             </button>
             <div className="stat-card">
-              <div className="stat-value">{nsRootContexts.length > 0 ? nsRootContexts.length : ((ns as any).contextCount ?? 0)}</div>
+              <div className="stat-value">{nsRootContexts.length}</div>
               <div className="stat-label">Contexts</div>
             </div>
             <div className="stat-card">
-              <div className="stat-value">{nsGroups.length > 0 ? nsGroups.length : ((ns as any).subgroupCount ?? 0)}</div>
+              <div className="stat-value">{nsLoadingGroups ? '…' : nsGroups.length}</div>
               <div className="stat-label">Groups</div>
             </div>
             <div className="stat-card">

--- a/apps/desktop/src/pages/NodeManagement.css
+++ b/apps/desktop/src/pages/NodeManagement.css
@@ -1,26 +1,15 @@
 .node-management-page {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
   background: transparent;
 }
 
 .node-management-header {
-  padding: 24px 32px;
-  border-bottom: 1px solid var(--border-color);
-  background: rgba(10, 10, 12, 0.4);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  padding: 0 0 24px 0;
   animation: fadeUp 0.4s ease-out;
 }
 
-[data-theme="light"] .node-management-header {
-  background: rgba(250, 250, 250, 0.7);
-}
-
 .node-management-header h1 {
-  margin: 0 0 8px 0;
-  font-size: 28px;
+  margin: 0 0 6px 0;
+  font-size: 24px;
   font-weight: 700;
   color: var(--text-primary);
   letter-spacing: -0.5px;
@@ -33,9 +22,7 @@
 }
 
 .node-management-main {
-  flex: 1;
-  overflow-y: auto;
-  padding: 32px;
+  padding: 0;
   max-width: 1200px;
   margin: 0 auto;
   width: 100%;
@@ -53,7 +40,7 @@
   transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   animation: fadeUp 0.5s ease-out both;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .node-management-card::after {
@@ -108,28 +95,16 @@
   margin-bottom: 16px !important;
 }
 
-.node-status-cards {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin: 16px 0;
-}
-
 .node-status-card {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 10px;
-  padding: 12px 16px;
+  padding: 6px 12px;
   background: var(--surface-glass-soft);
   border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  min-width: 140px;
-  transition: all 0.2s;
-}
-
-.node-status-card:hover {
-  border-color: var(--border-hover);
-  transform: translateY(-1px);
+  border-radius: var(--radius-sm);
+  margin: 12px 0 0 0;
+  transition: border-color 0.2s;
 }
 
 .node-status-card.running {
@@ -334,4 +309,188 @@
 .button-secondary:hover:not(:disabled) {
   background: var(--button-glass-hover);
   border-color: var(--border-hover);
+}
+
+/* ── Custom Node Select Dropdown ── */
+
+.node-select-wrapper {
+  position: relative;
+  display: inline-block;
+  min-width: 220px;
+}
+
+.node-select-trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: var(--surface-glass-soft);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 14px;
+  color: var(--text-primary);
+  transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
+  text-align: left;
+  box-sizing: border-box;
+}
+
+.node-select-trigger:hover:not(:disabled) {
+  border-color: var(--border-hover);
+  background: var(--surface-glass);
+}
+
+.node-select-trigger.open {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px var(--accent-light);
+}
+
+.node-select-trigger:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.node-select-trigger-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.node-select-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--text-tertiary);
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.node-select-dot.running {
+  background: var(--success);
+  box-shadow: 0 0 6px rgba(63, 185, 80, 0.5);
+  animation: pulse-glow 2s ease-in-out infinite;
+}
+
+.node-select-name {
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.node-select-badge {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border-color);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.node-select-chevron {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+  transition: transform 0.2s ease;
+}
+
+.node-select-chevron.open {
+  transform: rotate(180deg);
+  color: var(--accent-primary);
+}
+
+.node-select-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  background: #0d1117;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: 200;
+  overflow: hidden;
+  animation: nodeDropdownIn 0.15s ease-out;
+}
+
+[data-theme="light"] .node-select-menu {
+  background: #ffffff;
+}
+
+@keyframes nodeDropdownIn {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.node-select-option {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 14px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border-color);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 14px;
+  color: var(--text-primary);
+  text-align: left;
+  transition: background 0.15s;
+  box-sizing: border-box;
+}
+
+.node-select-option:last-child {
+  border-bottom: none;
+}
+
+.node-select-option:hover {
+  background: var(--accent-light);
+}
+
+.node-select-option.selected {
+  background: rgba(165, 255, 17, 0.06);
+}
+
+[data-theme="light"] .node-select-option.selected {
+  background: rgba(106, 171, 0, 0.06);
+}
+
+.node-select-option-name {
+  flex: 1;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.node-select-option.selected .node-select-option-name {
+  color: var(--accent-primary);
+}
+
+.node-select-option-badge {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border-color);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.node-select-option.running .node-select-option-badge {
+  color: var(--success);
+  background: rgba(63, 185, 80, 0.08);
+  border-color: rgba(63, 185, 80, 0.2);
+}
+
+.node-select-check {
+  color: var(--accent-primary);
+  flex-shrink: 0;
 }

--- a/apps/desktop/src/pages/NodeManagement.tsx
+++ b/apps/desktop/src/pages/NodeManagement.tsx
@@ -13,7 +13,7 @@ import {
 } from "../utils/merod";
 import { invoke } from "@tauri-apps/api/tauri";
 import { useToast } from "../contexts/ToastContext";
-import { Play, Square, RefreshCw, Check, FileText } from "lucide-react";
+import { Play, Square, RefreshCw, Check, FileText, ChevronDown } from "lucide-react";
 import { LogsViewer } from "../components/LogsViewer";
 import { ScrollHint } from "../components/ScrollHint";
 import "./NodeManagement.css";
@@ -36,6 +36,8 @@ export default function NodeManagement() {
   const [authUrl, setAuthUrl] = useState("");
   const [saved, setSaved] = useState(false);
   const mainScrollRef = useRef<HTMLElement>(null);
+  const [nodeDropdownOpen, setNodeDropdownOpen] = useState(false);
+  const nodeDropdownRef = useRef<HTMLDivElement>(null);
   const [showLogsModal, setShowLogsModal] = useState(false);
   const [logsContent, setLogsContent] = useState("");
   const [logsLoading, setLogsLoading] = useState(false);
@@ -79,6 +81,17 @@ export default function NodeManagement() {
     setServerPort(maxServerPort + 1);
     setSwarmPort(maxSwarmPort + 1);
   }, [selectedNode, runningNodes, serverPort, swarmPort]);
+
+  useEffect(() => {
+    if (!nodeDropdownOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (nodeDropdownRef.current && !nodeDropdownRef.current.contains(e.target as Node)) {
+        setNodeDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [nodeDropdownOpen]);
 
   const loadNodes = async () => {
     try {
@@ -391,20 +404,48 @@ export default function NodeManagement() {
               <h3 className="node-card-title">Manage Nodes</h3>
               <div className="form-field">
                 <label>Select node</label>
-                <select
-                  value={selectedNode}
-                  onChange={(e) => setSelectedNode(e.target.value)}
-                  disabled={loading}
-                >
-                  {safeAvailableNodes.map((node) => {
-                    const nodeInfo = getRunningNodeInfo(node);
-                    return (
-                      <option key={node} value={node}>
-                        {node} {nodeInfo.running ? `• Port ${nodeInfo.port}` : '• Stopped'}
-                      </option>
-                    );
-                  })}
-                </select>
+                <div className="node-select-wrapper" ref={nodeDropdownRef}>
+                  <button
+                    type="button"
+                    className={`node-select-trigger${nodeDropdownOpen ? ' open' : ''}`}
+                    onClick={() => !loading && setNodeDropdownOpen(o => !o)}
+                    disabled={loading}
+                  >
+                    <span className="node-select-trigger-left">
+                      <span className={`node-select-dot${getRunningNodeInfo(selectedNode).running ? ' running' : ''}`} />
+                      <span className="node-select-name">{selectedNode || 'Select a node'}</span>
+                      {selectedNode && (
+                        <span className="node-select-badge">
+                          {getRunningNodeInfo(selectedNode).running ? `Port ${getRunningNodeInfo(selectedNode).port}` : 'Stopped'}
+                        </span>
+                      )}
+                    </span>
+                    <ChevronDown size={15} className={`node-select-chevron${nodeDropdownOpen ? ' open' : ''}`} />
+                  </button>
+                  {nodeDropdownOpen && (
+                    <div className="node-select-menu">
+                      {safeAvailableNodes.map((node) => {
+                        const nodeInfo = getRunningNodeInfo(node);
+                        const isSelected = node === selectedNode;
+                        return (
+                          <button
+                            key={node}
+                            type="button"
+                            className={`node-select-option${isSelected ? ' selected' : ''}${nodeInfo.running ? ' running' : ''}`}
+                            onClick={() => { setSelectedNode(node); setNodeDropdownOpen(false); }}
+                          >
+                            <span className={`node-select-dot${nodeInfo.running ? ' running' : ''}`} />
+                            <span className="node-select-option-name">{node}</span>
+                            <span className="node-select-option-badge">
+                              {nodeInfo.running ? `Port ${nodeInfo.port}` : 'Stopped'}
+                            </span>
+                            {isSelected && <Check size={13} className="node-select-check" />}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
               </div>
               <div className="form-row">
                 <div className="form-field">
@@ -432,25 +473,20 @@ export default function NodeManagement() {
                   />
                 </div>
               </div>
-              <div className="node-status-cards">
-                {safeAvailableNodes.map((node) => {
-                  const nodeInfo = getRunningNodeInfo(node);
-                  return (
-                    <div
-                      key={node}
-                      className={`node-status-card ${nodeInfo.running ? 'running' : 'stopped'}`}
-                    >
-                      <div className="node-status-card-header">
-                        <span className="node-status-dot" />
-                        <span className="node-status-name">{node}</span>
-                        <span className="node-status-badge">
-                          {nodeInfo.running ? `Port ${nodeInfo.port}` : 'Stopped'}
-                        </span>
-                      </div>
+              {selectedNode && (() => {
+                const nodeInfo = getRunningNodeInfo(selectedNode);
+                return (
+                  <div className={`node-status-card ${nodeInfo.running ? 'running' : 'stopped'}`}>
+                    <div className="node-status-card-header">
+                      <span className="node-status-dot" />
+                      <span className="node-status-name">{selectedNode}</span>
+                      <span className="node-status-badge">
+                        {nodeInfo.running ? `Port ${nodeInfo.port}` : 'Stopped'}
+                      </span>
                     </div>
-                  );
-                })}
-              </div>
+                  </div>
+                );
+              })()}
               <div className="node-actions">
                 <button
                   onClick={handleStartNode}

--- a/apps/desktop/src/pages/Onboarding.css
+++ b/apps/desktop/src/pages/Onboarding.css
@@ -1030,6 +1030,10 @@
 }
 
 /* Legacy styles for node setup form compatibility */
+.onboarding-step-login {
+  min-height: 480px;
+}
+
 .onboarding-card {
   background: transparent;
   border: none;

--- a/apps/desktop/src/pages/Onboarding.css
+++ b/apps/desktop/src/pages/Onboarding.css
@@ -190,12 +190,18 @@
   align-items: center;
   justify-content: flex-start;
   text-align: center;
-  padding: 32px 0;
+  padding: 32px;
   min-height: 0;
   width: 100%;
   overflow: visible;
   position: relative;
   gap: 0;
+}
+
+.step-content-spacer {
+  height: 48px;
+  flex-shrink: 0;
+  width: 100%;
 }
 
 .step-icon-wrapper {
@@ -1501,6 +1507,7 @@
   max-width: 500px;
   margin-left: auto;
   margin-right: auto;
+  align-items: stretch;
 }
 
 @media (max-width: 768px) {
@@ -1552,6 +1559,9 @@
   transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
+  height: 100%;
+  box-sizing: border-box;
+  text-align: left;
 }
 
 .onboarding-app-card:hover {

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -11,8 +11,7 @@ import { isCloudEnabled } from "../utils/featureFlags";
 import { fetchAppsFromAllRegistries, fetchAppManifest, recordDownload, type AppSummary } from "../utils/registry";
 import { useToast } from "../contexts/ToastContext";
 import { useTheme } from "../contexts/ThemeContext";
-import { ArrowLeft, ArrowRight, Check, Package, Download, CheckCircle2, ChevronDown, ChevronUp, Search, AlertTriangle } from "lucide-react";
-import { ScrollHint } from "../components/ScrollHint";
+import { ArrowLeft, ArrowRight, Check, Package, Download, CheckCircle2, ChevronDown, ChevronUp, AlertTriangle } from "lucide-react";
 import calimeroLogo from "../assets/calimero-logo.svg";
 import bs58 from "bs58";
 import "./Onboarding.css";
@@ -76,12 +75,10 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
   }, [setTheme]);
   
   // App installation state
-  const [allApps, setAllApps] = useState<AppSummary[]>([]);
   const [apps, setApps] = useState<AppSummary[]>([]);
   const [loadingApps, setLoadingApps] = useState(false);
   const [installingAppId, setInstallingAppId] = useState<string | null>(null);
   const [installedAppIds, setInstalledAppIds] = useState<Set<string>>(new Set());
-  const [searchQuery, setSearchQuery] = useState("");
 
   // Node setup state - restore from saved progress if available
   const [dataDir, setDataDir] = useState(() => loadOnboardingProgress()?.dataDir ?? "~/.calimero");
@@ -349,8 +346,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
         });
       });
       
-      setAllApps(fetchedApps);
-      setApps(fetchedApps.slice(0, 4)); // Show first 4 apps by default
+      setApps(fetchedApps.slice(0, 4));
       
       // Load installed apps
       try {
@@ -591,7 +587,6 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
               <ArrowRight size={18} />
             </button>
           </div>
-          <ScrollHint containerRef={stepContainerRef} />
         </div>
       </div>
     );
@@ -647,7 +642,6 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
               </button>
             </div>
           </div>
-          <ScrollHint containerRef={stepContainerRef} />
         </div>
       </div>
     );
@@ -898,7 +892,6 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
             </div>
             )}
           </div>
-          <ScrollHint containerRef={stepContainerRef} />
         </div>
       </div>
     );
@@ -979,7 +972,6 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
               </button>
             </div>
           </div>
-          <ScrollHint containerRef={stepContainerRef} />
         </div>
       </div>
     );
@@ -1022,8 +1014,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
                 )}
               </div>
             </div>
-            <ScrollHint containerRef={stepContainerRef} />
-          </div>
+            </div>
         </div>
       );
     }
@@ -1044,98 +1035,57 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
               <div className="apps-loading">
                 <p>Loading applications...</p>
               </div>
-            ) : allApps.length === 0 ? (
+            ) : apps.length === 0 ? (
               <div className="apps-empty">
                 <p>No applications available. You can install apps later from the Marketplace.</p>
               </div>
             ) : (
-              <>
-                <div className="onboarding-app-search">
-                  <Search size={18} className="search-icon" />
-                  <input
-                    type="text"
-                    placeholder="Search applications..."
-                    value={searchQuery}
-                    onChange={(e) => {
-                      const query = e.target.value.toLowerCase();
-                      setSearchQuery(e.target.value);
-                      if (query.trim() === "") {
-                        setApps(allApps.slice(0, 4));
-                      } else {
-                        const filtered = allApps.filter(app => 
-                          app.name.toLowerCase().includes(query) ||
-                          (app as any).description?.toLowerCase().includes(query)
-                        );
-                        setApps(filtered.slice(0, 4));
-                      }
-                    }}
-                    className="app-search-input"
-                  />
-                </div>
-                {apps.length === 0 ? (
-                  <div className="apps-empty">
-                    <p>No applications found matching your search.</p>
-                    <button
-                      onClick={() => {
-                        setSearchQuery("");
-                        setApps(allApps.slice(0, 4));
-                      }}
-                      className="step-button step-button-secondary"
-                    >
-                      Clear Search
-                    </button>
-                  </div>
-                ) : (
-                  <div className="onboarding-apps-grid">
-                    {apps.map((app) => {
-                      const isInstalled = installedAppIds.has(app.id);
-                      const isInstalling = installingAppId === app.id;
-                      const settings = getSettings();
-                      const registry = settings.registries?.[0] || '';
-                      
-                      return (
-                        <div key={app.id} className="onboarding-app-card">
-                          <div className="app-card-header">
-                            <div className="app-icon-placeholder">
-                              <Package size={24} />
-                            </div>
-                            <div className="app-info">
-                              <h3>{app.name}</h3>
-                              <p className="app-version">v{app.latest_version}</p>
-                            </div>
-                          </div>
-                          {(app as any).description && (
-                            <p className="app-description">{(app as any).description}</p>
-                          )}
-                          <p className="app-downloads">{(app as any).downloads ?? 0} downloads</p>
-                          <button
-                            onClick={() => handleInstallApp(app, registry)}
-                            className="app-install-button"
-                            disabled={isInstalled || isInstalling}
-                          >
-                            {isInstalled ? (
-                              <>
-                                <CheckCircle2 size={16} />
-                                Installed
-                              </>
-                            ) : isInstalling ? (
-                              <>
-                                <Download size={16} />
-                                Installing...
-                              </>
-                            ) : (
-                              <>
-                                <Download size={16} />
-                                Install
-                              </>
-                            )}
-                          </button>
+              <div className="onboarding-apps-grid">
+                {apps.map((app) => {
+                  const isInstalled = installedAppIds.has(app.id);
+                  const isInstalling = installingAppId === app.id;
+                  const settings = getSettings();
+                  const registry = settings.registries?.[0] || '';
+                  const description = (app as any).description || "No description available.";
+
+                  return (
+                    <div key={app.id} className="onboarding-app-card">
+                      <div className="app-card-header">
+                        <div className="app-icon-placeholder">
+                          <Package size={24} />
                         </div>
-                      );
-                    })}
-                  </div>
-                )}
-              </>
+                        <div className="app-info">
+                          <h3>{app.name}</h3>
+                          <p className="app-version">v{app.latest_version}</p>
+                        </div>
+                      </div>
+                      <p className="app-description">{description}</p>
+                      <button
+                        onClick={() => handleInstallApp(app, registry)}
+                        className="app-install-button"
+                        disabled={isInstalled || isInstalling}
+                      >
+                        {isInstalled ? (
+                          <>
+                            <CheckCircle2 size={16} />
+                            Installed
+                          </>
+                        ) : isInstalling ? (
+                          <>
+                            <Download size={16} />
+                            Installing...
+                          </>
+                        ) : (
+                          <>
+                            <Download size={16} />
+                            Install
+                          </>
+                        )}
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
             )}
 
             <div className="step-actions" style={{ marginTop: '24px' }}>
@@ -1150,8 +1100,8 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
                 Skip for now
               </button>
             </div>
+            <div className="step-content-spacer" aria-hidden="true" />
           </div>
-          <ScrollHint containerRef={stepContainerRef} />
         </div>
       </div>
     );

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -924,8 +924,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
                 </div>
               ) : (
                 <button
-                  className="button button-primary"
-                  style={{ fontSize: '1rem', padding: '12px 32px' }}
+                  className="google-signin-btn"
                   onClick={async () => {
                     setCloudConnecting(true);
                     try {
@@ -943,6 +942,12 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
                     }
                   }}
                 >
+                  <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg" style={{ flexShrink: 0 }}>
+                    <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4"/>
+                    <path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z" fill="#34A853"/>
+                    <path d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" fill="#FBBC05"/>
+                    <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 6.29C4.672 4.163 6.656 3.58 9 3.58z" fill="#EA4335"/>
+                  </svg>
                   Sign in with Google
                 </button>
               )}
@@ -982,14 +987,14 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
       return (
         <div className="onboarding-page" data-testid="onboarding-page">
         <ProgressIndicator />
-          <div ref={stepContainerRef} className="onboarding-step-container">
-            <div className="step-content">
+          <div ref={stepContainerRef} className="onboarding-step-container onboarding-step-login">
+            <div className="step-content" style={{ justifyContent: 'center' }}>
               <h1 className="step-title">Set Up Authentication</h1>
               <p className="step-description">
-                Create a username and password to authenticate with your Calimero node. 
+                Create a username and password to authenticate with your Calimero node.
                 This account will be used to securely access your node and manage your applications.
               </p>
-              <div className="onboarding-card">
+              <div className="onboarding-card" style={{ alignItems: 'center' }}>
                 {loginTransitioning ? (
                   <div className="loading-spinner">
                     <div className="spinner" />

--- a/apps/desktop/src/pages/Settings.css
+++ b/apps/desktop/src/pages/Settings.css
@@ -421,16 +421,7 @@
   border-color: var(--border-hover);
 }
 
-.button-danger {
-  background: var(--error);
-  color: white;
-}
 
-.button-danger:hover:not(:disabled) {
-  background: #dc2626;
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-md);
-}
 
 .reset-confirm-form {
   margin-top: 12px;
@@ -463,17 +454,55 @@
 .reset-confirm-checkbox {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   margin-bottom: 16px;
   cursor: pointer;
   font-size: 14px;
   color: var(--text-primary);
+  user-select: none;
 }
 
-.reset-confirm-checkbox input {
-  width: 16px;
-  height: 16px;
-  cursor: pointer;
+/* Hide native checkbox */
+.reset-confirm-checkbox input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* Custom checkbox box */
+.reset-confirm-checkbox input[type="checkbox"] + span::before {
+  content: '';
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  border-radius: 5px;
+  border: 2px solid var(--border-color);
+  background: var(--surface-glass-soft);
+  margin-right: 10px;
+  vertical-align: middle;
+  transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
+  position: relative;
+  top: -1px;
+}
+
+/* Checked state */
+.reset-confirm-checkbox input[type="checkbox"]:checked + span::before {
+  background: var(--error);
+  border-color: var(--error);
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.18);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 10'%3E%3Cpolyline points='1,5 4.5,8.5 11,1' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 65%;
+}
+
+/* Hover state */
+.reset-confirm-checkbox:hover input[type="checkbox"] + span::before {
+  border-color: var(--error);
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1);
 }
 
 .reset-confirm-actions {

--- a/apps/desktop/src/pages/Settings.css
+++ b/apps/desktop/src/pages/Settings.css
@@ -9,12 +9,13 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 24px 32px;
+  height: var(--header-height);
+  padding: 0 32px;
   border-bottom: 1px solid var(--border-color);
   background: var(--header-glass);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  animation: fadeUp 0.4s ease-out;
+  flex-shrink: 0;
 }
 
 [data-theme="light"] .settings-header {
@@ -27,9 +28,29 @@
   gap: 16px;
 }
 
-.settings-header h1 {
-  margin: 0;
-  font-size: 28px;
+.settings-back-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  transition: color 0.2s;
+}
+
+.settings-back-btn:hover {
+  background: none;
+  color: var(--accent-primary);
+}
+
+.settings-title {
+  margin: 0 0 24px 0;
+  font-size: 24px;
   font-weight: 700;
   color: var(--text-primary);
   letter-spacing: -0.5px;

--- a/apps/desktop/src/pages/Settings.tsx
+++ b/apps/desktop/src/pages/Settings.tsx
@@ -427,7 +427,7 @@ export default function Settings({ onBack }: SettingsProps) {
                     and managed infrastructure. Your local node stays primary — cloud features are additive.
                   </p>
                   <button
-                    className="button button-primary"
+                    className="google-signin-btn"
                     onClick={async () => {
                       setCloudLoading(true);
                       try {
@@ -455,7 +455,15 @@ export default function Settings({ onBack }: SettingsProps) {
                     }}
                     disabled={cloudLoading}
                   >
-                    {cloudLoading ? 'Waiting for sign-in...' : 'Sign in with Google'}
+                    {!cloudLoading && (
+                      <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg" style={{ flexShrink: 0 }}>
+                        <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4"/>
+                        <path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z" fill="#34A853"/>
+                        <path d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" fill="#FBBC05"/>
+                        <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 6.29C4.672 4.163 6.656 3.58 9 3.58z" fill="#EA4335"/>
+                      </svg>
+                    )}
+                    {cloudLoading ? 'Waiting for sign-in…' : 'Sign in with Google'}
                   </button>
                   <p className="field-hint" style={{ marginTop: '12px', fontStyle: 'italic' }}>
                     Your data stays on your device. Cloud features are optional.

--- a/apps/desktop/src/pages/Settings.tsx
+++ b/apps/desktop/src/pages/Settings.tsx
@@ -148,16 +148,16 @@ export default function Settings({ onBack }: SettingsProps) {
       <header className="settings-header">
         <div className="settings-header-left">
           {onBack && (
-            <button onClick={onBack} className="button button-secondary">
-              <ArrowLeft size={16} style={{ marginRight: '4px', verticalAlign: 'middle' }} />
+            <button onClick={onBack} className="settings-back-btn">
+              <ArrowLeft size={16} />
               Back
             </button>
           )}
-          <h1>Settings</h1>
         </div>
       </header>
 
       <main className="settings-main">
+        <h1 className="settings-title">Settings</h1>
         <div className="settings-tabs">
           <button 
             className={`settings-tab ${activeTab === 'general' ? 'active' : ''}`}

--- a/apps/desktop/src/utils/appUtils.ts
+++ b/apps/desktop/src/utils/appUtils.ts
@@ -34,11 +34,13 @@ export function decodeMetadata(metadata: any): any {
     let jsonString: string;
     
     if (typeof metadata === 'string') {
-      // Assume it's base64 encoded string
-      jsonString = atob(metadata);
+      // base64 → bytes → UTF-8 string (avoids mojibake from Latin-1 atob)
+      const binary = atob(metadata);
+      const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+      jsonString = new TextDecoder('utf-8').decode(bytes);
     } else if (Array.isArray(metadata)) {
-      // Convert array of bytes to string
-      jsonString = String.fromCharCode(...metadata);
+      // byte array → UTF-8 string (fixes garbled multi-byte chars like em-dash)
+      jsonString = new TextDecoder('utf-8').decode(new Uint8Array(metadata));
     } else {
       // Unknown format, return null
       return null;

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.10.1-rc.39"
+    "version": "0.10.1-rc.40"
 }

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.10.1-rc.40"
+    "version": "0.10.1-rc.41"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
   apps/desktop:
     dependencies:
       '@calimero-network/mero-js':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^2.2.0
+        version: 2.2.0
       '@calimero-network/mero-react':
-        specifier: ^1.1.0
-        version: 1.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^2.4.0
+        version: 2.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tauri-apps/api':
         specifier: ^1.5.0
         version: 1.6.0
@@ -194,12 +194,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  '@calimero-network/mero-js@1.4.0':
-    resolution: {integrity: sha512-kApqUK5PKyTxRh2wo33yqlhcJ1Hms1fZWOaIiZy06R0+AkKbrcPaxVhxv6/I19c7J5o56FfNgu2i7k93d3jbGA==}
+  '@calimero-network/mero-js@2.2.0':
+    resolution: {integrity: sha512-31DBV00KJ9XUJLyd1pymc9QL16uy6LJqcxvvr/u/Cm2fi2IwAScOhtRZ7L1slZizoDRjCvlGFpDjjLm/d3mhCQ==}
     engines: {node: '>=18.0.0'}
 
-  '@calimero-network/mero-react@1.1.0':
-    resolution: {integrity: sha512-GFRmApA72SuLKt5iIZBCfs2rVNxg7CSU54dHGkH31gQL3rWj+uQWZnhesR3tczh1nSE2E2xig4vV5abOeVwm/g==}
+  '@calimero-network/mero-react@2.4.0':
+    resolution: {integrity: sha512-QkTOhVVbkp41dmn8VJcK34y3/9IIaz8lDcKgMKjRo8Do7ez8uRqIT6jwPK+mj11Eb6q8DPLd/zOa8P+mGc9xlQ==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -1744,11 +1744,11 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  '@calimero-network/mero-js@1.4.0': {}
+  '@calimero-network/mero-js@2.2.0': {}
 
-  '@calimero-network/mero-react@1.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@calimero-network/mero-react@2.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@calimero-network/mero-js': 1.4.0
+      '@calimero-network/mero-js': 2.2.0
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 


### PR DESCRIPTION
# fix: rebuild all

## Description 
  - Namespace members list — clickable stat card scrolls to member section; members displayed with expandable rows showing full identity, role, and copy button; fixed display using direct
   API fetch to bypass mero-react hook parsing issue
  - Namespace name resolution — namespaces now display their actual name (from server name field + group metadata fallback) instead of raw ID
  - Create context error propagation — replaced useCreateContext wrapper (which swallowed errors) with direct mero.admin.createContext() call; real error message now shown in toast
  - HA cloud connection guard — Enable HA button is disabled with an info banner if not connected to Calimero Cloud; prevents silent failures
  - Login form validation — inline field-level errors for username/password; submit button disabled while fields empty or invalid; removed floating error banner
  - Button color consistency — destructive actions (Uninstall, Delete namespace, Reset node, Delete data folder) are uniformly red via .button.button-danger global rule with correct CSS
  specificity
  - Custom checkbox styling — Settings confirmation checkboxes match the glassmorphism design system
  - Google Sign-In button — white background, official Google G logo, no green bleed from global .button styles
  - Library upgrades — mero-js 1.4.0 → 2.2.0, mero-react 1.1.0 → 2.4.0; updated all callsites for breaking type changes (GroupInfo.alias → metadata.name, defaultVisibility →
  subgroupVisibility, GroupMember.alias → name, GroupContextEntry.alias → name)
  - Version bumps — merod rc.39 → rc.40, app 0.0.35 → 0.0.36

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to major `mero-js`/`mero-react` upgrades and expanded namespace admin actions (create/join/delete, member removal) that touch auth-protected node APIs and cloud HA toggling. UI-focused refactors are broad but mostly additive; main regression risk is mismatched API expectations or accidental destructive actions.
> 
> **Overview**
> Upgrades the desktop app to `@calimero-network/mero-js@2.2.0` and `mero-react@2.4.0` (plus app/version bumps) and adjusts the UI to new metadata fields (e.g. group/member/context `name`, `subgroupVisibility`).
> 
> Improves app navigation and marketplace UX: decouples periodic node *health* checks from app/context loading, adds a marketplace app detail modal + “explore registry” link, refresh/filter UI changes, and updates installed-app management with a compact table skeleton, a three-dot actions menu (copy ID/uninstall), and removal of desktop-shortcut creation.
> 
> Expands namespace management capabilities: resolves namespace display names via server/group metadata, adds member listing (with expandable rows) and direct admin API fetch to bypass hook parsing issues, and introduces join/invite/delete flows for namespaces, groups, contexts, and members (with confirmation modals and improved error propagation from `mero.admin`). Styling is refreshed broadly (danger button variant, header sizing, new dropdown components, skeleton theme tweaks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e383be928eb47367951de40c02b08c92b75d46ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->