### PR TITLE
chore: disable Windows CI builds

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -24,10 +24,6 @@ on:
       artifact-name:
         description: "Name of the uploaded artifact"
         value: ${{ jobs.build.outputs.artifact-name }}
-  pull_request:
-    branches:
-      - master
-      - main
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,19 +52,6 @@ jobs:
       TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
       TAURI_PUBLIC_KEY: ${{ secrets.TAURI_PUBLIC_KEY }}
 
-  build-windows:
-    name: Build Windows
-    needs: prepare
-    uses: ./.github/workflows/build-windows.yml
-    with:
-      version: ${{ needs.prepare.outputs.version }}
-    secrets:
-      TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-      TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-      TAURI_PUBLIC_KEY: ${{ secrets.TAURI_PUBLIC_KEY }}
-      WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-      WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
-
   build-linux:
     name: Build Linux
     needs: prepare
@@ -79,9 +66,9 @@ jobs:
   # Publish release with all platform artifacts
   publish:
     name: Publish Release
-    needs: [prepare, build-macos, build-windows, build-linux]
+    needs: [prepare, build-macos, build-linux]
     # Continue even if some platforms fail (partial release)
-    if: always() && needs.prepare.result == 'success' && (needs.build-macos.result == 'success' || needs.build-windows.result == 'success' || needs.build-linux.result == 'success')
+    if: always() && needs.prepare.result == 'success' && (needs.build-macos.result == 'success' || needs.build-linux.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -95,13 +82,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: macos-build
-          path: release-assets/
-
-      - name: Download Windows artifacts
-        if: needs.build-windows.result == 'success'
-        uses: actions/download-artifact@v4
-        with:
-          name: windows-build
           path: release-assets/
 
       - name: Download Linux artifacts
@@ -153,9 +133,6 @@ jobs:
           PLATFORMS=""
           if [ "${{ needs.build-macos.result }}" = "success" ]; then
             PLATFORMS="${PLATFORMS}"$'\n'"- **macOS** (Universal): Download the DMG file"
-          fi
-          if [ "${{ needs.build-windows.result }}" = "success" ]; then
-            PLATFORMS="${PLATFORMS}"$'\n'"- **Windows** (64-bit): Download the installer"
           fi
           if [ "${{ needs.build-linux.result }}" = "success" ]; then
             PLATFORMS="${PLATFORMS}"$'\n'"- **Linux** (64-bit): Download AppImage, deb, or rpm"


### PR DESCRIPTION
## Summary
- Removed `pull_request` trigger from `build-windows.yml` so it no longer runs on PRs
- Removed `build-windows` job from `release.yml`
- Cleaned up all Windows references in the `publish` job (artifact download, release notes, needs/if conditions)

macOS and Linux builds are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tagged releases will no longer include Windows installers or updater artifacts until the workflow is re-enabled, which affects Windows users and any release validation that expected a full three-platform matrix.
> 
> **Overview**
> **Windows is no longer built or shipped by CI.** The reusable `build-windows` workflow no longer runs on pull requests, and tagged/manual **release** flows no longer invoke that job.
> 
> The **publish** step now depends only on **macOS** and **Linux** builds: Windows artifact download and Windows download bullets in release notes are removed, and a release can still go out if either of those platforms succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eab73609273f9cf97d5b04534bfbaa144a9ede18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->