### PR TITLE
chore: bump node version to rc.45 and desktop to 0.0.42

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.41"
+    "version": "0.0.42"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.10.1-rc.43"
+    "version": "0.10.1-rc.45"
 }


### PR DESCRIPTION
## Summary
- Bumps merod node binary version: `0.10.1-rc.43` → `0.10.1-rc.45` in `merod-config.json`
- Bumps desktop app version: `0.0.41` → `0.0.42` in `apps/desktop/package.json` and `apps/desktop/src-tauri/tauri.conf.json`

## Test plan
- [ ] Verify merod binary download uses the new rc.45 version
- [ ] Verify desktop app reports version 0.0.42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string bumps only; no application logic, security, or API changes.
> 
> **Overview**
> This PR is a **version-only** release alignment: the bundled **merod** node is pinned from `0.10.1-rc.43` to **`0.10.1-rc.45`** in `merod-config.json`, which drives `prepare-merod.mjs` (GitHub release fetch) and the compile-time `MEROD_CONFIG_VERSION` embedded in the Tauri app. The **Calimero Desktop** app version is bumped from **0.0.41** to **0.0.42** in `apps/desktop/package.json` and `apps/desktop/src-tauri/tauri.conf.json` so npm and Tauri packaging stay in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b2e0403f8d0dc830841c278c86eee04cb8671bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->