### PR TITLE
chore(cloud): remove deprecated per-context HA helpers (#119)

### DIFF
--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -153,56 +153,6 @@ export async function getFleetMeasurements(
   return res.json();
 }
 
-export interface EnableHaResponse {
-  status: string;
-  context_id: string;
-}
-
-/**
- * Enable HA for a context — requests TEE fleet nodes to join this
- * namespace/group. Requires a paid plan.
- */
-export async function enableHa(
-  idToken: string,
-  contextId: string,
-  groupId?: string,
-): Promise<EnableHaResponse | null> {
-  const res = await cloudFetch(
-    `/api/cloud/me/contexts/${encodeURIComponent(contextId)}/enable-ha`,
-    idToken,
-    {
-      method: 'POST',
-      body: JSON.stringify(groupId ? { group_id: groupId } : {}),
-    },
-  );
-  if (!res.ok) {
-    const error = await res.json().catch(() => null);
-    if (res.status === 402) {
-      throw new Error(error?.detail?.message || 'Plan limit reached — upgrade to enable HA');
-    }
-    throw new Error(error?.detail || 'Failed to enable HA');
-  }
-  return res.json();
-}
-
-/**
- * Disable HA for a context.
- */
-export async function disableHa(
-  idToken: string,
-  contextId: string,
-): Promise<void> {
-  const res = await cloudFetch(
-    `/api/cloud/me/contexts/${encodeURIComponent(contextId)}/disable-ha`,
-    idToken,
-    { method: 'POST' },
-  );
-  if (!res.ok) {
-    const error = await res.json().catch(() => null);
-    throw new Error(error?.detail || 'Failed to disable HA');
-  }
-}
-
 export interface NamespaceHaGroup {
   group_id: string;
   context_id: string;


### PR DESCRIPTION
## #119 cleanup — remove deprecated per-context HA from the desktop client

Removes the deprecated **per-context** HA helpers from `apps/desktop/src/utils/cloudApi.ts`:

- `enableHa(idToken, contextId, groupId?)` → `POST /api/cloud/me/contexts/{id}/enable-ha`
- `disableHa(idToken, contextId)` → `POST /api/cloud/me/contexts/{id}/disable-ha`
- `EnableHaResponse` (the type used only by `enableHa`)

These call mdma endpoints that are being removed in the **parallel mdma per-context-HA endpoint removal**. Namespace HA fully supersedes them and is verified end-to-end in prod.

### Why this is safe
- Grepped all of `apps/desktop/src` (pages, components, tests): the per-context `enableHa(` / `disableHa(` had **no callers** outside their own definitions. The Phase-4 work already moved every consumer to the namespace path.
- `EnableHaResponse` was referenced only by `enableHa`.

### Kept (untouched — the live path)
- `enableHaForNamespace` / `enableHaNamespace` / `disableHaNamespace` (namespace HA).
- `claimContexts` / `requestOwnershipProof` / `requestNamespaceOwnershipProof` (context registration / proofs).
- The `Namespaces.tsx` namespace-HA flow.
- `getCloudGroups` / `/groups` consumption (separate #119 step, not in this PR).

### Verification
- `pnpm tsc --noEmit` — no new errors (the 3 pre-existing `Namespaces.tsx` `GroupInfo` errors are unrelated and present on `master`).
- `pnpm test:unit` — green (37/37; 16 in `cloudApi.test.ts`, all targeting namespace HA / proofs / claims). No test cases targeted the removed per-context functions, so none were removed.

### Links
- mdma #119 (paired per-context-HA endpoint removal)
- `NAMESPACE_NATIVE_READMODEL_PLAN.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that deletes unused client-side wrappers and a type without changing the active namespace-HA code paths.
> 
> **Overview**
> Removes the deprecated per-context HA helpers from `cloudApi.ts` by deleting `enableHa`, `disableHa`, and the associated `EnableHaResponse` type that called `/api/cloud/me/contexts/{id}/enable-ha` and `/disable-ha`.
> 
> Namespace-based HA APIs (e.g. `enableHaNamespace` / `disableHaNamespace`) remain as the supported path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07dafb8ddea6301fce699ac99f32f1e68a921b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->