### PR TITLE
fix(desktop): fix namespace/context join invitation flow and nuke seq…

### DIFF
--- a/apps/desktop/src/components/ToastContainer.css
+++ b/apps/desktop/src/components/ToastContainer.css
@@ -68,7 +68,10 @@
   font-size: 14px;
   line-height: 1.5;
   color: var(--text-primary);
-  word-wrap: break-word;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  max-height: 120px;
+  overflow-y: auto;
 }
 
 .toast-close {

--- a/apps/desktop/src/pages/Namespaces.css
+++ b/apps/desktop/src/pages/Namespaces.css
@@ -181,8 +181,17 @@
 .ns-modal-actions {
   display: flex;
   justify-content: flex-end;
+  align-items: center;
   gap: 8px;
   margin-top: 4px;
+  flex-wrap: nowrap;
+}
+
+.ns-modal-actions .ns-action-btn {
+  margin-left: 0;
+  flex-shrink: 0;
+  min-width: 120px;
+  justify-content: center;
 }
 
 .ns-modal-cancel {
@@ -195,6 +204,8 @@
   font-weight: 500;
   cursor: pointer;
   transition: all 0.15s;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .ns-modal-cancel:hover:not(:disabled) {

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -30,14 +30,33 @@ import "./Namespaces.css";
 
 function parseApiError(e: any): string {
   if (!e) return 'Unknown error';
-  const msg: string = e?.message ?? String(e);
-  try { const p = JSON.parse(msg); if (p?.error) return String(p.error); } catch {}
-  if (e?.body?.error) return String(e.body.error);
-  if (typeof e?.bodyText === 'string') {
-    try { const p = JSON.parse(e.bodyText); if (p?.error) return String(p.error); } catch {}
-    return e.bodyText;
+  const status = e?.status ? `${e.status}: ` : '';
+
+  // SDK HTTPError — bodyText is the raw response body
+  if (typeof e?.bodyText === 'string' && e.bodyText) {
+    try {
+      const p = JSON.parse(e.bodyText);
+      const human = p?.error ?? p?.message ?? p?.msg ?? p?.detail ?? p?.details ?? p?.reason;
+      if (human) return `${status}${String(human)}`;
+      // Whole body is JSON but no known field — compact it, cap at 200 chars
+      const compact = JSON.stringify(p);
+      return `${status}${compact.length > 200 ? compact.slice(0, 200) + '…' : compact}`;
+    } catch {
+      const t = e.bodyText.trim();
+      return `${status}${t.length > 200 ? t.slice(0, 200) + '…' : t}`;
+    }
   }
-  return msg;
+
+  // Plain JS Error whose message happens to be JSON
+  const msg: string = e?.message ?? String(e);
+  try {
+    const p = JSON.parse(msg);
+    const human = p?.error ?? p?.message ?? p?.msg;
+    if (human) return `${status}${String(human)}`;
+  } catch {}
+
+  if (e?.body?.error) return `${status}${String(e.body.error)}`;
+  return `${status}${msg}`;
 }
 
 const DEFAULT_NAMESPACE_CAPABILITIES = 1 | 2 | 8;
@@ -319,8 +338,10 @@ export default function Namespaces() {
     if (!mero) return;
     setActionLoading(true);
     try {
-      const invitation = JSON.parse(atob(invitationText));
-      await (mero.admin as any).joinNamespace(invitation);
+      const decoded = JSON.parse(atob(invitationText.trim()));
+      const namespaceId = (decoded.invitation.invitation.group_id as number[])
+        .map((b: number) => b.toString(16).padStart(2, '0')).join('');
+      await mero.admin.joinNamespace(namespaceId, decoded);
       toast.success('Joined namespace');
       setJoinNsModal(false);
       await refetchNamespaces();
@@ -331,11 +352,12 @@ export default function Namespaces() {
     }
   };
 
-  const handleJoinContext = async (contextId: string, refetch: () => void) => {
+  const handleJoinContext = async (invitationText: string, refetch: () => void) => {
     if (!mero) return;
     setActionLoading(true);
     try {
-      await (mero.admin as any).joinContext(contextId.trim());
+      const decoded = JSON.parse(atob(invitationText.trim()));
+      await mero.admin.joinGroup(decoded);
       toast.success('Joined context');
       setJoinCtxModal(null);
       refetch();
@@ -1277,7 +1299,7 @@ function JoinNamespaceModal({ loading, onClose, onSubmit }: JoinNamespaceModalPr
           </label>
           <div className="ns-modal-actions">
             <button type="button" className="ns-modal-cancel" onClick={onClose} disabled={loading}>Cancel</button>
-            <button type="submit" className="ns-action-btn" style={{ marginLeft: 0 }} disabled={loading || !payload.trim()}>
+            <button type="submit" className="ns-action-btn" disabled={loading || !payload.trim()}>
               {loading ? 'Joining...' : 'Join Namespace'}
             </button>
           </div>
@@ -1290,37 +1312,39 @@ function JoinNamespaceModal({ loading, onClose, onSubmit }: JoinNamespaceModalPr
 interface JoinContextModalProps {
   loading: boolean;
   onClose: () => void;
-  onSubmit: (contextId: string) => void;
+  onSubmit: (invitationText: string) => void;
 }
 
 function JoinContextModal({ loading, onClose, onSubmit }: JoinContextModalProps) {
-  const [contextId, setContextId] = useState('');
+  const [payload, setPayload] = useState('');
 
   return (
     <div className="ns-modal-backdrop" onClick={onClose}>
-      <div className="ns-modal" onClick={(e) => e.stopPropagation()} role="dialog">
+      <div className="ns-modal ns-modal-wide" onClick={(e) => e.stopPropagation()} role="dialog">
         <div className="ns-modal-header">
           <h2>Join Context</h2>
           <button className="ns-modal-close" onClick={onClose} aria-label="Close"><X size={16} /></button>
         </div>
         <form
           className="ns-modal-body"
-          onSubmit={(e) => { e.preventDefault(); if (!contextId.trim()) return; onSubmit(contextId.trim()); }}
+          onSubmit={(e) => { e.preventDefault(); if (!payload.trim()) return; onSubmit(payload.trim()); }}
         >
-          <p className="ns-modal-hint">Enter the ID of an existing context to join it.</p>
+          <p className="ns-modal-hint">Paste the invitation payload you received from a context admin.</p>
           <label className="ns-modal-field">
-            <span>Context ID</span>
-            <input
-              type="text"
-              value={contextId}
-              onChange={(e) => setContextId(e.target.value)}
-              placeholder="e.g. a1b2c3d4e5f6..."
+            <span>Invitation Payload</span>
+            <textarea
+              className="ns-invite-payload"
+              value={payload}
+              onChange={(e) => setPayload(e.target.value)}
+              placeholder="Paste invitation payload here..."
+              rows={4}
+              spellCheck={false}
               autoFocus
             />
           </label>
           <div className="ns-modal-actions">
             <button type="button" className="ns-modal-cancel" onClick={onClose} disabled={loading}>Cancel</button>
-            <button type="submit" className="ns-action-btn" style={{ marginLeft: 0 }} disabled={loading || !contextId.trim()}>
+            <button type="submit" className="ns-action-btn" disabled={loading || !payload.trim()}>
               {loading ? 'Joining...' : 'Join Context'}
             </button>
           </div>

--- a/apps/desktop/src/pages/Settings.tsx
+++ b/apps/desktop/src/pages/Settings.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { getSettings, saveSettings, clearAllAppData } from "../utils/settings";
 import { parseTauriError } from "../utils/appUtils";
 import { invoke } from "@tauri-apps/api/tauri";
-import { killAllMerodProcesses, deleteCalimeroDataDir, stopMerod } from "../utils/merod";
+import { killAllMerodProcesses, deleteCalimeroDataDir, stopMerod, getMerodStatus } from "../utils/merod";
 import { startCloudLogin, disconnectCloud } from "../utils/cloudAuth";
 import { getCloudSubscription, CloudSessionExpiredError } from "../utils/cloudApi";
 import { isCloudEnabled } from "../utils/featureFlags";
@@ -37,6 +37,7 @@ export default function Settings({ onBack }: SettingsProps) {
   const [showNukeConfirm, setShowNukeConfirm] = useState(false);
   const [nukeConfirmed, setNukeConfirmed] = useState(false);
   const [nuking, setNuking] = useState(false);
+  const [nukeStatus, setNukeStatus] = useState('');
   const [startAtLogin, setStartAtLogin] = useState(false);
   const [startAtLoginLoading, setStartAtLoginLoading] = useState(true);
   const [startAtLoginAvailable, setStartAtLoginAvailable] = useState(true);
@@ -378,15 +379,44 @@ export default function Settings({ onBack }: SettingsProps) {
                         onClick={async () => {
                           if (!nukeConfirmed) return;
                           setNuking(true);
+
+                          // Step 1: graceful stop of the embedded node
+                          setNukeStatus('Stopping nodes...');
+                          try {
+                            await stopMerod();
+                          } catch {
+                            // not running — ok
+                          }
+
+                          // Step 2: force-kill any remaining merod processes
                           try {
                             await killAllMerodProcesses();
                           } catch (err: unknown) {
                             toast.error(parseTauriError(err));
                             setNuking(false);
+                            setNukeStatus('');
                             return;
                           }
-                          // Delete both the settings path and default ~/.calimero.
+
+                          // Step 3: wait until the embedded node reports stopped (max 10s)
+                          setNukeStatus('Waiting for nodes to stop...');
+                          const deadline = Date.now() + 10_000;
+                          while (Date.now() < deadline) {
+                            try {
+                              const status = await getMerodStatus();
+                              if (!status.running) break;
+                            } catch {
+                              break; // process gone — treat as stopped
+                            }
+                            await new Promise((r) => setTimeout(r, 500));
+                          }
+
+                          // Step 4: brief OS-level settle so file handles are released
+                          await new Promise((r) => setTimeout(r, 500));
+
+                          // Step 5: delete both the settings path and default ~/.calimero.
                           // After clearAllAppData(), onboarding uses ~/.calimero, so we must remove it.
+                          setNukeStatus('Deleting...');
                           const settingsDataDir = getSettings().embeddedNodeDataDir || "~/.calimero";
                           const defaultDataDir = "~/.calimero";
                           const dirsToDelete = [...new Set([settingsDataDir, defaultDataDir])];
@@ -397,15 +427,17 @@ export default function Settings({ onBack }: SettingsProps) {
                           } catch (err: unknown) {
                             toast.error(parseTauriError(err));
                             setNuking(false);
+                            setNukeStatus('');
                             return;
                           }
+
                           clearAllAppData();
                           window.location.reload();
                         }}
                         className="button button-danger"
                         disabled={!nukeConfirmed || nuking}
                       >
-                        {nuking ? 'Deleting...' : 'Delete everything and reset'}
+                        {nuking ? (nukeStatus || 'Deleting...') : 'Delete everything and reset'}
                       </button>
                     </div>
                   </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the namespace/context join flow to parse and submit invitation payloads differently, which could break joining if the payload format or SDK expectations differ. Also adjusts the destructive “total nuke” reset sequence to stop/kill nodes and wait before deleting data, reducing but not eliminating risk of edge-case failures on different OS/process states.
> 
> **Overview**
> Fixes **namespace/context joining** to use pasted invitation payloads end-to-end: decodes the base64 payload, derives the `namespaceId` from the embedded `group_id`, and calls the newer SDK join methods (`joinNamespace(namespaceId, decoded)` / `joinGroup(decoded)`), updating the Join Context modal UX from “ID input” to “invitation payload” text area.
> 
> Improves error and UX robustness: `parseApiError` now extracts human-friendly messages from JSON/SDK `bodyText` (with status prefix and truncation), toasts can wrap/scroll long messages, and modal action button layout is tightened to prevent wrapping.
> 
> Hardens **Settings → Total nuke** by adding a stepwise shutdown/delete sequence (graceful stop, kill processes, poll `getMerodStatus` up to 10s, brief settle delay) and showing progress text on the destructive button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca76128b997cbc1dbaf5ba5a6dc2659a1e92528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->