### PR TITLE
fix: show copied feedback on logs copy button

### DIFF
--- a/apps/desktop/src/components/LogsViewer.css
+++ b/apps/desktop/src/components/LogsViewer.css
@@ -70,7 +70,8 @@
   cursor: not-allowed;
 }
 
-.logs-viewer-btn--copied {
+.logs-viewer-btn--copied,
+.logs-viewer-btn--copied:hover:not(:disabled) {
   color: var(--color-success, #22c55e);
   border-color: var(--color-success, #22c55e);
 }

--- a/apps/desktop/src/components/LogsViewer.css
+++ b/apps/desktop/src/components/LogsViewer.css
@@ -70,6 +70,11 @@
   cursor: not-allowed;
 }
 
+.logs-viewer-btn--copied {
+  color: var(--color-success, #22c55e);
+  border-color: var(--color-success, #22c55e);
+}
+
 .logs-viewer-close {
   padding: 6px 10px;
 }

--- a/apps/desktop/src/components/LogsViewer.tsx
+++ b/apps/desktop/src/components/LogsViewer.tsx
@@ -26,6 +26,7 @@ export function LogsViewer({
   const [autoScroll, setAutoScroll] = useState(true);
   const [copied, setCopied] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const levels = [
     { id: "", label: "All" },
@@ -69,11 +70,22 @@ export function LogsViewer({
     return text ? convert.toHtml(text) : "";
   }, [filteredLines, convert]);
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(filteredLines.join("\n"));
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(filteredLines.join("\n"));
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      setCopied(true);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard write failed — don't show feedback
+    }
   };
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
 
   useEffect(() => {
     if (autoScroll && scrollRef.current) {

--- a/apps/desktop/src/components/LogsViewer.tsx
+++ b/apps/desktop/src/components/LogsViewer.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useRef, useEffect } from "react";
-import { Search, Copy, RefreshCw, X } from "lucide-react";
+import { Search, Copy, Check, RefreshCw, X } from "lucide-react";
 import Convert from "ansi-to-html";
 import { useTheme } from "../contexts/ThemeContext";
 import "./LogsViewer.css";
@@ -24,6 +24,7 @@ export function LogsViewer({
   const [caseSensitive, setCaseSensitive] = useState(false);
   const [levelFilter, setLevelFilter] = useState<string>("");
   const [autoScroll, setAutoScroll] = useState(true);
+  const [copied, setCopied] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const levels = [
@@ -70,6 +71,8 @@ export function LogsViewer({
 
   const handleCopy = () => {
     navigator.clipboard.writeText(filteredLines.join("\n"));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   useEffect(() => {
@@ -95,11 +98,11 @@ export function LogsViewer({
             </button>
             <button
               onClick={handleCopy}
-              className="logs-viewer-btn"
+              className={`logs-viewer-btn${copied ? " logs-viewer-btn--copied" : ""}`}
               title="Copy to clipboard"
             >
-              <Copy size={14} />
-              Copy
+              {copied ? <Check size={14} /> : <Copy size={14} />}
+              {copied ? "Copied!" : "Copy"}
             </button>
             <button
               onClick={onClose}


### PR DESCRIPTION
## Summary

- Copy button in the node logs viewer now shows visual feedback when clicked
- Icon switches from `Copy` → `Check`, label changes to "Copied!", button turns green
- Reverts back to normal after 2 seconds

## Test plan

- [ ] Open a node's logs from the Nodes page
- [ ] Click the Copy button — verify it turns green with a checkmark and "Copied!" label
- [ ] Wait 2 seconds — verify it returns to the default Copy state
- [ ] Paste somewhere to confirm the logs were actually copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to LogsViewer copy behavior with no auth, data, or API impact.
> 
> **Overview**
> The desktop **logs viewer** copy action now gives clear success feedback instead of copying silently.
> 
> After a successful clipboard write, the button briefly shows a **check** icon, **"Copied!"** label, and **green** styling via `logs-viewer-btn--copied`, then resets after **2 seconds**. Copy is **async** with error handling so failed writes do not show success. Pending timeouts are cleared on unmount and when copying again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e746b5a6fd8d9dd4d6655f8dd8c40aab3d51275b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->