### PR TITLE
chore: bump node version to rc.47 and desktop to 0.0.44

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.43"
+    "version": "0.0.44"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.10.1-rc.46"
+    "version": "0.10.1-rc.47"
 }


### PR DESCRIPTION
## Summary
- Bumps merod node binary version from `0.10.1-rc.46` to `0.10.1-rc.47` in `merod-config.json`
- Bumps desktop app version from `0.0.43` to `0.0.44` in `apps/desktop/package.json` and `apps/desktop/src-tauri/tauri.conf.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes with no application logic, auth, or data-handling updates.
> 
> **Overview**
> Release alignment only: the bundled **merod** node is pinned from `0.10.1-rc.46` to **`0.10.1-rc.47`** in `merod-config.json`, which drives `prepare-merod` downloads and the compile-time `MEROD_CONFIG_VERSION` in the Tauri app. The **Calimero Desktop** app version is bumped from **0.0.43** to **0.0.44** in `apps/desktop/package.json` and `tauri.conf.json` so the packaged app and updater metadata match the new node release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71ec58ffeffcaa151d5dff8af837501cc9306da9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->