### PR TITLE
chore(cloud): #119 step 2a — migrate tauri getCloudGroups /groups -> /namespaces + fix GroupInfo tsc errors

### DIFF
--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -10,6 +10,7 @@ import {
   useCreateNamespace,
   type Namespace,
 } from "@calimero-network/mero-react";
+import type { GroupInfo } from "@calimero-network/mero-js";
 import { useToast } from "../contexts/ToastContext";
 import { ChevronLeft, Users, Box, Layers, Copy, ChevronRight, Shield, Globe, Plus, X, Play, Trash2, UserMinus, Link, ChevronDown, Check, MoreHorizontal, LogIn } from "lucide-react";
 import { apiClient } from "../lib/mero-client";
@@ -19,7 +20,7 @@ import { getSettings } from "../utils/settings";
 import {
   enableHaForNamespace,
   disableHaNamespace,
-  getCloudGroups,
+  getCloudNamespaces,
   CloudSessionExpiredError,
 } from "../utils/cloudApi";
 import { getCloudIdToken } from "../utils/cloudAuth";
@@ -93,6 +94,32 @@ type View =
   | { type: "namespace"; ns: Namespace }
   | { type: "group"; ns: Namespace; groupId: string };
 
+// The merod admin group-info response (core's GroupInfoApiResponseData,
+// crates/server/primitives/src/admin/mod.rs, #[serde(rename_all =
+// "camelCase")]) carries three camelCase fields the bundled mero-js
+// `GroupInfo` type omits / misnames:
+//   • `subgroupVisibility` — the live field for group visibility (the SDK
+//     type declares `defaultVisibility`, a different/legacy name).
+//   • `metadata` — the group's full metadata record (name + opaque data
+//     map); serde omits it when none is set, hence optional.
+//   • `groupStateHash` — governance-convergence hash.
+// The package's `exports` map blocks deep-path module augmentation under
+// bundler resolution, so we extend the SDK type locally instead of casting
+// to `any` — access stays fully typed and mirrors the wire shape. Drop the
+// extra members once the SDK type is corrected upstream.
+interface GroupMetadataRecord {
+  name?: string | null;
+  data: Record<string, string>;
+  updatedAt: number;
+  updatedBy: string;
+}
+
+interface GroupInfoExt extends GroupInfo {
+  subgroupVisibility: string;
+  metadata?: GroupMetadataRecord;
+  groupStateHash?: string;
+}
+
 export default function Namespaces() {
   const toast = useToast();
   const { mero } = useMero();
@@ -104,8 +131,12 @@ export default function Namespaces() {
 
   const { namespaces, loading, error, refetch: refetchNamespaces } = useNamespaces();
   const { groups: nsGroups, loading: nsLoadingGroups, error: nsGroupsError, refetch: refetchNsGroups } = useNamespaceGroups(activeNsId) as any;
-  const { groupInfo, loading: groupInfoLoading } = useGroupInfo(activeGroupId);
-  const { groupInfo: nsRootGroupInfo } = useGroupInfo(activeNsRootId);
+  const { groupInfo: groupInfoRaw, loading: groupInfoLoading } = useGroupInfo(activeGroupId);
+  const { groupInfo: nsRootGroupInfoRaw } = useGroupInfo(activeNsRootId);
+  // See GroupInfoExt: the live merod response carries metadata /
+  // subgroupVisibility, which the bundled SDK type omits.
+  const groupInfo = groupInfoRaw as GroupInfoExt | null;
+  const nsRootGroupInfo = nsRootGroupInfoRaw as GroupInfoExt | null;
   const { members: groupMembers, refetch: refetchGroupMembers } = useGroupMembers(activeGroupId) as any;
   const [nsMembers, setNsMembers] = useState<any[]>([]);
   const [nsMembersLoading, setNsMembersLoading] = useState(false);
@@ -376,14 +407,14 @@ export default function Namespaces() {
     const token = getCloudIdToken();
     if (!token) return;
     let cancelled = false;
-    getCloudGroups(token)
-      .then((groups) => {
+    getCloudNamespaces(token)
+      .then((namespaces) => {
         if (cancelled) return;
         const byNamespace: Record<string, boolean> = {};
-        for (const g of groups) {
-          if (!g.namespace_id) continue;
-          if (g.ha_status === "enabled") byNamespace[g.namespace_id] = true;
-          else if (byNamespace[g.namespace_id] === undefined) byNamespace[g.namespace_id] = false;
+        for (const n of namespaces) {
+          if (!n.namespace_id) continue;
+          if (n.ha_status === "enabled") byNamespace[n.namespace_id] = true;
+          else if (byNamespace[n.namespace_id] === undefined) byNamespace[n.namespace_id] = false;
         }
         setHaEnabled(byNamespace);
       })

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -10,7 +10,7 @@ import {
   useCreateNamespace,
   type Namespace,
 } from "@calimero-network/mero-react";
-import type { GroupInfo } from "@calimero-network/mero-js";
+import type { GroupInfo, MetadataRecord } from "@calimero-network/mero-js";
 import { useToast } from "../contexts/ToastContext";
 import { ChevronLeft, Users, Box, Layers, Copy, ChevronRight, Shield, Globe, Plus, X, Play, Trash2, UserMinus, Link, ChevronDown, Check, MoreHorizontal, LogIn } from "lucide-react";
 import { apiClient } from "../lib/mero-client";
@@ -96,29 +96,20 @@ type View =
 
 // The merod admin group-info response (core's GroupInfoApiResponseData,
 // crates/server/primitives/src/admin/mod.rs, #[serde(rename_all =
-// "camelCase")]) carries three camelCase fields the bundled mero-js
-// `GroupInfo` type omits / misnames:
-//   • `subgroupVisibility` — the live field for group visibility (the SDK
-//     type declares `defaultVisibility`, a different/legacy name).
-//   • `metadata` — the group's full metadata record (name + opaque data
-//     map); serde omits it when none is set, hence optional.
-//   • `groupStateHash` — governance-convergence hash.
-// The package's `exports` map blocks deep-path module augmentation under
-// bundler resolution, so we extend the SDK type locally instead of casting
-// to `any` — access stays fully typed and mirrors the wire shape. Drop the
-// extra members once the SDK type is corrected upstream.
-interface GroupMetadataRecord {
-  name?: string | null;
-  data: Record<string, string>;
-  updatedAt: number;
-  updatedBy: string;
-}
-
-interface GroupInfoExt extends GroupInfo {
-  subgroupVisibility: string;
-  metadata?: GroupMetadataRecord;
+// "camelCase")]) carries `groupStateHash` — a governance-convergence hash —
+// that the bundled mero-js `GroupInfo` type still omits. `subgroupVisibility`
+// and `metadata` are already present on the SDK type (and we keep the SDK's
+// `MetadataRecord` shape verbatim via Omit, so the cast at the use sites is a
+// sound widening of the stale SDK type rather than a redeclaration).
+//
+// We re-add `metadata` through Omit (instead of `extends`) because declaring
+// it again on a subtype clashes with the SDK's `metadata?: MetadataRecord |
+// null` (TS2430) — Omit-then-restore keeps the field wire-accurate without the
+// conflict. Drop the whole alias once mero-js exposes `groupStateHash`.
+type GroupInfoExt = Omit<GroupInfo, "metadata"> & {
+  metadata?: MetadataRecord | null;
   groupStateHash?: string;
-}
+};
 
 export default function Namespaces() {
   const toast = useToast();
@@ -133,8 +124,10 @@ export default function Namespaces() {
   const { groups: nsGroups, loading: nsLoadingGroups, error: nsGroupsError, refetch: refetchNsGroups } = useNamespaceGroups(activeNsId) as any;
   const { groupInfo: groupInfoRaw, loading: groupInfoLoading } = useGroupInfo(activeGroupId);
   const { groupInfo: nsRootGroupInfoRaw } = useGroupInfo(activeNsRootId);
-  // See GroupInfoExt: the live merod response carries metadata /
-  // subgroupVisibility, which the bundled SDK type omits.
+  // The SDK's `GroupInfo` is stale vs core's API (skew): it lacks
+  // `groupStateHash` that the live merod response carries. We narrow to the
+  // wire-accurate `GroupInfoExt` (a sound widening — see its definition).
+  // Remove this cast once mero-js is bumped to expose the field.
   const groupInfo = groupInfoRaw as GroupInfoExt | null;
   const nsRootGroupInfo = nsRootGroupInfoRaw as GroupInfoExt | null;
   const { members: groupMembers, refetch: refetchGroupMembers } = useGroupMembers(activeGroupId) as any;

--- a/apps/desktop/src/utils/cloudApi.test.ts
+++ b/apps/desktop/src/utils/cloudApi.test.ts
@@ -18,6 +18,7 @@ import {
   requestOwnershipProof,
   claimContexts,
   enableHaForNamespace,
+  getCloudNamespaces,
   CLOUD_BASE_URL,
 } from './cloudApi';
 
@@ -178,6 +179,44 @@ describe('claimContexts', () => {
     await expect(
       claimContexts(makeJwt({ iss: 'mdma' }), []),
     ).rejects.toThrow(/Ownership proof failed: signer not registered/);
+  });
+});
+
+describe('getCloudNamespaces', () => {
+  let restore: () => void;
+  afterEach(() => restore?.());
+
+  it('GETs the namespace-native read model with a bearer token', async () => {
+    const rows = [
+      {
+        namespace_id: 'ns-1',
+        contexts: ['ctx-1'],
+        ha_status: 'enabled',
+        ha_enabled_at: '2026-01-01T00:00:00Z',
+        fleet_replicas: { active: 1, assigned: 1, limit: 3 },
+      },
+    ];
+    const { calls, restore: r } = installFetch(() => jsonResponse(rows));
+    restore = r;
+
+    const out = await getCloudNamespaces(makeJwt({ iss: 'mdma' }));
+
+    expect(calls).toHaveLength(1);
+    // Migrated off the deprecated /api/cloud/me/groups alias.
+    expect(calls[0].url).toBe(`${CLOUD_BASE_URL}/api/cloud/me/namespaces`);
+    expect(calls[0].init?.method ?? 'GET').toBe('GET');
+    expect(
+      (calls[0].init?.headers as Record<string, string>).Authorization,
+    ).toMatch(/^Bearer /);
+    expect(out).toEqual(rows);
+  });
+
+  it('returns [] on a non-ok response instead of throwing', async () => {
+    const { restore: r } = installFetch(() => jsonResponse({}, 500));
+    restore = r;
+    await expect(getCloudNamespaces(makeJwt({ iss: 'mdma' }))).resolves.toEqual(
+      [],
+    );
   });
 });
 

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -113,17 +113,23 @@ export async function getCloudSubscription(
   return res.json();
 }
 
-export interface CloudGroup {
-  group_id: string;
-  namespace_id: string | null;
+// Shape of `GET /api/cloud/me/namespaces` (the namespace-native read model,
+// live since Phase 2). One row per namespace the caller owns. This is the
+// successor to the deprecated `/api/cloud/me/groups` alias, whose rows
+// carried an extra `group_id` (== `namespace_id`) that no longer exists
+// here — `namespace_id` is the sole identity key and is always present.
+export interface CloudNamespace {
+  namespace_id: string;
   contexts: string[];
   ha_status: string;
   ha_enabled_at: string | null;
   fleet_replicas: { active: number; assigned: number; limit: number };
 }
 
-export async function getCloudGroups(idToken: string): Promise<CloudGroup[]> {
-  const res = await cloudFetch('/api/cloud/me/groups', idToken);
+export async function getCloudNamespaces(
+  idToken: string,
+): Promise<CloudNamespace[]> {
+  const res = await cloudFetch('/api/cloud/me/namespaces', idToken);
   if (!res.ok) return [];
   return res.json();
 }


### PR DESCRIPTION
## #119 step 2a (tauri side)

Migrate the desktop client off the deprecated `/api/cloud/me/groups` alias and onto the namespace-native `/api/cloud/me/namespaces` read model (live since Phase 2), and fold in the pre-existing `tsc` errors on master.

### Migration: `/groups` -> `/namespaces`
- `apps/desktop/src/utils/cloudApi.ts`: `getCloudGroups` -> `getCloudNamespaces`, `CloudGroup` -> `CloudNamespace`. The fetch now targets `/api/cloud/me/namespaces`. The `/namespaces` shape is the `/groups` shape **minus `group_id`** (which was always `== namespace_id`), so `group_id` is dropped and `namespace_id` is now required (non-null) — `namespace_id` is the sole identity key.
- `apps/desktop/src/pages/Namespaces.tsx`: consumer updated to call `getCloudNamespaces` and iterate `n.namespace_id` / `n.ha_status`. The HA-enabled keying (`haEnabled[namespaceId]`) and the HA badge rendering are **unchanged** — only the data source switched.
- No remaining `/api/cloud/me/groups` call or `group_id`-on-cloud-response access anywhere in `apps/desktop/src` (the surviving `group_id` references are all request-side: `enableHa` body + `NamespaceHaGroup` enable-ha shapes).

### Pre-existing `tsc` fix (folded in)
`Namespaces.tsx` had 3 pre-existing `tsc --noEmit` errors on master (`GroupInfo.metadata`, `GroupInfo.subgroupVisibility`). Root cause: the bundled `@calimero-network/mero-js@1.4.0` `GroupInfo` type is **stale** relative to merod's actual group-info response. Core's `GroupInfoApiResponseData` (`crates/server/primitives/src/admin/mod.rs`, `#[serde(rename_all = "camelCase")]`) returns `subgroupVisibility` + `metadata` (`MetadataRecord`) + `groupStateHash` — fields the SDK type omits / misnames (`defaultVisibility`). The access sites were correct against the live API; the SDK type was wrong.

Fix: the package's `exports` map blocks deep-path module augmentation under `moduleResolution: bundler`, so instead of `any`/`@ts-ignore`, the SDK type is **extended locally** (`GroupInfoExt extends GroupInfo`) mirroring the wire shape, and `groupInfo`/`nsRootGroupInfo` are narrowed to it. Drop the local extension once the SDK type is corrected upstream.

### Verify
- `cd apps/desktop && pnpm tsc --noEmit` -> **0 errors**
- `pnpm test:unit` -> green (39 tests; added 2 `getCloudNamespaces` tests asserting the `/namespaces` URL + bearer auth + `[]`-on-non-ok).

Paired with the cloud-frontend migration. The `/groups` backend alias is dropped later (step 2b). Links #119 (mdma) and `NAMESPACE_NATIVE_READMODEL_PLAN.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches the desktop client’s cloud HA status source from the deprecated `/api/cloud/me/groups` to `/api/cloud/me/namespaces`, which could affect HA toggle state if the new read model differs in production. Also widens `GroupInfo` typing locally to match the live API response, which is low runtime risk but could mask future SDK/API drift.
> 
> **Overview**
> Updates the desktop cloud integration to **stop calling the deprecated** `/api/cloud/me/groups` alias and instead fetch HA status from the namespace-native `/api/cloud/me/namespaces` read model via new `getCloudNamespaces` (replacing `getCloudGroups`/`CloudGroup` with `CloudNamespace`). The Namespaces page’s HA enablement map is now populated from this namespaces list, with behavior otherwise unchanged.
> 
> Fixes pre-existing TypeScript errors in `Namespaces.tsx` by introducing a local `GroupInfoExt` type (via `Omit` + restore) and casting `useGroupInfo` results to include fields present on the wire (notably `groupStateHash` and correct `metadata`). Adds unit tests asserting `getCloudNamespaces` uses the new URL, includes bearer auth, and returns `[]` on non-OK responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdd178806432359f397cabdeabf038e24f988ac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->