### PR TITLE
fix(e2e): update Playwright tests for UI redesign

### DIFF
--- a/apps/desktop/e2e/marketplace.spec.ts
+++ b/apps/desktop/e2e/marketplace.spec.ts
@@ -31,7 +31,7 @@ test.describe("Marketplace – browsing & searching", () => {
     page,
   }) => {
     await expect(page.locator('input[placeholder="Search applications..."]')).toBeVisible();
-    await expect(page.locator("select")).toBeVisible();
+    await expect(page.locator(".filter-pill", { hasText: "All" })).toBeVisible();
   });
 
   test("displays apps fetched from registry", async ({ page }) => {
@@ -65,7 +65,7 @@ test.describe("Marketplace – browsing & searching", () => {
   });
 
   test("refresh button is present and clickable", async ({ page }) => {
-    const refreshBtn = page.locator('button[title="Refresh applications"]');
+    const refreshBtn = page.locator('.marketplace-filters button[title="Refresh"]');
     await expect(refreshBtn).toBeVisible();
     await refreshBtn.click();
   });
@@ -103,7 +103,7 @@ test.describe("Installed Applications – listing", () => {
     await setupAuthenticatedPage(page);
     await navigateVia(page, "Applications");
     await expect(
-      page.getByRole("heading", { name: "Installed Applications", level: 2 }),
+      page.getByRole("heading", { name: "Applications", level: 1 }),
     ).toBeVisible();
   });
 
@@ -158,7 +158,7 @@ test.describe("Installed Applications – empty state", () => {
 
     await navigateVia(page, "Applications");
     await expect(
-      page.getByRole("heading", { name: "Installed Applications", level: 2 }),
+      page.getByRole("heading", { name: "Applications", level: 1 }),
     ).toBeVisible();
     await expect(page.getByText("No applications installed.")).toBeVisible();
   });
@@ -175,13 +175,12 @@ describeAfter35("Installed Applications – row variants", () => {
     await setupAuthenticatedPage(page);
     await navigateVia(page, "Applications");
     await expect(
-      page.getByRole("heading", { name: "Installed Applications", level: 2 }),
+      page.getByRole("heading", { name: "Applications", level: 1 }),
     ).toBeVisible();
 
     const demoRow = page.locator("tr", { hasText: "Blockchain Demo" });
-    await expect(demoRow.getByRole("button", { name: "Uninstall" })).toBeVisible();
     await expect(demoRow.getByRole("button", { name: "Open" })).toHaveCount(0);
-    await expect(demoRow.getByRole("button", { name: "Shortcut" })).toHaveCount(0);
+    await expect(demoRow.locator(".btn-more")).toBeVisible();
   });
 });
 
@@ -192,7 +191,7 @@ describeAfter35("Installed Applications – actions", () => {
     await setupAuthenticatedPage(page);
     await navigateVia(page, "Applications");
     await expect(
-      page.getByRole("heading", { name: "Installed Applications", level: 2 }),
+      page.getByRole("heading", { name: "Applications", level: 1 }),
     ).toBeVisible();
   });
 
@@ -204,14 +203,6 @@ describeAfter35("Installed Applications – actions", () => {
     await expect(openBtn).toBeVisible();
   });
 
-  test("Shortcut button is visible for apps with frontend URLs", async ({
-    page,
-  }) => {
-    const chatRow = page.locator("tr", { hasText: "Only Peers Chat" });
-    const shortcutBtn = chatRow.locator('button:has-text("Shortcut")');
-    await expect(shortcutBtn).toBeVisible();
-  });
-
   test("Uninstall button is visible for all installed apps", async ({
     page,
   }) => {
@@ -219,9 +210,7 @@ describeAfter35("Installed Applications – actions", () => {
       const meta = JSON.parse(atob(app.metadata));
       const displayName = meta.name || app.name;
       const row = page.locator("tr", { hasText: displayName });
-      await expect(
-        row.locator('button:has-text("Uninstall")'),
-      ).toBeVisible();
+      await expect(row.locator(".btn-more")).toBeVisible();
     }
   });
 });
@@ -242,7 +231,7 @@ describeAfter35("Marketplace ↔ Applications navigation", () => {
 
     await navigateVia(page, "Applications");
     await expect(
-      page.getByRole("heading", { name: "Installed Applications", level: 2 }),
+      page.getByRole("heading", { name: "Applications", level: 1 }),
     ).toBeVisible();
 
     await navigateVia(page, "Marketplace");

--- a/apps/desktop/e2e/namespaces.spec.ts
+++ b/apps/desktop/e2e/namespaces.spec.ts
@@ -45,7 +45,7 @@ test.describe("Namespaces – page rendering", () => {
 
   test("renders the Namespaces heading inside the page", async ({ page }) => {
     await expect(
-      page.locator(".ns-header h1"),
+      page.locator(".ns-page-top h1"),
     ).toHaveText("Namespaces");
   });
 


### PR DESCRIPTION
## Summary

- Update heading assertions from `h2 "Installed Applications"` to `h1 "Applications"` across all marketplace tests
- Replace `page.locator("select")` filter selector with `.filter-pill` pill button selector
- Fix refresh button selector from `button[title="Refresh applications"]` to `.marketplace-filters button[title="Refresh"]`
- Replace direct `Uninstall` / `Shortcut` button assertions with `.btn-more` dropdown check (actions moved to overflow menu)
- Remove "Shortcut button is visible" test (Shortcut button was removed from the UI)
- Fix Namespaces heading selector from `.ns-header h1` to `.ns-page-top h1` (heading lives in list view container, not detail header)

## Test plan

- [ ] Run `pnpm exec playwright test e2e/marketplace.spec.ts` — all tests pass
- [ ] Run `pnpm exec playwright test e2e/namespaces.spec.ts` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Playwright e2e assertions/selectors to match UI updates, with no production logic or data handling impact.
> 
> **Overview**
> Updates desktop Playwright e2e tests to match recent UI redesigns in Marketplace, Applications, and Namespaces.
> 
> Marketplace tests now assert the new filter pill UI and updated refresh button selector, and Applications tests switch heading expectations to `h1 "Applications"` while validating row actions via the overflow `.btn-more` menu (dropping the removed Shortcut button coverage). Namespaces tests update the heading selector from `.ns-header h1` to `.ns-page-top h1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62e11c13f6540849dd19467aa38880d6ffbf01d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->