### PR TITLE
chore: bump merod binary to 0.10.1-rc.42

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.38"
+    "version": "0.0.39"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.10.1-rc.41"
+    "version": "0.10.1-rc.42"
 }


### PR DESCRIPTION
## Summary
- Updates `merod-config.json` from `0.10.1-rc.41` to `0.10.1-rc.42`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps version numbers for the desktop app/Tauri bundle and updates the pinned `merod` binary version, with no functional code changes shown.
> 
> **Overview**
> Bumps the Calimero Desktop app version from `0.0.38` to `0.0.39` in both `apps/desktop/package.json` and `src-tauri/tauri.conf.json`.
> 
> Updates `merod-config.json` to use the `merod` binary `0.10.1-rc.42` (from `0.10.1-rc.41`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2097e627471fc9cae517ccc334c76a8523ddefb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->