### PR TITLE
fix(namespaces): name+faded-ID rows everywhere, bump mero-js to 2.2.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,7 +24,7 @@
     "test:e2e:install": "playwright install chromium"
   },
   "dependencies": {
-    "@calimero-network/mero-js": "^2.2.0",
+    "@calimero-network/mero-js": "^2.2.1",
     "@calimero-network/mero-react": "^2.4.0",
     "@tauri-apps/api": "^1.5.0",
     "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/apps/desktop/src/pages/Namespaces.css
+++ b/apps/desktop/src/pages/Namespaces.css
@@ -515,6 +515,39 @@
   padding: 12px 0;
 }
 
+.ns-row-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.ns-row-name {
+  font-weight: 500;
+  color: var(--text-primary);
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ns-row-name-muted {
+  color: var(--text-tertiary);
+  font-style: italic;
+  font-weight: 400;
+}
+
+.ns-row-id {
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  opacity: 0.7;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ─── Group List ─── */
 .ns-group-list {
   display: flex;

--- a/apps/desktop/src/pages/Namespaces.css
+++ b/apps/desktop/src/pages/Namespaces.css
@@ -532,12 +532,6 @@
   white-space: nowrap;
 }
 
-.ns-row-name-muted {
-  color: var(--text-tertiary);
-  font-style: italic;
-  font-weight: 400;
-}
-
 .ns-row-id {
   color: var(--text-tertiary);
   font-size: 11px;

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -464,11 +464,20 @@ export default function Namespaces() {
   const renderContextItem = (c: any, applicationId: string, _refetch: () => void) => {
     const app = installedApps.find((a) => a.id === applicationId);
     const canLaunch = !!app?.frontendUrl;
+    const hasName = !!c.name;
     return (
       <div key={c.contextId} className="ns-context-item">
         <Box size={14} />
-        <span className="context-name">{c.name || truncateId(c.contextId)}</span>
-        <span className="context-id mono">{truncateId(c.contextId)}</span>
+        <div className="ns-row-info">
+          {hasName ? (
+            <>
+              <span className="ns-row-name">{c.name}</span>
+              <span className="ns-row-id">{truncateId(c.contextId)}</span>
+            </>
+          ) : (
+            <span className="ns-row-name mono">{truncateId(c.contextId)}</span>
+          )}
+        </div>
         <button className="copy-btn" onClick={() => copyToClipboard(c.contextId)} title="Copy ID">
           <Copy size={12} />
         </button>
@@ -742,7 +751,16 @@ export default function Namespaces() {
             <h2>Application</h2>
             <div className="ns-detail-field">
               <span className="field-label">Target Application</span>
-              <span className="field-value mono">{truncateId(ns.targetApplicationId)}</span>
+              <div className="ns-row-info">
+                {appById[ns.targetApplicationId]?.name ? (
+                  <>
+                    <span className="ns-row-name">{appById[ns.targetApplicationId]!.name}</span>
+                    <span className="ns-row-id">{truncateId(ns.targetApplicationId)}</span>
+                  </>
+                ) : (
+                  <span className="ns-row-name mono">{truncateId(ns.targetApplicationId)}</span>
+                )}
+              </div>
               <button className="copy-btn" onClick={() => copyToClipboard(ns.targetApplicationId)} title="Copy">
                 <Copy size={12} />
               </button>
@@ -810,15 +828,20 @@ export default function Namespaces() {
               <div className="ns-member-list">
                 {nsMembers.map((m) => {
                   const isExpanded = expandedMemberId === m.identity;
+                  const hasName = !!m.name;
                   return (
                     <div key={m.identity} className={`ns-member-item ns-member-clickable${isExpanded ? ' ns-member-expanded' : ''}`}>
                       <div className="ns-member-row" onClick={() => setExpandedMemberId(isExpanded ? null : m.identity)}>
                         <div className="member-info">
                           <div className="member-name-row">
-                            <span className="member-name">{m.name || truncateId(m.identity)}</span>
+                            {hasName ? (
+                              <span className="member-name">{m.name}</span>
+                            ) : (
+                              <span className="member-name mono">{truncateId(m.identity)}</span>
+                            )}
                             {myIdentity && m.identity === myIdentity && <span className="ns-me-badge">you</span>}
                           </div>
-                          <span className="member-id mono">{truncateId(m.identity)}</span>
+                          {hasName && <span className="member-id mono">{truncateId(m.identity)}</span>}
                         </div>
                         <span className="member-role" style={{ color: roleColor(m.role) }}>{m.role}</span>
                         <button
@@ -878,23 +901,36 @@ export default function Namespaces() {
               <p className="empty-hint">No groups in this namespace</p>
             ) : (
               <div className="ns-group-list">
-                {nsGroups.map((g: any) => (
-                  <div key={g.groupId} className="ns-group-item">
-                    <Layers size={16} />
-                    <span className="group-name" onClick={() => openGroup(ns, g.groupId)} style={{ flex: 1, cursor: 'pointer' }}>
-                      {(g as any).name || (g as any).metadata?.name || truncateId(g.groupId)}
-                    </span>
-                    <span className="group-id mono">{truncateId(g.groupId)}</span>
-                    <button
-                      className="ns-danger-icon-btn"
-                      title="Delete group"
-                      onClick={(e) => { e.stopPropagation(); setDeleteGroupTarget(g.groupId); }}
-                    >
-                      <Trash2 size={13} />
-                    </button>
-                    <ChevronRight size={14} className="ns-card-chevron" onClick={() => openGroup(ns, g.groupId)} style={{ cursor: 'pointer' }} />
-                  </div>
-                ))}
+                {nsGroups.map((g: any) => {
+                  const gName = (g as any).name || (g as any).metadata?.name;
+                  return (
+                    <div key={g.groupId} className="ns-group-item">
+                      <Layers size={16} />
+                      <div
+                        className="ns-row-info"
+                        onClick={() => openGroup(ns, g.groupId)}
+                        style={{ cursor: 'pointer' }}
+                      >
+                        {gName ? (
+                          <>
+                            <span className="ns-row-name">{gName}</span>
+                            <span className="ns-row-id">{truncateId(g.groupId)}</span>
+                          </>
+                        ) : (
+                          <span className="ns-row-name mono">{truncateId(g.groupId)}</span>
+                        )}
+                      </div>
+                      <button
+                        className="ns-danger-icon-btn"
+                        title="Delete group"
+                        onClick={(e) => { e.stopPropagation(); setDeleteGroupTarget(g.groupId); }}
+                      >
+                        <Trash2 size={13} />
+                      </button>
+                      <ChevronRight size={14} className="ns-card-chevron" onClick={() => openGroup(ns, g.groupId)} style={{ cursor: 'pointer' }} />
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>
@@ -984,15 +1020,21 @@ export default function Namespaces() {
                   <p className="empty-hint">No members</p>
                 ) : (
                   <div className="ns-member-list">
-                    {safeGroupMembers.map((m: any) => (
+                    {safeGroupMembers.map((m: any) => {
+                      const hasName = !!m.name;
+                      return (
                       <div key={m.identity} className="ns-member-item">
                         <div className="ns-member-row">
                           <div className="member-info">
                             <div className="member-name-row">
-                              <span className="member-name">{m.name || truncateId(m.identity)}</span>
+                              {hasName ? (
+                                <span className="member-name">{m.name}</span>
+                              ) : (
+                                <span className="member-name mono">{truncateId(m.identity)}</span>
+                              )}
                               {myIdentity && m.identity === myIdentity && <span className="ns-me-badge">you</span>}
                             </div>
-                            <span className="member-id mono">{truncateId(m.identity)}</span>
+                            {hasName && <span className="member-id mono">{truncateId(m.identity)}</span>}
                           </div>
                           <span className="member-role" style={{ color: roleColor(m.role) }}>{m.role}</span>
                           <button className="copy-btn" onClick={() => copyToClipboard(m.identity)} title="Copy identity">
@@ -1012,7 +1054,8 @@ export default function Namespaces() {
                           </button>
                         </div>
                       </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 )}
               </div>
@@ -1032,23 +1075,36 @@ export default function Namespaces() {
                 <div className="ns-detail-section">
                   <h2><Layers size={16} /> Subgroups ({groupSubgroups.length})</h2>
                   <div className="ns-group-list">
-                    {groupSubgroups.map((g: any) => (
-                      <div key={g.groupId} className="ns-group-item">
-                        <Layers size={16} />
-                        <span className="group-name" onClick={() => openGroup(ns, g.groupId)} style={{ flex: 1, cursor: 'pointer' }}>
-                          {(g as any).name || (g as any).metadata?.name || truncateId(g.groupId)}
-                        </span>
-                        <span className="group-id mono">{truncateId(g.groupId)}</span>
-                        <button
-                          className="ns-danger-icon-btn"
-                          title="Delete subgroup"
-                          onClick={() => setDeleteGroupTarget(g.groupId)}
-                        >
-                          <Trash2 size={13} />
-                        </button>
-                        <ChevronRight size={14} className="ns-card-chevron" onClick={() => openGroup(ns, g.groupId)} style={{ cursor: 'pointer' }} />
-                      </div>
-                    ))}
+                    {groupSubgroups.map((g: any) => {
+                      const gName = (g as any).name || (g as any).metadata?.name;
+                      return (
+                        <div key={g.groupId} className="ns-group-item">
+                          <Layers size={16} />
+                          <div
+                            className="ns-row-info"
+                            onClick={() => openGroup(ns, g.groupId)}
+                            style={{ cursor: 'pointer' }}
+                          >
+                            {gName ? (
+                              <>
+                                <span className="ns-row-name">{gName}</span>
+                                <span className="ns-row-id">{truncateId(g.groupId)}</span>
+                              </>
+                            ) : (
+                              <span className="ns-row-name mono">{truncateId(g.groupId)}</span>
+                            )}
+                          </div>
+                          <button
+                            className="ns-danger-icon-btn"
+                            title="Delete subgroup"
+                            onClick={() => setDeleteGroupTarget(g.groupId)}
+                          >
+                            <Trash2 size={13} />
+                          </button>
+                          <ChevronRight size={14} className="ns-card-chevron" onClick={() => openGroup(ns, g.groupId)} style={{ cursor: 'pointer' }} />
+                        </div>
+                      );
+                    })}
                   </div>
                 </div>
               )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   apps/desktop:
     dependencies:
       '@calimero-network/mero-js':
-        specifier: ^2.2.0
-        version: 2.2.0
+        specifier: ^2.2.1
+        version: 2.2.1
       '@calimero-network/mero-react':
         specifier: ^2.4.0
         version: 2.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -194,8 +194,8 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  '@calimero-network/mero-js@2.2.0':
-    resolution: {integrity: sha512-31DBV00KJ9XUJLyd1pymc9QL16uy6LJqcxvvr/u/Cm2fi2IwAScOhtRZ7L1slZizoDRjCvlGFpDjjLm/d3mhCQ==}
+  '@calimero-network/mero-js@2.2.1':
+    resolution: {integrity: sha512-xDBMpk0w3wxnYCh5cwVCUiQ0rjU1+LD6uHCHRWdSI0i4myTfLByOBamgYQX76RF8+6LS+O1sSDddmjbC8u9Y/g==}
     engines: {node: '>=18.0.0'}
 
   '@calimero-network/mero-react@2.4.0':
@@ -522,89 +522,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -698,56 +714,67 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
@@ -807,24 +834,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@1.5.0':
     resolution: {integrity: sha512-OFzKMkg3bmBjr/BYQ1kx4QOHL+JSkzX+Cw8RcG7CKnq8QoJyg8N0K0UTskgsVwlCN4l7bxeuSLvEveg4SBA2AQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-x64-gnu@1.5.0':
     resolution: {integrity: sha512-V2stfUH3Qrc3cIXAd+cKbJruS1oJqqGd40GTVcKOKlRk9Ef9H3WNUQ5PyWKj1t1rk8AxjcBO/vK+Unkuy1WSCw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@1.5.0':
     resolution: {integrity: sha512-qpcGeesuksxzE7lC3RCnikTY9DCRMnAYwhWa9i8MA7pKDX1IXaEvAaXrse44XCZUohxLLgn2k2o6Pb+65dDijQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@1.5.0':
     resolution: {integrity: sha512-Glt/AEWwbFmFnQuoPRbB6vMzCIT9jYSpD59zRP8ljhRSzwDHE59q5nXOrheLKICwMmaXqtAuCIq9ndDBKghwoQ==}
@@ -1744,11 +1775,11 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  '@calimero-network/mero-js@2.2.0': {}
+  '@calimero-network/mero-js@2.2.1': {}
 
   '@calimero-network/mero-react@2.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@calimero-network/mero-js': 2.2.0
+      '@calimero-network/mero-js': 2.2.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 


### PR DESCRIPTION
## Summary

- **UX:** Adopt a consistent _name-on-top + faded mono ID below_ pattern on every row in the Namespaces page (target application, contexts, groups, subgroups, namespace members, group members). When a name is available, the user sees the human-readable label first and the ID only as supporting metadata. When no name is set, the row falls back to just the truncated ID — no "Unnamed X" placeholder text inflating the row.
- **Subgroup listing fix:** Bump `@calimero-network/mero-js` from `^2.2.0` to `^2.2.1` to pick up [mero-js#38](https://github.com/calimero-network/mero-js/pull/38), which fixes `listSubgroups` reading the wrong wrapper key from the merod response. Without that, the Subgroups section in a group's detail view was invisible even when the server was returning named subgroups.

## Why

Before, every row showed only the truncated ID twice (or once, depending on the section) regardless of whether the entity had a human-set name. Example: a group named "Cool new thing" rendered as `955c1707…1b1fabe8`, and a Mero Chat namespace with 14 named groups rendered as 14 indistinguishable truncated IDs. Members repeated the same identity hash on two lines because the name fallback equalled the row's secondary ID.

The new pattern:

```
Name of the thing          ← prominent, name from server metadata
abcd1234...wxyz5678        ← faded, monospace, sits below
```

When no name is present:

```
abcd1234...wxyz5678        ← single row, no "Unnamed" prefix
```

## Files changed

- `apps/desktop/src/pages/Namespaces.tsx` — render conditionals across application target, context rows, namespace-group rows, subgroup rows, and both member-row sites.
- `apps/desktop/src/pages/Namespaces.css` — new reusable `.ns-row-info`, `.ns-row-name`, `.ns-row-id` classes.
- `apps/desktop/package.json`, `pnpm-lock.yaml` — `^2.2.0` → `^2.2.1`.

## Verified locally

- Mero Chat → group rows show metadata names with IDs faded below.
- Application section resolves `targetApplicationId` against `listApplications` and shows the app name (falls back to ID if metadata is unavailable).
- Group detail → Subgroups section now appears for groups that have subgroups, with name "Cool new thing" shown above the faded ID.
- Member rows with no name set show just the identity (no duplicate row).

## Test plan

- [ ] CI passes (`pnpm install --frozen-lockfile`, lint, tsc).
- [ ] On a node with at least one namespace that contains named + unnamed groups, verify the rendered list distinguishes them by typography.
- [ ] On a group that contains a subgroup with a name, verify the Subgroups section is visible and shows the name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly UI rendering tweaks, but it also bumps `@calimero-network/mero-js`, which can affect namespaces/groups/subgroups data loading behavior in the desktop app.
> 
> **Overview**
> Improves the Namespaces UI by standardizing list rows to show a *primary display name* with a secondary, faded monospace truncated ID beneath it, and falling back to a single ID-only row when no name exists (applied across target application, contexts, members, groups, and subgroups).
> 
> Adds reusable CSS styles for the new row layout and updates `@calimero-network/mero-js` to `^2.2.1` (and lockfile) to pick up the upstream `listSubgroups` parsing fix so subgroup listings render correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2266b0a9db2818f588f978fe18414b1a1a4c9aeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->