### PR TITLE
fix(proxy): bypass Tauri IPC for SSE — restore real-time events in app windows

### DIFF
--- a/apps/desktop/e2e/marketplace.spec.ts
+++ b/apps/desktop/e2e/marketplace.spec.ts
@@ -31,7 +31,7 @@ test.describe("Marketplace – browsing & searching", () => {
     page,
   }) => {
     await expect(page.locator('input[placeholder="Search applications..."]')).toBeVisible();
-    await expect(page.locator("select")).toBeVisible();
+    await expect(page.locator(".filter-pill").first()).toBeVisible();
   });
 
   test("displays apps fetched from registry", async ({ page }) => {
@@ -65,7 +65,7 @@ test.describe("Marketplace – browsing & searching", () => {
   });
 
   test("refresh button is present and clickable", async ({ page }) => {
-    const refreshBtn = page.locator('button[title="Refresh applications"]');
+    const refreshBtn = page.locator('.marketplace-filters button[title="Refresh"]');
     await expect(refreshBtn).toBeVisible();
     await refreshBtn.click();
   });
@@ -103,7 +103,7 @@ test.describe("Installed Applications – listing", () => {
     await setupAuthenticatedPage(page);
     await navigateVia(page, "Applications");
     await expect(
-      page.getByRole("heading", { name: "Installed Applications", level: 2 }),
+      page.locator(".installed-apps-header h1"),
     ).toBeVisible();
   });
 
@@ -158,7 +158,7 @@ test.describe("Installed Applications – empty state", () => {
 
     await navigateVia(page, "Applications");
     await expect(
-      page.getByRole("heading", { name: "Installed Applications", level: 2 }),
+      page.locator(".installed-apps-header h1"),
     ).toBeVisible();
     await expect(page.getByText("No applications installed.")).toBeVisible();
   });
@@ -175,13 +175,15 @@ describeAfter35("Installed Applications – row variants", () => {
     await setupAuthenticatedPage(page);
     await navigateVia(page, "Applications");
     await expect(
-      page.getByRole("heading", { name: "Installed Applications", level: 2 }),
+      page.locator(".installed-apps-header h1"),
     ).toBeVisible();
 
     const demoRow = page.locator("tr", { hasText: "Blockchain Demo" });
-    await expect(demoRow.getByRole("button", { name: "Uninstall" })).toBeVisible();
-    await expect(demoRow.getByRole("button", { name: "Open" })).toHaveCount(0);
-    await expect(demoRow.getByRole("button", { name: "Shortcut" })).toHaveCount(0);
+    // No frontend URL → no Open button directly in row
+    await expect(demoRow.locator('button.btn-open')).toHaveCount(0);
+    // Uninstall lives inside the More dropdown
+    await demoRow.locator('.btn-more').click();
+    await expect(page.locator('.app-actions-dropdown .dropdown-item', { hasText: "Uninstall" })).toBeVisible();
   });
 });
 
@@ -192,7 +194,7 @@ describeAfter35("Installed Applications – actions", () => {
     await setupAuthenticatedPage(page);
     await navigateVia(page, "Applications");
     await expect(
-      page.getByRole("heading", { name: "Installed Applications", level: 2 }),
+      page.locator(".installed-apps-header h1"),
     ).toBeVisible();
   });
 
@@ -204,24 +206,27 @@ describeAfter35("Installed Applications – actions", () => {
     await expect(openBtn).toBeVisible();
   });
 
-  test("Shortcut button is visible for apps with frontend URLs", async ({
+  test("dropdown menu has Uninstall for apps with frontend URLs", async ({
     page,
   }) => {
     const chatRow = page.locator("tr", { hasText: "Only Peers Chat" });
-    const shortcutBtn = chatRow.locator('button:has-text("Shortcut")');
-    await expect(shortcutBtn).toBeVisible();
+    await chatRow.locator('.btn-more').click();
+    await expect(page.locator('.app-actions-dropdown .dropdown-item', { hasText: "Uninstall" })).toBeVisible();
   });
 
-  test("Uninstall button is visible for all installed apps", async ({
+  test("Uninstall is in dropdown for all installed apps", async ({
     page,
   }) => {
     for (const app of MOCK_INSTALLED_APPS) {
       const meta = JSON.parse(atob(app.metadata));
       const displayName = meta.name || app.name;
       const row = page.locator("tr", { hasText: displayName });
+      await row.locator('.btn-more').click();
       await expect(
-        row.locator('button:has-text("Uninstall")'),
+        page.locator('.app-actions-dropdown .dropdown-item', { hasText: "Uninstall" }),
       ).toBeVisible();
+      // close dropdown before next iteration
+      await page.locator('.installed-apps-header').click();
     }
   });
 });
@@ -242,7 +247,7 @@ describeAfter35("Marketplace ↔ Applications navigation", () => {
 
     await navigateVia(page, "Applications");
     await expect(
-      page.getByRole("heading", { name: "Installed Applications", level: 2 }),
+      page.locator(".installed-apps-header h1"),
     ).toBeVisible();
 
     await navigateVia(page, "Marketplace");

--- a/apps/desktop/e2e/namespaces.spec.ts
+++ b/apps/desktop/e2e/namespaces.spec.ts
@@ -45,7 +45,7 @@ test.describe("Namespaces – page rendering", () => {
 
   test("renders the Namespaces heading inside the page", async ({ page }) => {
     await expect(
-      page.locator(".ns-header h1"),
+      page.locator(".ns-page-top h1"),
     ).toHaveText("Namespaces");
   });
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.39",
+  "version": "0.0.38",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -479,6 +479,7 @@ version = "0.1.0"
 dependencies = [
  "dirs 5.0.1",
  "env_logger",
+ "futures-util",
  "keyring",
  "log",
  "regex",
@@ -4420,7 +4421,19 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -11,12 +11,13 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.5", features = [ "http-all", "system-tray", "updater", "process-relaunch", "shell-open", "window-all", "dialog-all", "icon-png"] }
+tauri = { version = "1.5", features = [ "system-tray", "updater", "process-relaunch", "shell-open", "window-all", "dialog-all", "icon-png"] }
 tauri-plugin-autostart = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1", features = ["time", "process", "fs", "io-util"] }
-reqwest = { version = "0.11", features = ["json"] }
+tokio = { version = "1", features = ["time", "process", "fs", "io-util", "sync", "macros", "rt"] }
+reqwest = { version = "0.11", features = ["json", "stream"] }
+futures-util = "0.3"
 url = "2.5"
 log = "0.4"
 env_logger = "0.11"

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -437,6 +437,88 @@ async fn proxy_http_request_inner(request: HttpRequest, configured_node_url: Opt
     })
 }
 
+// Registry of active SSE streams, keyed by stream_id, for cancellation support.
+type SseCancelRegistry = std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, tokio::sync::oneshot::Sender<()>>>>;
+
+/// Open an SSE connection to `url` on the Rust side (bypasses mixed-content
+/// restrictions for HTTPS-hosted app windows) and relay each chunk back to the
+/// JS layer as a `sse-chunk-{stream_id}` window event.  Fires `sse-end-{stream_id}`
+/// when the stream closes or errors.  Designed to be fire-and-forget from JS
+/// (do not await the return value for data — use the window events).
+#[tauri::command]
+async fn proxy_sse_stream(
+    window: tauri::Window,
+    url: String,
+    auth_header: String,
+    stream_id: String,
+    cancel_registry: tauri::State<'_, SseCancelRegistry>,
+) -> Result<(), TauriError> {
+    use futures_util::StreamExt;
+
+    let (cancel_tx, mut cancel_rx) = tokio::sync::oneshot::channel::<()>();
+    {
+        let mut registry = cancel_registry.lock().unwrap_or_else(|p| p.into_inner());
+        registry.insert(stream_id.clone(), cancel_tx);
+    }
+
+    let chunk_event = format!("sse-chunk-{}", stream_id);
+    let end_event   = format!("sse-end-{}", stream_id);
+
+    let client = http_client();
+    let result = client
+        .get(&url)
+        .header("Authorization", &auth_header)
+        .header("Accept", "text/event-stream")
+        .header("Cache-Control", "no-cache")
+        .send()
+        .await;
+
+    let response = match result {
+        Ok(r) => r,
+        Err(e) => {
+            cancel_registry.lock().unwrap_or_else(|p| p.into_inner()).remove(&stream_id);
+            let _ = window.emit(&end_event, "");
+            return Err(TauriError::with_details(
+                TauriErrorCode::HttpRequestFailed,
+                format!("SSE connection to {} failed", url),
+                e.to_string(),
+            ));
+        }
+    };
+
+    let mut stream = response.bytes_stream();
+    loop {
+        tokio::select! {
+            chunk = stream.next() => {
+                match chunk {
+                    Some(Ok(bytes)) => {
+                        let text = String::from_utf8_lossy(&bytes).to_string();
+                        if window.emit(&chunk_event, text).is_err() {
+                            break; // window closed
+                        }
+                    }
+                    Some(Err(_)) | None => break,
+                }
+            }
+            _ = &mut cancel_rx => break,
+        }
+    }
+
+    cancel_registry.lock().unwrap_or_else(|p| p.into_inner()).remove(&stream_id);
+    let _ = window.emit(&end_event, "");
+    Ok(())
+}
+
+/// Cancel a running SSE stream started by `proxy_sse_stream`.
+#[tauri::command]
+fn cancel_sse_stream(stream_id: String, cancel_registry: tauri::State<'_, SseCancelRegistry>) {
+    if let Ok(mut registry) = cancel_registry.lock() {
+        if let Some(sender) = registry.remove(&stream_id) {
+            let _ = sender.send(());
+        }
+    }
+}
+
 #[tauri::command]
 fn get_pending_open_app(state: tauri::State<'_, PendingOpenApp>) -> Option<(String, String)> {
     state.0.lock().ok().and_then(|g| g.clone())
@@ -2193,6 +2275,7 @@ fn main() {
             Ok(())
         })
         .manage(MerodState::default())
+        .manage(SseCancelRegistry::new(std::sync::Mutex::new(std::collections::HashMap::new())))
         .invoke_handler(tauri::generate_handler![
             get_pending_open_app,
             clear_pending_open_app,
@@ -2202,6 +2285,8 @@ fn main() {
             create_app_window,
             open_devtools,
             proxy_http_request,
+            proxy_sse_stream,
+            cancel_sse_stream,
             start_merod,
             stop_merod,
             stop_merod_by_pid_command,

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -2412,4 +2412,128 @@ mod tests {
         assert!(validate_allowed_url("http://user@localhost:2528/", None).is_err());
         assert!(validate_allowed_url("http://localhost:2528@evil.com/", None).is_err());
     }
+
+    // SSE streaming tests — spin up a real TCP listener and drive reqwest's
+    // bytes_stream() + tokio::select! cancellation, verifying the mechanism
+    // used by proxy_sse_stream without needing a live tauri::Window.
+
+    #[tokio::test]
+    async fn test_sse_stream_delivers_chunks() {
+        use futures_util::StreamExt;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            // drain request headers
+            let mut buf = vec![0u8; 4096];
+            let mut total = Vec::new();
+            loop {
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                if n == 0 { break; }
+                total.extend_from_slice(&buf[..n]);
+                if total.windows(4).any(|w| w == b"\r\n\r\n") { break; }
+            }
+            // send SSE headers + two chunked events + terminal chunk
+            sock.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n"
+            ).await.unwrap();
+            for event in &["data: hello\n\n", "data: world\n\n"] {
+                let frame = format!("{:x}\r\n{}\r\n", event.len(), event);
+                sock.write_all(frame.as_bytes()).await.unwrap();
+            }
+            sock.write_all(b"0\r\n\r\n").await.unwrap();
+        });
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!("http://127.0.0.1:{port}/sse"))
+            .header("Accept", "text/event-stream")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let mut body = String::new();
+        let mut stream = resp.bytes_stream();
+        while let Some(Ok(chunk)) = stream.next().await {
+            body.push_str(&String::from_utf8_lossy(&chunk));
+        }
+
+        assert!(body.contains("data: hello"), "unexpected body: {body:?}");
+        assert!(body.contains("data: world"), "unexpected body: {body:?}");
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_stops_on_cancel() {
+        use futures_util::StreamExt;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+        use tokio::sync::oneshot;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // Server sends one chunk then stalls (infinite stream)
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 4096];
+            let mut total = Vec::new();
+            loop {
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                if n == 0 { break; }
+                total.extend_from_slice(&buf[..n]);
+                if total.windows(4).any(|w| w == b"\r\n\r\n") { break; }
+            }
+            sock.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n"
+            ).await.unwrap();
+            let event = "data: first\n\n";
+            let frame = format!("{:x}\r\n{}\r\n", event.len(), event);
+            sock.write_all(frame.as_bytes()).await.unwrap();
+            sock.flush().await.unwrap();
+            // stall until the test drops the connection
+            tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+        });
+
+        let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
+        let mut cancel_tx_opt = Some(cancel_tx);
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .unwrap();
+        let resp = client
+            .get(format!("http://127.0.0.1:{port}/sse"))
+            .header("Accept", "text/event-stream")
+            .send()
+            .await
+            .unwrap();
+
+        let mut received: Vec<String> = Vec::new();
+        let mut stream = resp.bytes_stream();
+        loop {
+            tokio::select! {
+                chunk = stream.next() => {
+                    match chunk {
+                        Some(Ok(bytes)) => {
+                            received.push(String::from_utf8_lossy(&bytes).into_owned());
+                            if let Some(tx) = cancel_tx_opt.take() {
+                                let _ = tx.send(());
+                            }
+                        }
+                        Some(Err(_)) | None => break,
+                    }
+                }
+                _ = &mut cancel_rx => break,
+            }
+        }
+
+        assert!(!received.is_empty(), "expected at least one chunk before cancel");
+        let body = received.concat();
+        assert!(body.contains("data: first"), "unexpected: {body:?}");
+    }
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ use std::sync::OnceLock;
 use thiserror::Error;
 
 static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+static SSE_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
 fn http_client() -> &'static reqwest::Client {
     HTTP_CLIENT.get_or_init(|| {
@@ -17,6 +18,17 @@ fn http_client() -> &'static reqwest::Client {
             .timeout(std::time::Duration::from_secs(30))
             .build()
             .expect("Failed to build HTTP client")
+    })
+}
+
+// SSE streams are long-lived; no request timeout is set so the connection
+// is only closed when the server ends the stream or the stream is cancelled.
+fn sse_client() -> &'static reqwest::Client {
+    SSE_CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .danger_accept_invalid_certs(false)
+            .build()
+            .expect("Failed to build SSE HTTP client")
     })
 }
 
@@ -464,14 +476,20 @@ async fn proxy_sse_stream(
     let chunk_event = format!("sse-chunk-{}", stream_id);
     let end_event   = format!("sse-end-{}", stream_id);
 
-    let client = http_client();
-    let result = client
+    if let Err(reason) = validate_allowed_url(&url, None) {
+        cancel_registry.lock().unwrap_or_else(|p| p.into_inner()).remove(&stream_id);
+        let _ = window.emit(&end_event, "");
+        return Err(TauriError::new(TauriErrorCode::UrlNotAllowed, reason));
+    }
+
+    let mut request = sse_client()
         .get(&url)
-        .header("Authorization", &auth_header)
         .header("Accept", "text/event-stream")
-        .header("Cache-Control", "no-cache")
-        .send()
-        .await;
+        .header("Cache-Control", "no-cache");
+    if !auth_header.is_empty() {
+        request = request.header("Authorization", &auth_header);
+    }
+    let result = request.send().await;
 
     let response = match result {
         Ok(r) => r,

--- a/apps/desktop/src-tauri/src/proxy_script.js
+++ b/apps/desktop/src-tauri/src/proxy_script.js
@@ -55,14 +55,38 @@
     // Intercept fetch API IMMEDIATELY - React makes calls during initialization
     window.fetch = async function(url, init) {
         const urlStr = typeof url === 'string' ? url : (url instanceof URL ? url.href : url.toString());
-        
+
         // Debug: log all fetch calls to see what's happening
         console.log('[Tauri Proxy] Fetch called:', urlStr);
-        
+
         // Proxy any HTTP localhost request (any port) to avoid mixed content blocking.
         // The Rust backend validates the URL before proxying.
         const shouldProxy = isHttpLocalhost(urlStr);
         console.log('[Tauri Proxy] Should proxy?', shouldProxy, 'for URL:', urlStr);
+
+        // Never proxy streaming (SSE) requests. The Tauri IPC proxy calls
+        // response.text() on the Rust side which buffers the entire body —
+        // for a never-ending SSE stream this hangs forever, so SseClient
+        // never receives the connect message, session_id stays null, and no
+        // subscriptions reach the server.
+        // App windows are served from http://, not tauri://, so the original
+        // fetch can reach http://localhost:* directly with no mixed-content block.
+        if (shouldProxy && init) {
+            var acceptHeader = '';
+            if (init.headers instanceof Headers) {
+                acceptHeader = init.headers.get('Accept') || init.headers.get('accept') || '';
+            } else if (Array.isArray(init.headers)) {
+                var found = init.headers.find(function(h) { return h[0].toLowerCase() === 'accept'; });
+                if (found) acceptHeader = found[1];
+            } else if (init.headers && typeof init.headers === 'object') {
+                acceptHeader = init.headers['Accept'] || init.headers['accept'] || '';
+            }
+            if (acceptHeader === 'text/event-stream') {
+                console.log('[Tauri Proxy] SSE request — bypassing proxy for streaming:', urlStr);
+                return originalFetch.apply(this, arguments);
+            }
+        }
+
         if (shouldProxy) {
             // Reject immediately if signal is already aborted
             if (init && init.signal && init.signal.aborted) {

--- a/apps/desktop/src-tauri/src/proxy_script.js
+++ b/apps/desktop/src-tauri/src/proxy_script.js
@@ -63,21 +63,45 @@
         return null;
     }
 
+    // Low-level Tauri event listener that works with just window.__TAURI_INVOKE__
+    // (always injected natively) without needing window.__TAURI__.event (which
+    // requires the @tauri-apps/api JS bundle to be loaded by the page — Vercel
+    // hosted apps don't load it, so window.__TAURI__ is undefined there).
+    //
+    // Mirrors what @tauri-apps/api/event does internally:
+    //   1. Register a callback on window['_<id>'] — Tauri calls it when the event fires.
+    //   2. Tell the Tauri runtime to route the named event to that callback id.
+    async function tauriListen(eventName, handler, invokeFn) {
+        // Happy-path: @tauri-apps/api is loaded (e.g. localhost dev or app with bundled API).
+        if (window.__TAURI__ && window.__TAURI__.event && typeof window.__TAURI__.event.listen === 'function') {
+            return window.__TAURI__.event.listen(eventName, handler);
+        }
+        // Fallback: use __TAURI_INVOKE__ directly.
+        const id = Math.random() * 2147483647 | 0;
+        const prop = '_' + id;
+        Object.defineProperty(window, prop, {
+            value: handler,
+            writable: false,
+            configurable: true,
+        });
+        await invokeFn('tauri', {
+            __tauriModule: 'Event',
+            message: { cmd: 'listen', event: eventName, windowLabel: null, handler: id },
+        });
+        return function unlisten() {
+            Reflect.deleteProperty(window, prop);
+            invokeFn('tauri', {
+                __tauriModule: 'Event',
+                message: { cmd: 'unlisten', event: eventName, eventId: id },
+            }).catch(() => {});
+        };
+    }
+
     // Proxy an SSE request through Tauri IPC so it works even from HTTPS-hosted
     // app windows (where native fetch → http://localhost would be blocked by
     // mixed-content rules).  The Rust side streams chunks back as window events;
     // we expose them as a ReadableStream so SseClient.readStream() needs no changes.
     async function proxySSEViaTauri(url, authHeader, signal, invokeFn) {
-        const tauriEvent = window.__TAURI__ && window.__TAURI__.event;
-        if (!tauriEvent) {
-            // Tauri event API not available — fall back to direct fetch (HTTP windows only)
-            console.warn('[Tauri Proxy] SSE: Tauri event API unavailable, falling back to originalFetch');
-            return originalFetch(url, {
-                headers: { 'Authorization': authHeader, 'Accept': 'text/event-stream' },
-                signal,
-            });
-        }
-
         const streamId = 'sse-' + Date.now() + '-' + Math.random().toString(36).slice(2, 9);
         const encoder = new TextEncoder();
         let streamController = null;
@@ -96,22 +120,21 @@
         // Register listeners BEFORE invoking so we never miss the first chunk
         try {
             [unlistenChunk, unlistenEnd] = await Promise.all([
-                tauriEvent.listen('sse-chunk-' + streamId, (event) => {
+                tauriListen('sse-chunk-' + streamId, (event) => {
                     if (event.payload && streamController) {
                         try { streamController.enqueue(encoder.encode(event.payload)); } catch (_) {}
                     }
-                }),
-                tauriEvent.listen('sse-end-' + streamId, () => {
+                }, invokeFn),
+                tauriListen('sse-end-' + streamId, () => {
                     try { if (streamController) streamController.close(); } catch (_) {}
                     cleanup();
-                }),
+                }, invokeFn),
             ]);
         } catch (err) {
-            console.warn('[Tauri Proxy] SSE: event.listen failed, falling back to originalFetch', err);
-            return originalFetch(url, {
-                headers: { 'Authorization': authHeader, 'Accept': 'text/event-stream' },
-                signal,
-            });
+            console.warn('[Tauri Proxy] SSE: event listen failed:', err);
+            try { if (streamController) streamController.error(new Error('SSE listen setup failed: ' + err)); } catch (_) {}
+            cleanup();
+            return new Response(new ReadableStream({ start(c) { c.error(new Error('SSE unavailable')); } }), { status: 503 });
         }
 
         // Wire up AbortSignal → cancel_sse_stream

--- a/apps/desktop/src-tauri/src/proxy_script.js
+++ b/apps/desktop/src-tauri/src/proxy_script.js
@@ -1,7 +1,7 @@
 (function() {
     if (window.__TAURI_FETCH_PROXY_INJECTED__) return;
     window.__TAURI_FETCH_PROXY_INJECTED__ = true;
-    
+
     // Get configured node URL (injected by Rust backend)
     // This is replaced at runtime by Rust when creating the window
     const configuredNodeUrl = '__CONFIGURED_NODE_URL__';
@@ -11,30 +11,146 @@
     console.log('[Tauri Proxy] Configured node URL for interception:', nodeUrl);
 
     // Check if a URL is an HTTP localhost request that needs proxying
-    // Any http://localhost:* or http://127.0.0.1:* request from an HTTPS page
-    // will be blocked by mixed content rules, so we proxy all of them
     function isHttpLocalhost(urlStr) {
         try {
-            var u = new URL(urlStr);
+            const u = new URL(urlStr);
             return u.protocol === 'http:' && (u.hostname === 'localhost' || u.hostname === '127.0.0.1');
         } catch (e) {
             return false;
         }
     }
-    
-    // Helper function to proxy HTTP requests through Tauri
+
+    // Normalize the first fetch() argument: string | URL | Request → string URL
+    function normalizeUrl(urlArg) {
+        if (typeof urlArg === 'string') return urlArg;
+        if (urlArg instanceof URL) return urlArg.href;
+        if (typeof Request !== 'undefined' && urlArg instanceof Request) return urlArg.url;
+        return String(urlArg);
+    }
+
+    // Extract the Accept header value from a fetch init (or Request) headers bag.
+    // Returns '' when not present.
+    function getAcceptHeader(headers) {
+        if (!headers) return '';
+        // Headers object — .get() is case-insensitive per spec
+        if (headers instanceof Headers) return headers.get('accept') || '';
+        if (Array.isArray(headers)) {
+            const found = headers.find(h => h[0].toLowerCase() === 'accept');
+            return found ? found[1] : '';
+        }
+        if (typeof headers === 'object') return headers['Accept'] || headers['accept'] || '';
+        return '';
+    }
+
+    // Extract the Authorization header value from a headers bag.
+    function getAuthHeader(headers) {
+        if (!headers) return '';
+        if (headers instanceof Headers) return headers.get('authorization') || '';
+        if (Array.isArray(headers)) {
+            const found = headers.find(h => h[0].toLowerCase() === 'authorization');
+            return found ? found[1] : '';
+        }
+        if (typeof headers === 'object') return headers['Authorization'] || headers['authorization'] || '';
+        return '';
+    }
+
+    // Get the Tauri invoke function (resolves both API shapes)
+    function getTauriInvoke() {
+        if (typeof window.__TAURI_INVOKE__ === 'function') return window.__TAURI_INVOKE__;
+        if (typeof window.__TAURI__ !== 'undefined' && typeof window.__TAURI__.invoke === 'function') {
+            return window.__TAURI__.invoke.bind(window.__TAURI__);
+        }
+        return null;
+    }
+
+    // Proxy an SSE request through Tauri IPC so it works even from HTTPS-hosted
+    // app windows (where native fetch → http://localhost would be blocked by
+    // mixed-content rules).  The Rust side streams chunks back as window events;
+    // we expose them as a ReadableStream so SseClient.readStream() needs no changes.
+    async function proxySSEViaTauri(url, authHeader, signal, invokeFn) {
+        const tauriEvent = window.__TAURI__ && window.__TAURI__.event;
+        if (!tauriEvent) {
+            // Tauri event API not available — fall back to direct fetch (HTTP windows only)
+            console.warn('[Tauri Proxy] SSE: Tauri event API unavailable, falling back to originalFetch');
+            return originalFetch(url, {
+                headers: { 'Authorization': authHeader, 'Accept': 'text/event-stream' },
+                signal,
+            });
+        }
+
+        const streamId = 'sse-' + Date.now() + '-' + Math.random().toString(36).slice(2, 9);
+        const encoder = new TextEncoder();
+        let streamController = null;
+        let unlistenChunk = null;
+        let unlistenEnd = null;
+
+        const readableStream = new ReadableStream({
+            start(c) { streamController = c; },
+        });
+
+        function cleanup() {
+            if (unlistenChunk) { unlistenChunk(); unlistenChunk = null; }
+            if (unlistenEnd)   { unlistenEnd();   unlistenEnd   = null; }
+        }
+
+        // Register listeners BEFORE invoking so we never miss the first chunk
+        try {
+            [unlistenChunk, unlistenEnd] = await Promise.all([
+                tauriEvent.listen('sse-chunk-' + streamId, (event) => {
+                    if (event.payload && streamController) {
+                        try { streamController.enqueue(encoder.encode(event.payload)); } catch (_) {}
+                    }
+                }),
+                tauriEvent.listen('sse-end-' + streamId, () => {
+                    try { if (streamController) streamController.close(); } catch (_) {}
+                    cleanup();
+                }),
+            ]);
+        } catch (err) {
+            console.warn('[Tauri Proxy] SSE: event.listen failed, falling back to originalFetch', err);
+            return originalFetch(url, {
+                headers: { 'Authorization': authHeader, 'Accept': 'text/event-stream' },
+                signal,
+            });
+        }
+
+        // Wire up AbortSignal → cancel_sse_stream
+        if (signal) {
+            const onAbort = () => {
+                invokeFn('cancel_sse_stream', { streamId }).catch(() => {});
+                try { if (streamController) streamController.error(new DOMException('Aborted', 'AbortError')); } catch (_) {}
+                cleanup();
+            };
+            if (signal.aborted) {
+                onAbort();
+            } else {
+                signal.addEventListener('abort', onAbort, { once: true });
+            }
+        }
+
+        // Fire-and-forget the Rust streaming command
+        invokeFn('proxy_sse_stream', { url, authHeader, streamId }).catch((err) => {
+            console.error('[Tauri Proxy] SSE proxy_sse_stream error:', err);
+            try { if (streamController) streamController.error(new Error('SSE proxy error: ' + err)); } catch (_) {}
+            cleanup();
+        });
+
+        console.log('[Tauri Proxy] SSE stream started via Tauri IPC, stream_id:', streamId);
+        return new Response(readableStream, {
+            status: 200,
+            statusText: 'OK',
+            headers: new Headers({ 'content-type': 'text/event-stream', 'cache-control': 'no-cache' }),
+        });
+    }
+
+    // Helper function to proxy regular HTTP requests through Tauri
     async function proxyRequest(url, method, headers, body) {
-        // Get Tauri invoke function - check at call time, not script load time
-        let invokeFn = null;
-        if (typeof window.__TAURI_INVOKE__ === 'function') {
-            invokeFn = window.__TAURI_INVOKE__;
-        } else if (typeof window.__TAURI__ !== 'undefined' && typeof window.__TAURI__.invoke === 'function') {
-            invokeFn = window.__TAURI__.invoke.bind(window.__TAURI__);
-        } else {
+        const invokeFn = getTauriInvoke();
+        if (!invokeFn) {
             console.error('[Tauri Proxy] Tauri invoke API not available!');
             throw new Error('Tauri invoke API not available');
         }
-        
+
         console.log('[Tauri Proxy] Calling Tauri proxy with headers:', Object.keys(headers || {}));
         const response = await invokeFn('proxy_http_request', {
             request: {
@@ -45,18 +161,25 @@
             },
             configured_node_url: nodeUrl
         });
-        
+
         return response;
     }
-    
+
     // Store original fetch IMMEDIATELY before React loads
     const originalFetch = window.fetch.bind(window);
-    
-    // Intercept fetch API IMMEDIATELY - React makes calls during initialization
-    window.fetch = async function(url, init) {
-        const urlStr = typeof url === 'string' ? url : (url instanceof URL ? url.href : url.toString());
 
-        // Debug: log all fetch calls to see what's happening
+    // Intercept fetch API IMMEDIATELY - React makes calls during initialization
+    window.fetch = async function(urlArg, init) {
+        // Normalise url — could be a string, URL object, or Request object
+        const urlStr = normalizeUrl(urlArg);
+
+        // When fetch() receives a Request object as the sole argument, pull its
+        // headers so the SSE / proxy logic can inspect them without init
+        const effectiveHeaders = (init && init.headers)
+            || (typeof Request !== 'undefined' && urlArg instanceof Request ? urlArg.headers : null);
+        const effectiveSignal = (init && init.signal)
+            || (typeof Request !== 'undefined' && urlArg instanceof Request ? urlArg.signal : null);
+
         console.log('[Tauri Proxy] Fetch called:', urlStr);
 
         // Proxy any HTTP localhost request (any port) to avoid mixed content blocking.
@@ -64,32 +187,31 @@
         const shouldProxy = isHttpLocalhost(urlStr);
         console.log('[Tauri Proxy] Should proxy?', shouldProxy, 'for URL:', urlStr);
 
-        // Never proxy streaming (SSE) requests. The Tauri IPC proxy calls
-        // response.text() on the Rust side which buffers the entire body —
-        // for a never-ending SSE stream this hangs forever, so SseClient
-        // never receives the connect message, session_id stays null, and no
-        // subscriptions reach the server.
-        // App windows are served from http://, not tauri://, so the original
-        // fetch can reach http://localhost:* directly with no mixed-content block.
-        if (shouldProxy && init) {
-            var acceptHeader = '';
-            if (init.headers instanceof Headers) {
-                acceptHeader = init.headers.get('Accept') || init.headers.get('accept') || '';
-            } else if (Array.isArray(init.headers)) {
-                var found = init.headers.find(function(h) { return h[0].toLowerCase() === 'accept'; });
-                if (found) acceptHeader = found[1];
-            } else if (init.headers && typeof init.headers === 'object') {
-                acceptHeader = init.headers['Accept'] || init.headers['accept'] || '';
-            }
-            if (acceptHeader === 'text/event-stream') {
-                console.log('[Tauri Proxy] SSE request — bypassing proxy for streaming:', urlStr);
+        if (shouldProxy) {
+            // Route SSE requests through the Tauri streaming command so they work
+            // even from HTTPS-hosted app windows (e.g. Vercel frontends).
+            // Strict proxy buffering (response.text()) would hang an SSE stream,
+            // and a plain originalFetch() call fails with mixed-content when the
+            // app window is served over HTTPS.
+            const acceptHeader = getAcceptHeader(effectiveHeaders);
+            if (acceptHeader.includes('text/event-stream')) {
+                const invokeFn = getTauriInvoke();
+                if (invokeFn) {
+                    console.log('[Tauri Proxy] SSE request — routing via Tauri IPC streaming:', urlStr);
+                    return proxySSEViaTauri(
+                        urlStr,
+                        getAuthHeader(effectiveHeaders),
+                        effectiveSignal,
+                        invokeFn,
+                    );
+                }
+                // No Tauri IPC (shouldn't happen in app windows) — fall through to originalFetch
+                console.warn('[Tauri Proxy] SSE: no Tauri IPC, falling back to originalFetch for:', urlStr);
                 return originalFetch.apply(this, arguments);
             }
-        }
 
-        if (shouldProxy) {
             // Reject immediately if signal is already aborted
-            if (init && init.signal && init.signal.aborted) {
+            if (effectiveSignal && effectiveSignal.aborted) {
                 return Promise.reject(new DOMException('The operation was aborted.', 'AbortError'));
             }
 
@@ -97,13 +219,9 @@
                 const headers = {};
                 if (init && init.headers) {
                     if (init.headers instanceof Headers) {
-                        init.headers.forEach((value, key) => {
-                            headers[key] = value;
-                        });
+                        init.headers.forEach((value, key) => { headers[key] = value; });
                     } else if (Array.isArray(init.headers)) {
-                        init.headers.forEach(([key, value]) => {
-                            headers[key] = value;
-                        });
+                        init.headers.forEach(([key, value]) => { headers[key] = value; });
                     } else {
                         Object.assign(headers, init.headers);
                     }
@@ -127,17 +245,15 @@
                 const requestPromise = proxyRequest(urlStr, (init && init.method) || 'GET', headers, bodyStr);
 
                 let response;
-                if (init && init.signal) {
-                    // Race the request against the abort signal
+                if (effectiveSignal) {
                     const abortPromise = new Promise((_, reject) => {
                         const onAbort = () => {
-                            init.signal.removeEventListener('abort', onAbort);
+                            effectiveSignal.removeEventListener('abort', onAbort);
                             reject(new DOMException('The operation was aborted.', 'AbortError'));
                         };
-                        init.signal.addEventListener('abort', onAbort);
-                        // Clean up listener when request wins
-                        requestPromise.then(() => init.signal.removeEventListener('abort', onAbort))
-                                      .catch(() => init.signal.removeEventListener('abort', onAbort));
+                        effectiveSignal.addEventListener('abort', onAbort);
+                        requestPromise.then(() => effectiveSignal.removeEventListener('abort', onAbort))
+                                      .catch(() => effectiveSignal.removeEventListener('abort', onAbort));
                     });
                     response = await Promise.race([requestPromise, abortPromise]);
                 } else {
@@ -153,23 +269,19 @@
                 });
             } catch (error) {
                 console.error('[Tauri Proxy] Fetch proxy failed:', error, 'URL:', urlStr);
-                // In non-Tauri environments (tests, dev server), Tauri invoke isn't
-                // available — fall back so Playwright mocks and dev server still work.
                 const isTauri = typeof window.__TAURI_INVOKE__ === 'function' ||
                     (typeof window.__TAURI__ !== 'undefined' && typeof window.__TAURI__.invoke === 'function');
                 if (!isTauri) {
                     return originalFetch.apply(this, arguments);
                 }
-                // In Tauri, falling back always produces HTTP 0 (mixed content).
-                // Re-throw so the caller gets the real error.
                 throw error;
             }
         }
-        
+
         // For non-localhost requests, use original fetch
         return originalFetch.apply(this, arguments);
     };
-    
+
     // Also intercept XMLHttpRequest for libraries that use XHR instead of fetch
     const OriginalXHR = window.XMLHttpRequest;
     window.XMLHttpRequest = function() {
@@ -208,7 +320,7 @@
                         Object.defineProperty(xhr, 'response', { value: response.body || '', writable: false });
                         Object.defineProperty(xhr, 'readyState', { value: 4, writable: false });
 
-                        var headerStr = '';
+                        let headerStr = '';
                         if (response.headers) {
                             Object.keys(response.headers).forEach(function(key) {
                                 headerStr += key + ': ' + response.headers[key] + '\r\n';
@@ -255,7 +367,6 @@
     console.log('[Tauri Proxy] Fetch + XHR interceptors injected');
     console.log('[Tauri Proxy] Original fetch stored:', typeof originalFetch);
 
-    // Check Tauri API availability - it might not be ready immediately
     function checkTauriAPI() {
         if (typeof window.__TAURI_INVOKE__ === 'function') {
             console.log('[Tauri Proxy] Tauri invoke available: YES');
@@ -268,7 +379,6 @@
             return null;
         }
     }
-    
-    // Check immediately
+
     checkTauriAPI();
 })();

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.37"
+    "version": "0.0.38"
   },
   "tauri": {
     "allowlist": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.39"
+    "version": "0.0.38"
   },
   "tauri": {
     "allowlist": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.38"
+    "version": "0.0.39"
   },
   "tauri": {
     "allowlist": {

--- a/apps/desktop/src/utils/proxyScript.test.ts
+++ b/apps/desktop/src/utils/proxyScript.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Read the proxy script source once; tests replace the placeholder node URL.
+const RAW_PROXY_SCRIPT = readFileSync(
+  path.resolve(__dirname, "../../src-tauri/src/proxy_script.js"),
+  "utf-8"
+);
+
+/**
+ * Execute the proxy IIFE with a fake `window` object.
+ * Using `new Function('window', src)` means all `window.*` accesses inside
+ * the IIFE resolve to our mock; bare globals (URL, Headers, Response, …) are
+ * still resolved from the Node 18+ global scope.
+ */
+function injectProxy(mockWindow: any, nodeUrl = "http://localhost:2428") {
+  const src = RAW_PROXY_SCRIPT.replace("__CONFIGURED_NODE_URL__", nodeUrl);
+  new Function("window", src)(mockWindow);
+}
+
+function makeMockWindow() {
+  // Provide a minimal XMLHttpRequest stub so the script's XHR-wrapping code
+  // doesn't throw on init (we don't exercise XHR in these tests).
+  function FakeXHR() {}
+  FakeXHR.prototype = {};
+  return {
+    __TAURI_FETCH_PROXY_INJECTED__: undefined as boolean | undefined,
+    // Stored by the script as `originalFetch` — returned for non-proxied URLs.
+    fetch: vi.fn().mockResolvedValue(new Response("original", { status: 200 })),
+    XMLHttpRequest: FakeXHR,
+  } as any;
+}
+
+describe("proxy_script SSE routing", () => {
+  // Ensure each test gets a fresh injection (the script guards against
+  // double-injection via __TAURI_FETCH_PROXY_INJECTED__).
+  beforeEach(() => {});
+
+  it("routes SSE fetch through Tauri IPC and returns a ReadableStream Response", async () => {
+    const mockWindow = makeMockWindow();
+
+    // Capture event.listen callbacks by event name so we can fire them later.
+    const chunkCbs: Record<string, (e: { payload: string }) => void> = {};
+    const endCbs: Record<string, () => void> = {};
+    const invoked: Array<{ command: string; args: Record<string, unknown> }> =
+      [];
+
+    mockWindow.__TAURI__ = {
+      event: {
+        listen: vi.fn(async (eventName: string, cb: any) => {
+          if (eventName.startsWith("sse-chunk-")) chunkCbs[eventName] = cb;
+          if (eventName.startsWith("sse-end-")) endCbs[eventName] = cb;
+          return vi.fn(); // unlisten no-op
+        }),
+      },
+    };
+    // __TAURI_INVOKE__ is also checked by getTauriInvoke()
+    mockWindow.__TAURI_INVOKE__ = vi.fn(
+      async (command: string, args: Record<string, unknown>) => {
+        invoked.push({ command, args });
+        // Never settles — simulates an ongoing Rust SSE stream.
+        return new Promise<void>(() => {});
+      }
+    );
+
+    injectProxy(mockWindow);
+
+    // Kick off an SSE fetch; the interceptor must return before we read.
+    const response = await mockWindow.fetch(
+      "http://localhost:2428/admin-api/contexts/sse",
+      { headers: { Accept: "text/event-stream" } }
+    );
+
+    // --- structural assertions -----------------------------------------------
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+    expect(invoked.some((c) => c.command === "proxy_sse_stream")).toBe(true);
+
+    const chunkKey = Object.keys(chunkCbs)[0];
+    const endKey = Object.keys(endCbs)[0];
+    expect(chunkKey).toBeDefined();
+    expect(endKey).toBeDefined();
+
+    // The stream_id embedded in the event names must match.
+    expect(chunkKey.replace("sse-chunk-", "")).toBe(
+      endKey.replace("sse-end-", "")
+    );
+
+    // --- streaming assertions -------------------------------------------------
+    const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+    const decoder = new TextDecoder();
+
+    // Simulate Rust emitting two SSE chunks via window events.
+    chunkCbs[chunkKey]({ payload: "data: hello\n\n" });
+    chunkCbs[chunkKey]({ payload: "data: world\n\n" });
+
+    const chunk1 = await reader.read();
+    expect(chunk1.done).toBe(false);
+    expect(decoder.decode(chunk1.value, { stream: true })).toBe(
+      "data: hello\n\n"
+    );
+
+    const chunk2 = await reader.read();
+    expect(chunk2.done).toBe(false);
+    expect(decoder.decode(chunk2.value, { stream: true })).toBe(
+      "data: world\n\n"
+    );
+
+    // Simulate stream end — ReadableStream should close.
+    endCbs[endKey]();
+    const final = await reader.read();
+    expect(final.done).toBe(true);
+  });
+
+  it("does not invoke Tauri IPC for non-localhost requests", async () => {
+    const mockWindow = makeMockWindow();
+    mockWindow.__TAURI_INVOKE__ = vi.fn();
+    mockWindow.__TAURI__ = {
+      event: { listen: vi.fn(async () => vi.fn()) },
+    };
+
+    injectProxy(mockWindow);
+
+    // External HTTPS URL — must not go through the proxy.
+    await mockWindow.fetch("https://api.example.com/data", {});
+    expect(mockWindow.__TAURI_INVOKE__).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke Tauri IPC for non-SSE localhost requests", async () => {
+    const mockWindow = makeMockWindow();
+    const tauriInvoke = vi.fn().mockResolvedValue({
+      status: 200,
+      headers: {},
+      body: "{}",
+    });
+    mockWindow.__TAURI_INVOKE__ = tauriInvoke;
+    mockWindow.__TAURI__ = {
+      event: { listen: vi.fn(async () => vi.fn()) },
+    };
+
+    injectProxy(mockWindow);
+
+    // Plain JSON request to localhost — uses proxy_http_request, not proxy_sse_stream.
+    await mockWindow
+      .fetch("http://localhost:2428/admin-api/contexts", {
+        headers: { Accept: "application/json" },
+      })
+      .catch(() => {}); // may throw; we only care about which command was called
+
+    const sseCalls = tauriInvoke.mock.calls.filter(
+      ([cmd]: [string]) => cmd === "proxy_sse_stream"
+    );
+    expect(sseCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- **Root cause**: `proxy_script.js` intercepts ALL `fetch()` calls to `http://localhost:*` and routes them through `proxy_http_request` (Tauri IPC → Rust). The Rust handler calls `response.text().await` which buffers the full response. For SSE (`/sse` endpoint), the response never closes, so the Rust `await` hangs forever. `SseClient.connect()` never resolves, `sessionId` stays `null`, subscriptions never reach the server — all real-time events are silently dead.
- **Fix**: In the fetch interceptor, check for `Accept: text/event-stream` before proxying. If the header is present, fall through to `originalFetch`. App windows use `WindowUrl::External` (plain `http://`), so WKWebView can stream directly to `http://localhost:*` with no mixed-content block.
- **Version bump**: 0.0.37 → 0.0.38

## Test plan
- [ ] Open the desktop app and launch a curb (or any chat app) window
- [ ] Open a second curb window ("additional tab")
- [ ] Verify SSE events are received in both windows (new messages appear in real time)
- [ ] Regular API calls (REST) still work (they still go through the proxy)
- [ ] No regression on the main desktop window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Rust-side SSE streaming proxy and cancellation path and changes fetch interception logic, which affects network/I/O behavior in app windows. Risk is moderate due to long-lived connections and event-driven streaming/cancellation edge cases, but changes are scoped and covered by new unit tests.
> 
> **Overview**
> Restores real-time SSE behavior in desktop app windows by **adding a dedicated streaming path** instead of routing SSE through the buffered `proxy_http_request` IPC.
> 
> On the Rust side, introduces `proxy_sse_stream` (stream `bytes_stream()` chunks back as window events) plus `cancel_sse_stream` with a shared cancellation registry; updates Tauri deps/features (`reqwest` streaming, `tokio` runtime/macros, `futures-util`) and adds SSE-focused tests.
> 
> On the JS side, updates `proxy_script.js` fetch interception to detect `Accept: text/event-stream` and proxy SSE via the new streaming commands (with event listening fallback and AbortSignal cancellation), while keeping non-SSE localhost requests on the existing proxy. Also bumps the desktop version to `0.0.38` and updates Playwright selectors to match UI changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 549981465a7d614deff0675d0e8e65e4e887b1d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->