### PR TITLE
fix: focus existing app window instead of opening duplicates

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -135,11 +135,12 @@ struct HttpResponse {
     body: String,
 }
 
-/// Parses --open-app-url and --open-app-name from CLI args (used when launched from a desktop shortcut).
-fn parse_open_app_args() -> Option<(String, String)> {
+/// Parses --open-app-url, --open-app-name, --open-app-id from CLI args (used when launched from a desktop shortcut).
+fn parse_open_app_args() -> Option<(String, String, Option<String>)> {
     let args: Vec<String> = std::env::args().collect();
     let mut url = None;
     let mut name = None;
+    let mut app_id = None;
     let mut i = 0;
     while i < args.len() {
         if args[i] == "--open-app-url" && i + 1 < args.len() {
@@ -152,9 +153,14 @@ fn parse_open_app_args() -> Option<(String, String)> {
             i += 2;
             continue;
         }
+        if args[i] == "--open-app-id" && i + 1 < args.len() {
+            app_id = Some(args[i + 1].clone());
+            i += 2;
+            continue;
+        }
         i += 1;
     }
-    url.map(|u| (u, name.unwrap_or_else(|| "Application".to_string())))
+    url.map(|u| (u, name.unwrap_or_else(|| "Application".to_string()), app_id))
 }
 
 /// Check CLI args for a calimero:// deep link URL (passed by OS when app is launched via URL scheme).
@@ -168,7 +174,7 @@ fn parse_deep_link_arg() -> Option<String> {
 }
 
 /// State for app to open when launched from a desktop shortcut (read by frontend on load).
-pub struct PendingOpenApp(pub std::sync::Mutex<Option<(String, String)>>);
+pub struct PendingOpenApp(pub std::sync::Mutex<Option<(String, String, Option<String>)>>);
 
 /// State for pending Calimero Cloud auth callback (set by deep link handler, read by frontend).
 pub struct PendingCloudAuth(pub std::sync::Mutex<Option<String>>);
@@ -555,7 +561,7 @@ fn cancel_sse_stream(stream_id: String, cancel_registry: tauri::State<'_, SseCan
 }
 
 #[tauri::command]
-fn get_pending_open_app(state: tauri::State<'_, PendingOpenApp>) -> Option<(String, String)> {
+fn get_pending_open_app(state: tauri::State<'_, PendingOpenApp>) -> Option<(String, String, Option<String>)> {
     state.0.lock().ok().and_then(|g| g.clone())
 }
 
@@ -600,6 +606,7 @@ fn create_desktop_shortcut(
     app_handle: tauri::AppHandle,
     app_name: String,
     frontend_url: String,
+    app_id: Option<String>,
 ) -> Result<String, TauriError> {
     let exe = std::env::current_exe()
         .map_err(|e| TauriError::with_details(TauriErrorCode::ShortcutCreationFailed, "Could not get executable path", e.to_string()))?;
@@ -621,7 +628,8 @@ fn create_desktop_shortcut(
         let lnk_path = desktop.join(format!("{}.lnk", shortcut_name));
         let url_esc = frontend_url.replace('"', "\\\"");
         let name_esc = app_name.replace('"', "\\\"");
-        let args = format!("--open-app-url \"{}\" --open-app-name \"{}\"", url_esc, name_esc);
+        let id_arg = app_id.as_deref().map(|id| format!(" --open-app-id \"{}\"", id.replace('"', "\\\""))).unwrap_or_default();
+        let args = format!("--open-app-url \"{}\" --open-app-name \"{}\"{}",  url_esc, name_esc, id_arg);
         let ps = format!(
             "$WshShell = New-Object -ComObject WScript.Shell; $s = $WshShell.CreateShortcut('{}'); $s.TargetPath = '{}'; $s.Arguments = '{}'; $s.Save()",
             lnk_path.display(),
@@ -651,11 +659,13 @@ fn create_desktop_shortcut(
         let macos_dir = app_path.join("Contents/MacOS");
         std::fs::create_dir_all(&macos_dir).map_err(|e| TauriError::with_details(TauriErrorCode::DirectoryError, "Failed to create .app bundle", e.to_string()))?;
         let launcher_path = macos_dir.join(shortcut_name);
+        let id_arg = app_id.as_deref().map(|id| format!(" --open-app-id \"{}\"", id.replace('\\', "\\\\").replace('"', "\\\""))).unwrap_or_default();
         let script = format!(
-            "#!/bin/bash\nexec \"{}\" --open-app-url \"{}\" --open-app-name \"{}\"\n",
+            "#!/bin/bash\nexec \"{}\" --open-app-url \"{}\" --open-app-name \"{}\"{}\n",
             exe_esc,
             frontend_url.replace('\\', "\\\\").replace('"', "\\\""),
-            app_name.replace('\\', "\\\\").replace('"', "\\\"")
+            app_name.replace('\\', "\\\\").replace('"', "\\\""),
+            id_arg
         );
         std::fs::write(&launcher_path, script).map_err(|e| TauriError::with_details(TauriErrorCode::FileWriteError, "Failed to write launcher script", e.to_string()))?;
         #[cfg(unix)]
@@ -699,16 +709,18 @@ fn create_desktop_shortcut(
         let exe_esc = exe_str.replace('\\', "\\\\").replace('"', "\\\"");
         let url_esc = frontend_url.replace('\\', "\\\\").replace('"', "\\\"");
         let name_esc = app_name.replace('\\', "\\\\").replace('"', "\\\"");
+        let id_arg = app_id.as_deref().map(|id| format!(" --open-app-id \"{}\"", id.replace('\\', "\\\\").replace('"', "\\\""))).unwrap_or_default();
         let content = format!(
             "[Desktop Entry]\n\
              Type=Application\n\
              Name={}\n\
-             Exec=\"{}\" --open-app-url \"{}\" --open-app-name \"{}\"\n\
+             Exec=\"{}\" --open-app-url \"{}\" --open-app-name \"{}\"{}\n\
              Terminal=false\n",
             name_esc,
             exe_esc,
             url_esc,
-            name_esc
+            name_esc,
+            id_arg
         );
         std::fs::write(&path, content).map_err(|e| TauriError::with_details(TauriErrorCode::FileWriteError, "Failed to write shortcut file", e.to_string()))?;
         #[cfg(unix)]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -154,7 +154,11 @@ fn parse_open_app_args() -> Option<(String, String, Option<String>)> {
             continue;
         }
         if args[i] == "--open-app-id" && i + 1 < args.len() {
-            app_id = Some(args[i + 1].clone());
+            let id = args[i + 1].clone();
+            // Validate before use: non-empty, ≤128 chars, alphanumeric + hyphen only.
+            if !id.is_empty() && id.len() <= 128 && id.chars().all(|c| c.is_alphanumeric() || c == '-') {
+                app_id = Some(id);
+            }
             i += 2;
             continue;
         }

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.40"
+    "version": "0.0.41"
   },
   "tauri": {
     "allowlist": {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -427,10 +427,10 @@ function App() {
     let cancelled = false;
     const t = setTimeout(async () => {
       try {
-        const pending = await invoke<[string, string] | null>("get_pending_open_app");
+        const pending = await invoke<[string, string, string | null] | null>("get_pending_open_app");
         if (cancelled || !pending) return;
-        const [url, name] = pending;
-        const windowLabel = await openAppFrontend(url, name);
+        const [url, name, appId] = pending;
+        const windowLabel = await openAppFrontend(url, name, undefined, appId ? { applicationId: appId } : undefined);
         if (windowLabel) {
           await invoke("focus_window", { windowLabel });
         }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -392,9 +392,9 @@ function App() {
   }, [checkConnection, toast]);
 
   // Open app frontend in a new window
-  const handleOpenAppFrontend = useCallback(async (frontendUrl: string, appName?: string) => {
+  const handleOpenAppFrontend = useCallback(async (frontendUrl: string, appName?: string, applicationId?: string) => {
     try {
-      await openAppFrontend(frontendUrl, appName);
+      await openAppFrontend(frontendUrl, appName, undefined, applicationId ? { applicationId } : undefined);
     } catch (error) {
       // Fallback to navigating to installed apps page
       setCurrentPage('installed');
@@ -936,7 +936,7 @@ function App() {
                     type="button"
                     onClick={() => {
                       if (frontendUrl) {
-                        handleOpenAppFrontend(frontendUrl, appName);
+                        handleOpenAppFrontend(frontendUrl, appName, app.id);
                       } else {
                         setCurrentPage('installed');
                       }

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -11,10 +11,10 @@ import {
   type Namespace,
 } from "@calimero-network/mero-react";
 import { useToast } from "../contexts/ToastContext";
-import { ChevronLeft, Users, Box, Layers, Copy, ChevronRight, Shield, Globe, Plus, X, Play, Trash2, UserMinus, Link, ChevronDown, Check, MoreHorizontal, LogIn } from "lucide-react";
+import { ChevronLeft, Users, Box, Layers, Copy, ChevronRight, Shield, Globe, Plus, X, Trash2, UserMinus, Link, ChevronDown, Check, MoreHorizontal, LogIn } from "lucide-react";
 import { apiClient } from "../lib/mero-client";
-import { saveContextKey, getContextKey } from "../utils/contextKeys";
-import { decodeMetadata, openAppFrontend } from "../utils/appUtils";
+import { saveContextKey } from "../utils/contextKeys";
+import { decodeMetadata } from "../utils/appUtils";
 import { getSettings } from "../utils/settings";
 import {
   enableHaForNamespace,
@@ -253,20 +253,6 @@ export default function Namespaces() {
     }
   };
 
-  const handleLaunchContext = async (contextId: string, applicationId: string) => {
-    const app = installedApps.find((a) => a.id === applicationId);
-    if (!app?.frontendUrl) { toast.error("This application has no frontend URL"); return; }
-    // Warm up the token — if it's expired the node will return 401+token_expired,
-    // mero-js refreshes and writes fresh tokens back to localStorage before we read them.
-    try { await apiClient.node.listApplications(); } catch {}
-    const key = getContextKey(contextId);
-    await openAppFrontend(app.frontendUrl, app.name, undefined, {
-      applicationId,
-      contextId,
-      executorPublicKey: key?.publicKey,
-    });
-  };
-
   const handleDeleteNamespace = async (ns: Namespace) => {
     if (!mero) return;
     setActionLoading(true);
@@ -461,9 +447,7 @@ export default function Namespaces() {
   };
 
   // ── Context row helper ──
-  const renderContextItem = (c: any, applicationId: string, _refetch: () => void) => {
-    const app = installedApps.find((a) => a.id === applicationId);
-    const canLaunch = !!app?.frontendUrl;
+  const renderContextItem = (c: any, _applicationId: string, _refetch: () => void) => {
     const hasName = !!c.name;
     return (
       <div key={c.contextId} className="ns-context-item">
@@ -481,15 +465,6 @@ export default function Namespaces() {
         <button className="copy-btn" onClick={() => copyToClipboard(c.contextId)} title="Copy ID">
           <Copy size={12} />
         </button>
-        {canLaunch && (
-          <button
-            className="ns-launch-btn"
-            onClick={() => handleLaunchContext(c.contextId, applicationId)}
-            title={`Launch ${app?.name ?? "app"} with this context`}
-          >
-            <Play size={12} /> Launch
-          </button>
-        )}
       </div>
     );
   };

--- a/apps/desktop/src/utils/appUtils.ts
+++ b/apps/desktop/src/utils/appUtils.ts
@@ -93,16 +93,15 @@ export async function openAppFrontend(
 
     const urlToOpen = `${frontendUrl}#${hashParams.toString()}`;
 
-    // Stable window label: same app+context always gets the same label so
-    // Tauri can find and focus the existing window instead of opening a new one.
+    // Stable window label keyed by applicationId so every call site
+    // (Home, Applications, Namespaces, shortcut) produces the same label
+    // for the same app and Tauri can focus the existing window.
     const urlObj = new URL(frontendUrl);
     const domain = urlObj.hostname.replace(/[^a-zA-Z0-9]/g, '-');
-    const contextSuffix = context?.contextId
-      ? `-${context.contextId.slice(0, 12)}`
-      : context?.applicationId
-        ? `-${context.applicationId.slice(0, 12)}`
-        : '';
-    const windowLabel = `app-${domain}${contextSuffix}`.slice(0, 64);
+    const appKey = context?.applicationId
+      ? context.applicationId.slice(0, 16)
+      : domain;
+    const windowLabel = `app-${appKey}`.slice(0, 64);
 
     // If the window is already open, focus it rather than opening a duplicate.
     const existing = WebviewWindow.getByLabel(windowLabel);

--- a/apps/desktop/src/utils/appUtils.ts
+++ b/apps/desktop/src/utils/appUtils.ts
@@ -97,17 +97,23 @@ export async function openAppFrontend(
     // (Home, Applications, Namespaces, shortcut) produces the same label
     // for the same app and Tauri can focus the existing window.
     const urlObj = new URL(frontendUrl);
-    const domain = urlObj.hostname.replace(/[^a-zA-Z0-9]/g, '-');
+    const domain = `${urlObj.hostname}${urlObj.port ? `-${urlObj.port}` : ''}`.replace(/[^a-zA-Z0-9]/g, '-');
     const appKey = context?.applicationId
-      ? context.applicationId.slice(0, 16)
+      ? context.applicationId.slice(0, 60)
       : domain;
     const windowLabel = `app-${appKey}`.slice(0, 64);
 
     // If the window is already open, focus it rather than opening a duplicate.
+    // Tauri v1 has no navigate() API, so we focus the existing window as-is;
+    // apps manage token refresh internally via refresh_token.
     const existing = WebviewWindow.getByLabel(windowLabel);
     if (existing) {
-      await existing.setFocus();
-      return windowLabel;
+      try {
+        await existing.setFocus();
+        return windowLabel;
+      } catch {
+        // window was closed between getByLabel and setFocus; fall through to create a new one
+      }
     }
 
     await invoke('create_app_window', {

--- a/apps/desktop/src/utils/appUtils.ts
+++ b/apps/desktop/src/utils/appUtils.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/tauri";
+import { WebviewWindow } from "@tauri-apps/api/window";
 import { getSettings } from "./settings";
 import { getAccessToken, getRefreshToken, getTokenExpiresAt } from "../lib/token-storage";
 
@@ -92,10 +93,23 @@ export async function openAppFrontend(
 
     const urlToOpen = `${frontendUrl}#${hashParams.toString()}`;
 
-    // Generate unique window label based on domain + timestamp to avoid conflicts
+    // Stable window label: same app+context always gets the same label so
+    // Tauri can find and focus the existing window instead of opening a new one.
     const urlObj = new URL(frontendUrl);
-    const domain = urlObj.hostname.replace(/\./g, '-');
-    const windowLabel = `app-${domain}-${Date.now()}`;
+    const domain = urlObj.hostname.replace(/[^a-zA-Z0-9]/g, '-');
+    const contextSuffix = context?.contextId
+      ? `-${context.contextId.slice(0, 12)}`
+      : context?.applicationId
+        ? `-${context.applicationId.slice(0, 12)}`
+        : '';
+    const windowLabel = `app-${domain}${contextSuffix}`.slice(0, 64);
+
+    // If the window is already open, focus it rather than opening a duplicate.
+    const existing = WebviewWindow.getByLabel(windowLabel);
+    if (existing) {
+      await existing.setFocus();
+      return windowLabel;
+    }
 
     await invoke('create_app_window', {
       windowLabel,

--- a/apps/desktop/src/utils/appUtils.ts
+++ b/apps/desktop/src/utils/appUtils.ts
@@ -100,10 +100,12 @@ export async function openAppFrontend(
     // (Home, Applications, Namespaces, shortcut) produces the same label
     // for the same app and Tauri can focus the existing window.
     const urlObj = new URL(frontendUrl);
-    const domain = `${urlObj.hostname}${urlObj.port ? `-${urlObj.port}` : ''}`.replace(/[^a-zA-Z0-9\-/_:]/g, '-');
-    // Preserve all Tauri-valid chars [a-zA-Z0-9-/_:]; strip everything else.
+    const domain = `${urlObj.hostname}${urlObj.port ? `-${urlObj.port}` : ''}`.replace(/[^a-zA-Z0-9-]/g, '-');
+    // Restrict to [a-zA-Z0-9-] to prevent label crafting via slash/colon/underscore.
+    // Calimero applicationIds are base58-encoded 32-byte keys (~43 chars), so the
+    // slice(0, 60) limit is never hit in practice and no truncation collisions occur.
     const appKey = context?.applicationId
-      ? context.applicationId.replace(/[^a-zA-Z0-9\-/_:]/g, '-').slice(0, 60)
+      ? context.applicationId.replace(/[^a-zA-Z0-9-]/g, '-').slice(0, 60)
       : domain;
     const windowLabel = `app-${appKey}`.slice(0, 64);
 

--- a/apps/desktop/src/utils/appUtils.ts
+++ b/apps/desktop/src/utils/appUtils.ts
@@ -98,8 +98,9 @@ export async function openAppFrontend(
     // for the same app and Tauri can focus the existing window.
     const urlObj = new URL(frontendUrl);
     const domain = `${urlObj.hostname}${urlObj.port ? `-${urlObj.port}` : ''}`.replace(/[^a-zA-Z0-9]/g, '-');
+    // Sanitize to Tauri's allowed label chars [a-zA-Z0-9-/_:] on both paths.
     const appKey = context?.applicationId
-      ? context.applicationId.slice(0, 60)
+      ? context.applicationId.replace(/[^a-zA-Z0-9]/g, '-').slice(0, 60)
       : domain;
     const windowLabel = `app-${appKey}`.slice(0, 64);
 
@@ -111,8 +112,9 @@ export async function openAppFrontend(
       try {
         await existing.setFocus();
         return windowLabel;
-      } catch {
+      } catch (e) {
         // window was closed between getByLabel and setFocus; fall through to create a new one
+        console.warn('setFocus failed, opening new window:', e);
       }
     }
 

--- a/apps/desktop/src/utils/appUtils.ts
+++ b/apps/desktop/src/utils/appUtils.ts
@@ -104,12 +104,20 @@ export async function openAppFrontend(
       : domain;
     const windowLabel = `app-${appKey}`.slice(0, 64);
 
-    // If the window is already open, focus it rather than opening a duplicate.
-    // Tauri v1 has no navigate() API, so we focus the existing window as-is;
-    // apps manage token refresh internally via refresh_token.
+    // If the window is already open, focus it and push fresh tokens via event.
+    // Tauri v1 has no navigate() API; we emit 'calimero:auth-refresh' so apps
+    // can update their auth state without a full reload.
     const existing = WebviewWindow.getByLabel(windowLabel);
     if (existing) {
       try {
+        if (accessToken && refreshToken) {
+          await existing.emit('calimero:auth-refresh', {
+            access_token: accessToken,
+            refresh_token: refreshToken,
+            expires_at: getTokenExpiresAt() ?? Date.now() + 3600_000,
+            node_url: nodeUrl,
+          });
+        }
         await existing.setFocus();
         return windowLabel;
       } catch (e) {

--- a/apps/desktop/src/utils/appUtils.ts
+++ b/apps/desktop/src/utils/appUtils.ts
@@ -67,6 +67,9 @@ export interface OpenAppFrontendContext {
   executorPublicKey?: string;
 }
 
+// Guards against two concurrent openAppFrontend calls racing to create the same window.
+const pendingWindowCreations = new Set<string>();
+
 export async function openAppFrontend(
   frontendUrl: string,
   appName?: string,
@@ -97,28 +100,23 @@ export async function openAppFrontend(
     // (Home, Applications, Namespaces, shortcut) produces the same label
     // for the same app and Tauri can focus the existing window.
     const urlObj = new URL(frontendUrl);
-    const domain = `${urlObj.hostname}${urlObj.port ? `-${urlObj.port}` : ''}`.replace(/[^a-zA-Z0-9]/g, '-');
-    // Sanitize to Tauri's allowed label chars [a-zA-Z0-9-/_:] on both paths.
+    const domain = `${urlObj.hostname}${urlObj.port ? `-${urlObj.port}` : ''}`.replace(/[^a-zA-Z0-9\-/_:]/g, '-');
+    // Preserve all Tauri-valid chars [a-zA-Z0-9-/_:]; strip everything else.
     const appKey = context?.applicationId
-      ? context.applicationId.replace(/[^a-zA-Z0-9]/g, '-').slice(0, 60)
+      ? context.applicationId.replace(/[^a-zA-Z0-9\-/_:]/g, '-').slice(0, 60)
       : domain;
     const windowLabel = `app-${appKey}`.slice(0, 64);
 
-    // If the window is already open, focus it and push fresh tokens via event.
-    // Tauri v1 has no navigate() API; we emit 'calimero:auth-refresh' so apps
-    // can update their auth state without a full reload.
+    // If the window is already open, focus it and signal a token refresh.
+    // setFocus first: if it throws (window closed), we skip the emit entirely
+    // so no credentials reach a window that may have navigated to a different origin.
     const existing = WebviewWindow.getByLabel(windowLabel);
     if (existing) {
       try {
-        if (accessToken && refreshToken) {
-          await existing.emit('calimero:auth-refresh', {
-            access_token: accessToken,
-            refresh_token: refreshToken,
-            expires_at: getTokenExpiresAt() ?? Date.now() + 3600_000,
-            node_url: nodeUrl,
-          });
-        }
         await existing.setFocus();
+        // Signal apps to re-read their auth state. No token payload here to avoid
+        // sending credentials to a window whose current origin we cannot verify.
+        await existing.emit('calimero:auth-refresh', null).catch(() => {});
         return windowLabel;
       } catch (e) {
         // window was closed between getByLabel and setFocus; fall through to create a new one
@@ -126,13 +124,23 @@ export async function openAppFrontend(
       }
     }
 
-    await invoke('create_app_window', {
-      windowLabel,
-      url: urlToOpen,
-      title: appName || 'Application',
-      openDevtools: false,
-      nodeUrl: settings.nodeUrl,
-    });
+    // Guard concurrent calls: if another in-flight invocation is already creating
+    // this window, return early — Tauri rejects duplicate labels.
+    if (pendingWindowCreations.has(windowLabel)) {
+      return windowLabel;
+    }
+    pendingWindowCreations.add(windowLabel);
+    try {
+      await invoke('create_app_window', {
+        windowLabel,
+        url: urlToOpen,
+        title: appName || 'Application',
+        openDevtools: false,
+        nodeUrl: settings.nodeUrl,
+      });
+    } finally {
+      pendingWindowCreations.delete(windowLabel);
+    }
 
     return windowLabel;
   } catch (error) {

--- a/apps/desktop/src/utils/updater.test.ts
+++ b/apps/desktop/src/utils/updater.test.ts
@@ -19,8 +19,8 @@ const {
   mockKillAll: vi.fn().mockResolvedValue('killed'),
   mockDownloadAndReplace: vi.fn().mockResolvedValue({
     replaced: true,
-    expected_version: '0.10.1-rc.42',
-    current_version: 'merod 0.10.1-rc.42',
+    expected_version: '0.10.1-rc.43',
+    current_version: 'merod 0.10.1-rc.43',
     message: 'merod updated',
   }),
 }));
@@ -53,8 +53,8 @@ beforeEach(() => {
   mockKillAll.mockResolvedValue('killed');
   mockDownloadAndReplace.mockResolvedValue({
     replaced: true,
-    expected_version: '0.10.1-rc.42',
-    current_version: 'merod 0.10.1-rc.42',
+    expected_version: '0.10.1-rc.43',
+    current_version: 'merod 0.10.1-rc.43',
     message: 'merod updated',
   });
 });
@@ -66,7 +66,7 @@ describe('installUpdate', () => {
     mockKillAll.mockImplementation(async () => { callOrder.push('killAll'); });
     mockDownloadAndReplace.mockImplementation(async () => {
       callOrder.push('downloadAndReplace');
-      return { replaced: true, expected_version: '0.10.1-rc.42', current_version: 'merod 0.10.1-rc.42', message: '' };
+      return { replaced: true, expected_version: '0.10.1-rc.43', current_version: 'merod 0.10.1-rc.43', message: '' };
     });
     mockTauriInstallUpdate.mockImplementation(async () => { callOrder.push('tauriInstallUpdate'); });
     mockRelaunch.mockImplementation(async () => { callOrder.push('relaunch'); });
@@ -102,7 +102,7 @@ describe('installUpdate', () => {
 
   it('throws and does NOT relaunch when merod download fails (version mismatch)', async () => {
     mockDownloadAndReplace.mockRejectedValue(
-      new Error("Version mismatch after replace: expected '0.10.1-rc.42', binary reports 'merod 0.10.1-rc.41'"),
+      new Error("Version mismatch after replace: expected '0.10.1-rc.43', binary reports 'merod 0.10.1-rc.42'"),
     );
     await expect(installUpdate()).rejects.toThrow('Version mismatch');
     expect(mockTauriInstallUpdate).not.toHaveBeenCalled();
@@ -112,7 +112,7 @@ describe('installUpdate', () => {
   it('throws and does NOT relaunch when Tauri returns a serialized error object with version mismatch', async () => {
     // Tauri invoke() rejects with a plain object {message, code}, not a JS Error instance
     mockDownloadAndReplace.mockRejectedValue({
-      message: "Version mismatch after replace: expected '0.10.1-rc.42', binary reports 'merod 0.10.1-rc.41'",
+      message: "Version mismatch after replace: expected '0.10.1-rc.43', binary reports 'merod 0.10.1-rc.42'",
       code: 'InternalError',
     });
     await expect(installUpdate()).rejects.toMatchObject({ message: expect.stringContaining('Version mismatch') });
@@ -141,8 +141,8 @@ describe('installUpdate', () => {
   it('still relaunches when binary was already at the correct version (replaced=false)', async () => {
     mockDownloadAndReplace.mockResolvedValue({
       replaced: false,
-      expected_version: '0.10.1-rc.42',
-      current_version: 'merod 0.10.1-rc.42',
+      expected_version: '0.10.1-rc.43',
+      current_version: 'merod 0.10.1-rc.43',
       message: 'Binary is already at the expected version',
     });
     const statuses: string[] = [];

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.10.1-rc.42"
+    "version": "0.10.1-rc.43"
 }


### PR DESCRIPTION
## Summary

- `openAppFrontend` now generates a **deterministic** window label (domain + contextId/applicationId prefix) instead of appending `Date.now()`
- Before `create_app_window` is called, `WebviewWindow.getByLabel(label)` checks if a window for that app is already open — if so, it calls `.setFocus()` and returns early
- Fixes the bug where clicking "Open" on an installed app multiple times created a new window each time instead of focusing the existing one

## Test plan

- [ ] Open a Calimero app from the desktop
- [ ] Click "Open" on the same app again — existing window should come to focus, no second window opened
- [ ] Open two different apps — each should still get its own window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app-window lifecycle and auth refresh signaling across multiple entry points; shortcut CLI args are validated but still expand the launch surface.
> 
> **Overview**
> Repeats opening the same installed app now **reuses one Tauri webview** instead of spawning another: `openAppFrontend` builds a stable `app-{applicationId}` label (with a concurrent-create guard), focuses an existing `WebviewWindow` when present, and emits `calimero:auth-refresh` so the app can pick up tokens without putting credentials on the event.
> 
> **Desktop shortcuts and cold start** thread optional `applicationId` end-to-end: Rust parses/validates `--open-app-id`, stores it in pending open-app state, and Windows/macOS/Linux shortcut `Exec`/`Arguments` include it; the React shell passes `app.id` from Home and forwards pending `appId` on shortcut launch.
> 
> **Namespaces** drops per-context **Launch** (and the token-warmup `openAppFrontend` path there); context rows are view/copy only.
> 
> Also bumps desktop **0.0.41**, bundled **merod 0.10.1-rc.43**, and aligns updater unit-test strings with that merod version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea6035dde48f10a34c4c600c211230b515d78c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->