### PR TITLE
feat(cloud): Phase 4 (tauri) — namespace-native HA: skip group enum + decouple HA from /contexts/claim

### DIFF
--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -251,6 +251,15 @@ export default function Namespaces() {
         // core auto-follow propagates fleet membership into subgroups;
         // per-context registration via /contexts/claim remains a
         // separate concern handled elsewhere.
+        // .catch(() => []) is intentional, NOT silent error-swallowing:
+        // bundled mero-js 1.4.0 throws on namespace/group enumeration
+        // against newer core nodes (known packaging skew), so this probe
+        // is best-effort only. On error/empty we deliberately fall
+        // through to the context-less path, which is authorised
+        // server-side by a merod-signed namespace ownership proof (Phase
+        // 1) — the canonical HA authz, not a bypass/downgrade. Phase 4
+        // decouples HA from context registration, so this fallthrough is
+        // intended. Ref: NAMESPACE_NATIVE_READMODEL_PLAN.md §4.2.
         const rootCtxs = await mero.admin
           .listGroupContexts(nsId)
           .catch(() => [] as { contextId: string }[]);

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -22,7 +22,6 @@ import {
   disableHaNamespace,
   getCloudGroups,
   CloudSessionExpiredError,
-  type NamespaceHaGroup,
 } from "../utils/cloudApi";
 import { getCloudIdToken } from "../utils/cloudAuth";
 import { isCloudEnabled } from "../utils/featureFlags";
@@ -62,95 +61,6 @@ type View =
   | { type: "list" }
   | { type: "namespace"; ns: Namespace }
   | { type: "group"; ns: Namespace; groupId: string };
-
-/**
- * Find any {group_id, context_id} pair owned by the user under this
- * namespace. The manager only stores one HaRequest + HaContextStatus
- * per namespace regardless of how many groups the client sends, so
- * there is no reason to enumerate them all — we just need one entry
- * to attach billing + fleet-join bookkeeping to.
- *
- * Fast path: most namespaces have a context in the root group
- * (group_id === namespace_id), so one admin-API call usually suffices.
- * Fallback: probe subgroups in bounded-concurrency batches and
- * early-exit as soon as one batch returns a match. The old code did
- * O(N) sequential round-trips; bounded batches keep the local admin
- * API from seeing a burst of parallel requests on large namespaces
- * while still amortising latency.
- */
-const PROBE_BATCH_SIZE = 6;
-
-async function findRepresentativeHaGroup(
-  mero: NonNullable<ReturnType<typeof useMero>["mero"]>,
-  namespaceId: string,
-): Promise<NamespaceHaGroup> {
-  // Fast path failure is tolerated but logged — if it's a real
-  // connectivity issue the fallback path's listNamespaceGroups call
-  // will surface the same error with proper context. We don't
-  // distinguish "404 / no contexts" from other errors here because
-  // mero-js doesn't expose a stable error shape to switch on; the
-  // warning in dev console is what surfaces the cause.
-  const rootCtxs = await mero.admin
-    .listGroupContexts(namespaceId)
-    .catch((err: unknown) => {
-      console.warn(
-        `listGroupContexts(${namespaceId}) failed on fast path, falling through to subgroup probe:`,
-        err,
-      );
-      return [] as { contextId: string }[];
-    });
-  if (rootCtxs.length) {
-    return { group_id: namespaceId, context_id: rootCtxs[0].contextId };
-  }
-
-  const allGroups = await mero.admin.listNamespaceGroups(namespaceId);
-  // Root already proven empty on the fast path — drop it so we don't
-  // re-probe it in the fallback.
-  const subgroups = allGroups.filter((g) => g.groupId !== namespaceId);
-  if (!subgroups.length) {
-    // A fresh namespace has only the root group and no contexts. This is
-    // a valid HA target: return the root-only representative (empty
-    // context_id). enableHaForNamespace detects the no-context case and
-    // authorises it with a server-verified namespace ownership proof
-    // rather than a per-context claim — there is intentionally no throw
-    // here.
-    return { group_id: namespaceId, context_id: "" };
-  }
-
-  for (let i = 0; i < subgroups.length; i += PROBE_BATCH_SIZE) {
-    const batch = subgroups.slice(i, i + PROBE_BATCH_SIZE);
-    const probes = await Promise.all(
-      batch.map((g) =>
-        mero.admin
-          .listGroupContexts(g.groupId)
-          .then(
-            (ctxs) =>
-              ctxs[0]
-                ? ({ group_id: g.groupId, context_id: ctxs[0].contextId } as NamespaceHaGroup)
-                : null,
-            (err: unknown) => {
-              // Per-probe failure logged but non-fatal — another
-              // subgroup may still resolve. If every probe fails the
-              // caller sees the "no context yet" error below, and the
-              // dev console has the underlying reason.
-              console.warn(`listGroupContexts(${g.groupId}) failed:`, err);
-              return null;
-            },
-          ),
-      ),
-    );
-    const found = probes.find((p): p is NamespaceHaGroup => p !== null);
-    if (found) return found;
-  }
-
-  // No group has a context yet. This is a valid HA target — return the
-  // root-only representative (empty context_id) rather than throwing.
-  // The root group id == namespaceId; enableHaForNamespace authorises
-  // this no-context case with a server-verified namespace ownership
-  // proof, and core admits a ReadOnlyTee fleet member at the root with
-  // zero contexts and auto-follows contexts created later.
-  return { group_id: namespaceId, context_id: "" };
-}
 
 export default function Namespaces() {
   const toast = useToast();
@@ -313,13 +223,39 @@ export default function Namespaces() {
         setHaEnabled((prev) => ({ ...prev, [nsId]: false }));
         toast.success('HA disabled — TEE nodes will stop replicating');
       } else {
-        // The cloud only needs ONE representative {group_id, context_id}
-        // per namespace (post mdma#30 / core rc.29 — one HaRequest row
-        // per namespace, auto-follow propagates fleet membership into
-        // subgroups). Find one quickly instead of enumerating every
-        // subgroup sequentially.
-        const haGroup = await findRepresentativeHaGroup(mero, nsId);
-        await enableHaForNamespace(token, settings.nodeUrl, nsId, [haGroup]);
+        // Root-only, SDK-skew-safe probe. We deliberately do NOT
+        // enumerate namespace groups/subgroups here anymore:
+        //
+        //  • Namespace-proof is the HA authority for the context-less
+        //    case (Phase 1, #80). enableHaForNamespace already routes an
+        //    empty group list to requestNamespaceOwnershipProof +
+        //    enableHaNamespace(nsId, [], proof) — admin-of-root proof
+        //    authorises the whole namespace, and core auto-follow
+        //    propagates fleet membership into subgroups. Group/subgroup
+        //    enumeration was legacy context-native bookkeeping and is
+        //    being decoupled here (pulling a slice of Phase 4 forward).
+        //  • Skew safety: bundled mero-js 1.4.0's listNamespaceGroups
+        //    throws "This namespace has no groups" against a
+        //    core-master/rc.40 node, and it was only ever reached on the
+        //    context-less path — exactly the path we now hand straight
+        //    to the namespace proof. listGroupContexts(nsId) is the one
+        //    call confirmed working against core master.
+        //
+        // Intentional behavioural change (NOT a regression): a namespace
+        // whose contexts live ONLY in subgroups (root group empty) now
+        // takes the namespace-proof path instead of the per-context
+        // claim path. This is consistent with the namespace-native
+        // model — admin-of-root proof authorises the whole namespace and
+        // core auto-follow propagates fleet membership into subgroups;
+        // per-context registration via /contexts/claim remains a
+        // separate concern handled elsewhere.
+        const rootCtxs = await mero.admin
+          .listGroupContexts(nsId)
+          .catch(() => [] as { contextId: string }[]);
+        const groups = rootCtxs.length
+          ? [{ group_id: nsId, context_id: rootCtxs[0].contextId }]
+          : [];
+        await enableHaForNamespace(token, settings.nodeUrl, nsId, groups);
         setHaEnabled((prev) => ({ ...prev, [nsId]: true }));
         toast.success('HA enabled — TEE fleet nodes will join');
       }

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -259,10 +259,18 @@ export default function Namespaces() {
         // server-side by a merod-signed namespace ownership proof (Phase
         // 1) — the canonical HA authz, not a bypass/downgrade. Phase 4
         // decouples HA from context registration, so this fallthrough is
-        // intended. Ref: NAMESPACE_NATIVE_READMODEL_PLAN.md §4.2.
+        // intended. Ref: NAMESPACE_NATIVE_READMODEL_PLAN.md §4.2. The
+        // failure is now warn-logged so non-skew probe failures stay
+        // visible for diagnosis.
         const rootCtxs = await mero.admin
           .listGroupContexts(nsId)
-          .catch(() => [] as { contextId: string }[]);
+          .catch((err: unknown) => {
+            console.warn(
+              'listGroupContexts probe failed; treating namespace as context-less and falling through to the namespace-ownership-proof path (expected under mero-js↔core skew):',
+              err,
+            );
+            return [] as { contextId: string }[];
+          });
         const groups = rootCtxs.length
           ? [{ group_id: nsId, context_id: rootCtxs[0].contextId }]
           : [];

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -166,10 +166,12 @@ export default function Namespaces() {
     });
   };
 
-  // HA state — keyed by namespaceId (not groupId). A namespace is
-  // considered HA-enabled if at least one of its groups has HA enabled
-  // on the cloud side. `haEnabling` is a per-namespace map (not a single
-  // boolean) so toggling one namespace doesn't lock every other toggle.
+  // HA state — keyed by namespaceId. A namespace is HA-enabled when the
+  // cloud reports ha_status === "enabled" for it (namespace-scoped — the
+  // cloud collapses HA to one record per namespace; post Phase 4 the
+  // payload also carries zero-context namespaces). `haEnabling` is a
+  // per-namespace map (not a single boolean) so toggling one namespace
+  // doesn't lock every other toggle.
   const [haEnabling, setHaEnabling] = useState<Record<string, boolean>>({});
   const [haEnabled, setHaEnabled] = useState<Record<string, boolean>>({});
 
@@ -509,8 +511,9 @@ export default function Namespaces() {
             <div className="ns-detail-section">
               <h2><Shield size={16} style={{ marginRight: 6, verticalAlign: -2 }} />High Availability</h2>
               <p className="ha-description">
-                Enable TEE replication to have fleet nodes automatically join and replicate
-                your namespace data. Requires a Calimero Cloud account with a paid plan.
+                Enable TEE replication to have fleet nodes automatically join and
+                replicate this namespace. Requires a Calimero Cloud account with a
+                paid plan.
               </p>
               <div className="ha-toggle-row">
                 <span className="ha-status">

--- a/apps/desktop/src/utils/cloudApi.test.ts
+++ b/apps/desktop/src/utils/cloudApi.test.ts
@@ -181,12 +181,12 @@ describe('claimContexts', () => {
   });
 });
 
-describe('enableHaForNamespace silent-claim pre-flight', () => {
+describe('enableHaForNamespace (Phase 4 — HA decoupled from /contexts/claim)', () => {
   let restore: () => void;
   beforeEach(() => {
     // Deterministic but *distinct per call* — a counter advances each
-    // fill so parallel proof requests get different nonces (a constant
-    // mock would mask a per-batch duplicate-nonce regression).
+    // fill so the namespace-proof nonce is well-formed and a future
+    // multi-proof regression would still surface.
     let counter = 0;
     vi.spyOn(crypto, 'getRandomValues').mockImplementation((arr: any) => {
       for (let i = 0; i < arr.length; i++) arr[i] = (counter + i) & 0xff;
@@ -227,7 +227,7 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
       enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', [
         { group_id: 'g1', context_id: 'ctx-1' },
       ]),
-    ).rejects.toThrow(/Only the namespace admin can register contexts/);
+    ).rejects.toThrow(/Only the namespace admin can enable HA/);
   });
 
   it('gives a distinct error when our identity is not among the members', async () => {
@@ -267,7 +267,7 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
     ).rejects.toThrow(/Unexpected response from local node members endpoint/);
   });
 
-  it('runs members → proofs (parallel) → claim → measurements → tee-policy → enable in order', async () => {
+  it('real-context path: members → measurements → tee-policy → enable, NO proof, NO /contexts/claim', async () => {
     const calls: string[] = [];
     const { restore: r } = installFetch((url, init) => {
       calls.push(`${init?.method ?? 'GET'} ${url}`);
@@ -277,14 +277,6 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
             members: [{ identity: 'me', role: 'Admin' }],
             selfIdentity: 'me',
           }),
-        '/admin-api/groups/ns-root/issue-ownership-proof': () =>
-          jsonResponse({
-            signerPublicKey: 'pk',
-            signedPayload: 'sp',
-            signature: 'sig',
-          }),
-        '/api/cloud/me/contexts/claim': () =>
-          jsonResponse({ claimed: ['ctx-1', 'ctx-2'] }),
         '/api/cloud/fleet/measurements': () =>
           jsonResponse({
             release_tag: 'v1',
@@ -317,18 +309,14 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
     );
     expect(res.status).toBe('enabling');
 
-    // Order: members must come before any proof; proofs must come
-    // before the claim POST; claim must precede measurements; tee-
-    // policy must precede the final enable.
+    // Phase 4 decouple: HA enable performs NO context-claim preflight.
+    expect(calls.some((c) => c.includes('/issue-ownership-proof'))).toBe(false);
+    expect(calls.some((c) => c.includes('/contexts/claim'))).toBe(false);
+
+    // Order: members (UX fail-fast) → measurements → tee-policy → enable.
     const ordered = (substr: string) =>
       calls.findIndex((c) => c.includes(substr));
-    expect(ordered('/members')).toBeLessThan(ordered('/issue-ownership-proof'));
-    expect(ordered('/issue-ownership-proof')).toBeLessThan(
-      ordered('/contexts/claim'),
-    );
-    expect(ordered('/contexts/claim')).toBeLessThan(
-      ordered('/fleet/measurements'),
-    );
+    expect(ordered('/members')).toBeLessThan(ordered('/fleet/measurements'));
     expect(ordered('/fleet/measurements')).toBeLessThan(
       ordered('/tee-admission-policy'),
     );
@@ -336,20 +324,85 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
       ordered('/enable-ha'),
     );
 
-    // Exactly two proof requests (one per group) — parallel, but both
-    // present in the call list.
-    const proofCalls = calls.filter((c) =>
-      c.includes('/issue-ownership-proof'),
-    );
-    expect(proofCalls).toHaveLength(2);
+    // Real-context path sends the groups straight through, no proof key.
+    const enableCall = calls.find((c) => c.includes('/enable-ha'));
+    expect(enableCall).toBeDefined();
+  });
 
-    // *Every* proof call must precede the claim — findIndex only checks
-    // the first, so a bug where one proof lands after the claim would
-    // otherwise slip through.
-    const claimIdx = calls.findIndex((c) => c.includes('/contexts/claim'));
-    for (const pc of proofCalls) {
-      expect(calls.indexOf(pc)).toBeLessThan(claimIdx);
-    }
+  it('no-context path ([] groups): members → measurements → tee-policy → ONE namespace proof → enable, NO /contexts/claim', async () => {
+    const calls: string[] = [];
+    let enableBody: any;
+    const { restore: r } = installFetch((url, init) => {
+      calls.push(`${init?.method ?? 'GET'} ${url}`);
+      if (url.includes('/enable-ha')) {
+        enableBody = JSON.parse(String(init?.body));
+      }
+      return route(url, init, {
+        '/admin-api/groups/ns-root/members': () =>
+          jsonResponse({
+            members: [{ identity: 'me', role: 'Admin' }],
+            selfIdentity: 'me',
+          }),
+        '/admin-api/groups/ns-root/issue-namespace-ownership-proof': () =>
+          jsonResponse({
+            signerPublicKey: 'pk',
+            signedPayload: 'sp',
+            signature: 'sig',
+          }),
+        '/api/cloud/fleet/measurements': () =>
+          jsonResponse({
+            release_tag: 'v1',
+            allowed_mrtd: ['mrtd-1'],
+            allowed_rtmr0: [],
+            allowed_rtmr1: [],
+            allowed_rtmr2: [],
+            allowed_rtmr3: [],
+          }),
+        '/admin-api/groups/ns-root/settings/tee-admission-policy': () =>
+          new Response('{}', { status: 200 }),
+        '/api/cloud/me/namespaces/ns-root/enable-ha': () =>
+          jsonResponse({
+            status: 'enabling',
+            namespace_id: 'ns-root',
+            groups: [],
+          }),
+      });
+    });
+    restore = r;
+
+    const res = await enableHaForNamespace(
+      makeJwt({ iss: 'mdma', email: 'u@e' }),
+      'http://node',
+      'ns-root',
+      [], // zero-context namespace
+    );
+    expect(res.status).toBe('enabling');
+
+    // No /contexts/claim on the no-context path either.
+    expect(calls.some((c) => c.includes('/contexts/claim'))).toBe(false);
+
+    // Exactly one namespace-scoped ownership proof, after tee-policy.
+    const nsProofCalls = calls.filter((c) =>
+      c.includes('/issue-namespace-ownership-proof'),
+    );
+    expect(nsProofCalls).toHaveLength(1);
+    const ordered = (substr: string) =>
+      calls.findIndex((c) => c.includes(substr));
+    expect(ordered('/tee-admission-policy')).toBeLessThan(
+      ordered('/issue-namespace-ownership-proof'),
+    );
+    expect(ordered('/issue-namespace-ownership-proof')).toBeLessThan(
+      ordered('/enable-ha'),
+    );
+
+    // The namespace proof is sent as ownership_proof with an empty group
+    // list — the authoritative server-verified gate for this path.
+    expect(enableBody.groups).toEqual([]);
+    expect(enableBody.ownership_proof).toEqual({
+      signer_public_key: 'pk',
+      signed_payload: 'sp',
+      signature: 'sig',
+    });
   });
 
   it('throws a clear error when the MDMA session JWT lacks an identifier', async () => {
@@ -365,11 +418,11 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
     ).rejects.toThrow(/missing the user identifier/);
   });
 
-  it('issues a distinct nonce per parallel proof request', async () => {
-    const bodies: any[] = [];
+  it('the no-context namespace proof carries a well-formed nonce + the enable-ha audience', async () => {
+    let proofBody: any;
     const { restore: r } = installFetch((url, init) => {
-      if (url.includes('/issue-ownership-proof')) {
-        bodies.push(JSON.parse(String(init?.body)));
+      if (url.includes('/issue-namespace-ownership-proof')) {
+        proofBody = JSON.parse(String(init?.body));
       }
       return route(url, init, {
         '/admin-api/groups/ns-root/members': () =>
@@ -377,14 +430,73 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
             members: [{ identity: 'me', role: 'Admin' }],
             selfIdentity: 'me',
           }),
-        '/admin-api/groups/ns-root/issue-ownership-proof': () =>
+        '/admin-api/groups/ns-root/issue-namespace-ownership-proof': () =>
           jsonResponse({
             signerPublicKey: 'pk',
             signedPayload: 'sp',
             signature: 'sig',
           }),
-        '/api/cloud/me/contexts/claim': () =>
-          jsonResponse({ claimed: ['ctx-1', 'ctx-2'] }),
+        '/api/cloud/fleet/measurements': () =>
+          jsonResponse({
+            release_tag: 'v1',
+            allowed_mrtd: ['mrtd-1'],
+            allowed_rtmr0: [],
+            allowed_rtmr1: [],
+            allowed_rtmr2: [],
+            allowed_rtmr3: [],
+          }),
+        '/admin-api/groups/ns-root/settings/tee-admission-policy': () =>
+          new Response('{}', { status: 200 }),
+        '/api/cloud/me/namespaces/ns-root/enable-ha': () =>
+          jsonResponse({ status: 'enabling', namespace_id: 'ns-root', groups: [] }),
+      });
+    });
+    restore = r;
+    await enableHaForNamespace(
+      makeJwt({ iss: 'mdma', email: 'u@e' }),
+      'http://node',
+      'ns-root',
+      [],
+    );
+    expect(proofBody).toBeDefined();
+    expect(proofBody.audience).toBe('mdma:enable-ha-namespace');
+    expect(proofBody.subject).toBe('u@e');
+    expect(proofBody.nonce).toMatch(/^[0-9a-f]{32}$/);
+    // No contextId on a namespace-scoped proof.
+    expect(proofBody.contextId).toBeUndefined();
+  });
+
+  it('rejects a non-MDMA or expired session token before any network call', async () => {
+    const { calls, restore: r } = installFetch(() => jsonResponse({}));
+    restore = r;
+    // iss != "mdma"
+    await expect(
+      enableHaForNamespace(makeJwt({ iss: 'google', email: 'u@e' }), 'http://node', 'ns', [
+        { group_id: 'g', context_id: 'c' },
+      ]),
+    ).rejects.toThrow(/Not signed in to Calimero Cloud/);
+    // mdma but expired
+    await expect(
+      enableHaForNamespace(
+        makeJwt({ iss: 'mdma', email: 'u@e', exp: Math.floor(Date.now() / 1000) - 10 }),
+        'http://node',
+        'ns',
+        [{ group_id: 'g', context_id: 'c' }],
+      ),
+    ).rejects.toThrow(/Cloud session has expired/);
+    expect(calls).toHaveLength(0); // failed fast, no merod/cloud round-trips
+  });
+
+  it('does not call /contexts/claim even when real contexts are supplied', async () => {
+    const seen: string[] = [];
+    const { restore: r } = installFetch((url, init) => {
+      seen.push(url);
+      return route(url, init, {
+        '/admin-api/groups/ns-root/members': () =>
+          jsonResponse({
+            members: [{ identity: 'me', role: 'Admin' }],
+            selfIdentity: 'me',
+          }),
         '/api/cloud/fleet/measurements': () =>
           jsonResponse({
             release_tag: 'v1',
@@ -410,58 +522,10 @@ describe('enableHaForNamespace silent-claim pre-flight', () => {
         { group_id: 'sub-1', context_id: 'ctx-2' },
       ],
     );
-    expect(bodies).toHaveLength(2);
-    expect(bodies[0].nonce).not.toBe(bodies[1].nonce);
-    for (const b of bodies) expect(b.nonce).toMatch(/^[0-9a-f]{32}$/);
-  });
-
-  it('rejects a non-MDMA or expired session token before any network call', async () => {
-    const { calls, restore: r } = installFetch(() => jsonResponse({}));
-    restore = r;
-    // iss != "mdma"
-    await expect(
-      enableHaForNamespace(makeJwt({ iss: 'google', email: 'u@e' }), 'http://node', 'ns', [
-        { group_id: 'g', context_id: 'c' },
-      ]),
-    ).rejects.toThrow(/Not signed in to Calimero Cloud/);
-    // mdma but expired
-    await expect(
-      enableHaForNamespace(
-        makeJwt({ iss: 'mdma', email: 'u@e', exp: Math.floor(Date.now() / 1000) - 10 }),
-        'http://node',
-        'ns',
-        [{ group_id: 'g', context_id: 'c' }],
-      ),
-    ).rejects.toThrow(/Cloud session has expired/);
-    expect(calls).toHaveLength(0); // failed fast, no merod/cloud round-trips
-  });
-
-  it('throws (and does not enable HA) when the cloud only partially claims', async () => {
-    const seen: string[] = [];
-    const { restore: r } = installFetch((url, init) => {
-      seen.push(url);
-      return route(url, init, {
-        '/admin-api/groups/ns-root/members': () =>
-          jsonResponse({
-            members: [{ identity: 'me', role: 'Admin' }],
-            selfIdentity: 'me',
-          }),
-        '/admin-api/groups/ns-root/issue-ownership-proof': () =>
-          jsonResponse({ signerPublicKey: 'pk', signedPayload: 'sp', signature: 'sig' }),
-        // Submitted ctx-1 + ctx-2, cloud only claims ctx-1.
-        '/api/cloud/me/contexts/claim': () => jsonResponse({ claimed: ['ctx-1'] }),
-      });
-    });
-    restore = r;
-    await expect(
-      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', [
-        { group_id: 'ns-root', context_id: 'ctx-1' },
-        { group_id: 'sub-1', context_id: 'ctx-2' },
-      ]),
-    ).rejects.toThrow(/did not register 1 of 2 context\(s\): ctx-2/);
-    // Must have stopped before the enable-ha / tee-policy steps.
-    expect(seen.some((u) => u.includes('/enable-ha'))).toBe(false);
-    expect(seen.some((u) => u.includes('/tee-admission-policy'))).toBe(false);
+    // The decouple invariant: no /contexts/claim and no per-context
+    // /issue-ownership-proof anywhere in the HA-enable flow.
+    expect(seen.some((u) => u.includes('/contexts/claim'))).toBe(false);
+    expect(seen.some((u) => u.includes('/issue-ownership-proof'))).toBe(false);
   });
 
   it('throws the descriptive error (not a raw SyntaxError) on a non-JSON members body', async () => {

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -639,20 +639,29 @@ export async function claimContexts(
 }
 
 /**
- * Enable HA end-to-end for a namespace:
- * 1. Pre-flight: verify caller is namespace Admin and silently register
- *    each group's representative context with the cloud (so the
- *    subsequent enableHaNamespace call doesn't reject with
- *    "Contexts not found or not owned by user").
+ * Enable HA end-to-end for a namespace (Phase 4 — HA authz decoupled
+ * from context registration):
+ * 1. Pre-flight: verify the caller is the namespace-root Admin. This is
+ *    a UX fail-fast only — the authoritative gate is server-side (the
+ *    namespace ownership proof on the no-context path; a UserContext the
+ *    caller already claimed on the real-context path). HA enable no
+ *    longer silently claims contexts as a precondition: there is NO
+ *    `/contexts/claim` round-trip on either path. `/contexts/claim`
+ *    remains a separate, explicit context-registration concern (see
+ *    `claimContexts` / `requestOwnershipProof`) that callers invoke on
+ *    their own; it is not a hidden dependency of enabling HA.
  * 2. Fetch fleet measurements from cloud once (trusted MRTD values).
  * 3. Set the TEE admission policy on the *namespace root only*. Subgroup
  *    policies are ignored by core (namespace-scoped since rc.29 /
  *    calimero-network/core#2188) — applying them would error. Auto-follow
  *    propagates fleet-node membership into subgroups without a second
  *    admission check.
- * 4. Register the namespace with cloud. MDMA still needs the full group
- *    list for billing + per-group status rows until the server-side
- *    flattening lands, so the caller keeps enumerating groups.
+ * 4. Register the namespace with cloud:
+ *    • Real-context path: `groups` carries representative
+ *      {group_id, context_id} entries; the cloud authorises each context
+ *      against a UserContext the caller already claimed out-of-band.
+ *    • No-context path: `groups` is `[]` plus a single namespace-scoped
+ *      ownership proof — the authoritative server-verified namespace gate.
  */
 export async function enableHaForNamespace(
   idToken: string,
@@ -661,23 +670,22 @@ export async function enableHaForNamespace(
   groups: NamespaceHaGroup[],
 ): Promise<EnableHaNamespaceResponse> {
   // A context-less namespace is a first-class HA target. When no group
-  // has a real context yet there is nothing to claim per-context, so the
-  // per-context proof + claimContexts batch below is skipped; instead we
-  // send the cloud ONE namespace-scoped ownership proof and an empty
-  // group list. Core admits a ReadOnlyTee fleet member at the root group
-  // (group_id == namespaceId) with zero contexts and auto-follows
-  // contexts created later. The namespace proof is the authoritative
-  // server-verified ownership gate for this path (the cloud cannot
-  // authorise off a UserContext row because none exists yet) — without
-  // it, any authenticated user could enable HA on any namespace.
+  // has a real context the cloud authorises off ONE namespace-scoped
+  // ownership proof + an empty group list (the authoritative
+  // server-verified gate — no UserContext row exists to authorise
+  // against). When real contexts are supplied the cloud authorises each
+  // against a UserContext the caller already registered out-of-band via
+  // the separate /contexts/claim flow. Neither path claims contexts as a
+  // side effect of enabling HA (Phase 4 decouple).
   const hasRealContext = groups.some((g) => !!g.context_id);
 
-  // ── Step 1: silent claim ──
+  // ── Step 1: token-shape fail-fast + Admin pre-flight ──
   // The cloud verifier is the authoritative trust boundary: it re-checks
   // the proof signature and that the proof's subject == the authenticated
   // bearer's MDMA account. Validating the token shape here is defence-in-
-  // depth + fail-fast — refuse to spend local merod round-trips (role
-  // check + N proof issuances) on a token the cloud will reject anyway.
+  // depth + fail-fast — refuse to spend a local merod round-trip (role
+  // check, plus a namespace-proof issuance on the no-context path) on a
+  // token the cloud will reject anyway.
   if (!isMdmaSessionToken(idToken)) {
     throw new Error('Not signed in to Calimero Cloud — connect in Settings');
   }
@@ -707,10 +715,11 @@ export async function enableHaForNamespace(
     );
   }
 
-  // Pre-flight role check on the namespace root. Only the admin can
-  // hand out ownership proofs that the cloud verifier will accept —
-  // bailing early gives a clear error rather than a confusing 403
-  // later when the cloud rejects every proof in the batch.
+  // Pre-flight role check on the namespace root. Only the direct admin
+  // of the namespace root can enable HA — bailing early gives a clear
+  // error rather than a confusing 403/422 later when the cloud rejects
+  // the proof (no-context path) or the namespace registration. This is a
+  // UX fail-fast; the authoritative gate is server-side.
   // Wire format is locked: GroupMemberRole in core serialises as
   // {Admin, Member, ReadOnly, ReadOnlyTee}. We require Admin only.
   const role = await getSelfRoleInGroup(nodeUrl, namespaceId);
@@ -724,69 +733,20 @@ export async function enableHaForNamespace(
     );
   }
   if (role !== 'Admin') {
-    throw new Error('Only the namespace admin can register contexts with the cloud.');
+    throw new Error('Only the namespace admin can enable HA for this namespace.');
   }
 
-  // Real-context path (unchanged): per-context proof + claimContexts so
-  // the cloud can authorise each context against a claimed UserContext.
-  // The context-less path skips this entirely and instead supplies the
-  // single namespace proof to enableHaNamespace below; the Admin
-  // pre-flight above is a UX fail-fast for both, but the server-verified
-  // namespace proof is the authoritative gate for the context-less path.
-  if (hasRealContext) {
-  // Every proof is scoped to the *namespace root* (`namespaceId`), not
-  // each group's own `group_id`, even for contexts that live in
-  // subgroups. This is deliberate and consistent across the three
-  // coordinated repos:
-  //   • The ownership gate is "direct admin of the namespace root"
-  //     (the role check above), so the root is the authoritative
-  //     scope for the whole namespace.
-  //   • core's resolve_group_signing_key walks ancestors, so the
-  //     root's signing key signs proofs for subgroup contexts too.
-  //   • core's context↔namespace containment check (calimero#2362)
-  //     accepts any context within the namespace rooted at this
-  //     group_id — a strict per-group equality check would reject
-  //     subgroup contexts here.
-  // Same rationale as the "set TEE policy on the root only, subgroups
-  // inherit" step further below.
-  //
-  // Issue one proof per group in parallel — they hit the local merod
-  // and are independent, so latency stacks linearly otherwise. Note
-  // Promise.all is all-or-nothing: a single proof failure aborts the
-  // whole HA-enable and the user retries the flow.
-  const proofs = await Promise.all(
-    groups.map((g) =>
-      requestOwnershipProof(nodeUrl, namespaceId, {
-        contextId: g.context_id,
-        subject,
-      }).then<ClaimedContext>((proof) => ({
-        context_id: g.context_id,
-        ownership_proof: proof,
-      })),
-    ),
-  );
+  // NOTE (Phase 4 decouple): there is intentionally no per-context
+  // ownership-proof + /contexts/claim batch here anymore. Enabling HA no
+  // longer silently registers contexts as a precondition. The
+  // real-context path now sends `groups` straight to enableHaNamespace —
+  // the cloud authorises each context against a UserContext the caller
+  // already registered via the separate, explicit /contexts/claim flow
+  // (requestOwnershipProof + claimContexts remain available for that, but
+  // are not invoked from this HA path). The no-context path supplies a
+  // single namespace-scoped ownership proof below.
 
-  // Single batched submit. Errors propagate to the caller (Namespaces
-  // page surfaces via toast). Verify the cloud actually recorded every
-  // context we submitted — a partial `claimed[]` would otherwise let HA
-  // proceed for groups whose contexts were never registered, surfacing
-  // later as a confusing "context not owned" failure.
-  const claimed = await claimContexts(idToken, proofs);
-  const claimedSet = new Set(claimed);
-  // Compare against *unique* submitted ids — duplicate context_ids in
-  // `groups` would otherwise count a single cloud-claimed id as multiple
-  // "missing" entries and falsely abort.
-  const submitted = [...new Set(proofs.map((p) => p.context_id))];
-  const missing = submitted.filter((id) => !claimedSet.has(id));
-  if (missing.length > 0) {
-    throw new Error(
-      `Cloud did not register ${missing.length} of ${submitted.length} ` +
-        `context(s): ${missing.join(', ')}. HA was not enabled.`,
-    );
-  }
-  } // end real-context claim block
-
-  // ── Step 2–4: existing flow ──
+  // ── Step 2–4: measurements → tee-policy → register ──
   const measurements = await getFleetMeasurements(idToken);
   if (!measurements.allowed_mrtd.length) {
     throw new Error('No fleet MRTD measurements available — cannot set admission policy');
@@ -797,7 +757,9 @@ export async function enableHaForNamespace(
   await setTeeAdmissionPolicy(nodeUrl, namespaceId, measurements.allowed_mrtd);
 
   if (hasRealContext) {
-    // Real-context path: contexts already claimed above, no proof.
+    // Real-context path: the cloud authorises each context against a
+    // UserContext the caller registered out-of-band via /contexts/claim.
+    // No proof here, and HA no longer claims on the caller's behalf.
     return enableHaNamespace(idToken, namespaceId, groups);
   }
 


### PR DESCRIPTION
## Summary

The **tauri side of Phase 4** of the namespace-native read-model migration. Authoritative spec: `NAMESPACE_NATIVE_READMODEL_PLAN.md` (§4.2 *decouple HA authz from context registration*, §4.3 *tauri*, *Decisions (RESOLVED 2026-05-19)* C, *Deprecations & removal tracking* item 3).

Phases 1, 2 (mdma#120) + mdma#121 are merged & verified in prod; the prod zero-context namespace is `678c2de9be148105d1ea1cb2a8241d89c1e2bd1fc22548dd844d32d7b0533000`. The mdma Phase 4 read-model PR (re-root `get_my_groups` on `UserNamespace`, so `/api/cloud/me/groups` also returns the zero-context namespace with `ha_status:"enabled"`) is **parallel** to this PR.

## What's in here

Three stacked pieces:

1. **Skip group enumeration** (`87942fe`, slice pulled forward earlier): the Enable-HA click handler no longer enumerates namespace groups/subgroups. `findRepresentativeHaGroup` (+ `PROBE_BATCH_SIZE`, unused `NamespaceHaGroup` import) deleted; a single root-only `mero.admin.listGroupContexts(nsId)` probe decides real-context vs. context-less, with the empty case handed straight to `enableHaForNamespace`'s namespace-ownership-proof path. SDK-skew-safe (bundled mero-js 1.4.0 `listNamespaceGroups` throws against core master/rc.40 on exactly the context-less path).

2. **Decouple HA from /contexts/claim** (§4.2): `cloudApi.ts::enableHaForNamespace` no longer runs the silent context-claim preflight. The per-context `requestOwnershipProof` + `claimContexts` batch (and its partial-claim coverage check) is removed, so enabling HA performs **no** `/contexts/claim` on either path:
   - **No-context path** (unchanged): `requestNamespaceOwnershipProof` → `enableHaNamespace(nsId, [], proof)` — the authoritative server-verified namespace-ownership gate.
   - **Real-context path**: `groups` sent straight to `enableHaNamespace`; the cloud authorises each context against a `UserContext` the caller registered out-of-band. HA no longer claims on the caller's behalf.
   - Admin role pre-flight retained as a **pure UX fail-fast** (error copy updated `register contexts` → `enable HA`).
   - `requestOwnershipProof` / `claimContexts` / `requestNamespaceOwnershipProof` stay defined & exported — `/contexts/claim` remains **pure context registration (NOT deprecated)**; only HA's hidden dependency on it is removed (spec *Deprecations* item 3, *Decision C*).

3. **Misnomer #2 UI label** (§4.3): HA copy reads "replicate this namespace" (was "your namespace data"); the HA-state comment no longer frames a namespace as "at least one of its groups". UI strings only — no code-identifier mass-rename.

## Enabled-state render (no over-change)

`Namespaces.tsx` already sets `haEnabled[g.namespace_id] = true` when `g.ha_status === "enabled"` and renders "✓ HA Enabled". This data path keys off `g.ha_status` / `g.namespace_id` from `/api/cloud/me/groups` and is **unchanged** here — it "just works" once the parallel mdma Phase 4 `/groups` payload includes the zero-context namespace in the same field shape. The skip-group-enum slice only touched `toggleHa`'s enable branch, not the hydration `useEffect` or the render, so it didn't break this.

**Gap noted (C):** the tauri side is fully dependent on mdma Phase 4 populating a **non-null `namespace_id`** (with `ha_status:"enabled"`) on the zero-context row. The hydration loop has a pre-existing defensive `if (!g.namespace_id) continue;` (correct to keep — `CloudGroup.namespace_id` is `string | null`); no tauri-side change can compensate if the server returns `namespace_id: null`. This matches the spec's expectation that the fix is server-side (§4.1) — flagging it, not over-engineering around it.

## Verification

- `cd apps/desktop && pnpm tsc --noEmit` — passes (strict, `noUnusedLocals`/`noUnusedParameters` on).
- `pnpm test:unit` — 34/34 pass (HA describe block reworked for the decoupled flow: asserts NO `/contexts/claim` and NO per-context `/issue-ownership-proof` on the real-context path; adds a no-context-path test; drops obsolete proof→claim ordering / partial-claim tests; standalone `requestOwnershipProof`/`claimContexts` tests kept).
- Playwright e2e: all 116 tests across 9 specs compile (`--list`, exit 0). No repo ESLint config/lint script — `tsc` strict is the hygiene gate.
- Full E2E of the HA round-trip needs the **parallel mdma Phase 4 deploy** (and a bundled .app — dev mode can't complete the `calimero://` OAuth callback). Expected and deferred.

Refs mdma#120 / mdma#121 / mdma#119.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the HA enable flow and its authorization/probing logic, which can affect whether HA is enabled for namespaces (especially those with subgroup-only contexts) and alters cloud/local API call sequencing.
> 
> **Overview**
> **Namespace HA enablement is refactored to be namespace-native and less coupled to context registration.** The desktop `Namespaces` HA toggle no longer enumerates namespace groups/subgroups; it does a root-only `listGroupContexts` probe (warn-logged on failure) and either enables HA with a single root context or falls back to the context-less namespace-proof path.
> 
> **`enableHaForNamespace` no longer silently issues per-context ownership proofs or calls `/contexts/claim`.** Real-context enables now send `groups` directly to `enableHaNamespace`, while the no-context path issues exactly one `issue-namespace-ownership-proof` and includes it in the enable request; error messaging and unit tests are updated to assert the new call order and the absence of `/contexts/claim`/per-context proof calls. UI copy for HA description is slightly tweaked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b4893d5e3e43cf073503c4fbe51c0951a8a766d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->