### PR TITLE
chore: bump node version to rc.46 and desktop to 0.0.43

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.42"
+    "version": "0.0.43"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.10.1-rc.45"
+    "version": "0.10.1-rc.46"
 }


### PR DESCRIPTION
## Summary
- Bumps merod node binary version: `0.10.1-rc.45` → `0.10.1-rc.46` in `merod-config.json`
- Bumps desktop app version: `0.0.42` → `0.0.43` in `apps/desktop/package.json` and `apps/desktop/src-tauri/tauri.conf.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes with no logic, security, or API surface modifications.
> 
> **Overview**
> Release alignment only: bumps the bundled **merod** node from `0.10.1-rc.45` to **`0.10.1-rc.46`** in `merod-config.json`, which drives `pnpm merod:prepare` downloads and the compile-time `MEROD_CONFIG_VERSION` embedded in the desktop binary. The Calimero Desktop app version is bumped from **0.0.42** to **0.0.43** in `apps/desktop/package.json` and `apps/desktop/src-tauri/tauri.conf.json` so packaging and the Tauri updater stay in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f421315d900ce447a7cccbb03ef77baf520ef666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->