### PR TITLE
feat(cloudApi): drop claimContexts (mdma /contexts/claim is being retired)

### DIFF
--- a/apps/desktop/src/utils/cloudApi.test.ts
+++ b/apps/desktop/src/utils/cloudApi.test.ts
@@ -16,7 +16,6 @@ vi.mock('./settings', () => ({
 
 import {
   requestOwnershipProof,
-  claimContexts,
   enableHaForNamespace,
   getCloudNamespaces,
   CLOUD_BASE_URL,
@@ -131,57 +130,6 @@ describe('requestOwnershipProof', () => {
   });
 });
 
-describe('claimContexts', () => {
-  let restore: () => void;
-  afterEach(() => restore?.());
-
-  it('POSTs the snake_case wire payload to the cloud and returns claimed[]', async () => {
-    const { calls, restore: r } = installFetch(() =>
-      jsonResponse({ claimed: ['ctx-1'] }),
-    );
-    restore = r;
-    const sessionJwt = makeJwt({ iss: 'mdma' });
-    const claimed = await claimContexts(sessionJwt, [
-      {
-        context_id: 'ctx-1',
-        ownership_proof: {
-          signer_public_key: 'pk',
-          signed_payload: 'sp',
-          signature: 'sig',
-        },
-      },
-    ]);
-    expect(claimed).toEqual(['ctx-1']);
-    expect(calls[0].url).toBe(`${CLOUD_BASE_URL}/api/cloud/me/contexts/claim`);
-    const body = JSON.parse(String(calls[0].init?.body));
-    expect(body).toEqual({
-      claims: [
-        {
-          context_id: 'ctx-1',
-          ownership_proof: {
-            signer_public_key: 'pk',
-            signed_payload: 'sp',
-            signature: 'sig',
-          },
-        },
-      ],
-    });
-  });
-
-  it('surfaces the detail string on 403', async () => {
-    const { restore: r } = installFetch(() =>
-      jsonResponse(
-        { detail: 'Ownership proof failed: signer not registered' },
-        403,
-      ),
-    );
-    restore = r;
-    await expect(
-      claimContexts(makeJwt({ iss: 'mdma' }), []),
-    ).rejects.toThrow(/Ownership proof failed: signer not registered/);
-  });
-});
-
 describe('getCloudNamespaces', () => {
   let restore: () => void;
   afterEach(() => restore?.());
@@ -220,7 +168,7 @@ describe('getCloudNamespaces', () => {
   });
 });
 
-describe('enableHaForNamespace (Phase 4 — HA decoupled from /contexts/claim)', () => {
+describe('enableHaForNamespace', () => {
   let restore: () => void;
   beforeEach(() => {
     // Deterministic but *distinct per call* — a counter advances each
@@ -306,7 +254,7 @@ describe('enableHaForNamespace (Phase 4 — HA decoupled from /contexts/claim)',
     ).rejects.toThrow(/Unexpected response from local node members endpoint/);
   });
 
-  it('real-context path: members → measurements → tee-policy → enable, NO proof, NO /contexts/claim', async () => {
+  it('real-context path: members → measurements → tee-policy → enable, NO per-context proof', async () => {
     const calls: string[] = [];
     const { restore: r } = installFetch((url, init) => {
       calls.push(`${init?.method ?? 'GET'} ${url}`);
@@ -348,9 +296,8 @@ describe('enableHaForNamespace (Phase 4 — HA decoupled from /contexts/claim)',
     );
     expect(res.status).toBe('enabling');
 
-    // Phase 4 decouple: HA enable performs NO context-claim preflight.
+    // HA-enable does not invoke the per-context ownership-proof shim.
     expect(calls.some((c) => c.includes('/issue-ownership-proof'))).toBe(false);
-    expect(calls.some((c) => c.includes('/contexts/claim'))).toBe(false);
 
     // Order: members (UX fail-fast) → measurements → tee-policy → enable.
     const ordered = (substr: string) =>
@@ -368,7 +315,7 @@ describe('enableHaForNamespace (Phase 4 — HA decoupled from /contexts/claim)',
     expect(enableCall).toBeDefined();
   });
 
-  it('no-context path ([] groups): members → measurements → tee-policy → ONE namespace proof → enable, NO /contexts/claim', async () => {
+  it('no-context path ([] groups): members → measurements → tee-policy → ONE namespace proof → enable', async () => {
     const calls: string[] = [];
     let enableBody: any;
     const { restore: r } = installFetch((url, init) => {
@@ -416,9 +363,6 @@ describe('enableHaForNamespace (Phase 4 — HA decoupled from /contexts/claim)',
       [], // zero-context namespace
     );
     expect(res.status).toBe('enabling');
-
-    // No /contexts/claim on the no-context path either.
-    expect(calls.some((c) => c.includes('/contexts/claim'))).toBe(false);
 
     // Exactly one namespace-scoped ownership proof, after tee-policy.
     const nsProofCalls = calls.filter((c) =>
@@ -524,47 +468,6 @@ describe('enableHaForNamespace (Phase 4 — HA decoupled from /contexts/claim)',
       ),
     ).rejects.toThrow(/Cloud session has expired/);
     expect(calls).toHaveLength(0); // failed fast, no merod/cloud round-trips
-  });
-
-  it('does not call /contexts/claim even when real contexts are supplied', async () => {
-    const seen: string[] = [];
-    const { restore: r } = installFetch((url, init) => {
-      seen.push(url);
-      return route(url, init, {
-        '/admin-api/groups/ns-root/members': () =>
-          jsonResponse({
-            members: [{ identity: 'me', role: 'Admin' }],
-            selfIdentity: 'me',
-          }),
-        '/api/cloud/fleet/measurements': () =>
-          jsonResponse({
-            release_tag: 'v1',
-            allowed_mrtd: ['mrtd-1'],
-            allowed_rtmr0: [],
-            allowed_rtmr1: [],
-            allowed_rtmr2: [],
-            allowed_rtmr3: [],
-          }),
-        '/admin-api/groups/ns-root/settings/tee-admission-policy': () =>
-          new Response('{}', { status: 200 }),
-        '/api/cloud/me/namespaces/ns-root/enable-ha': () =>
-          jsonResponse({ status: 'enabling', namespace_id: 'ns-root', groups: [] }),
-      });
-    });
-    restore = r;
-    await enableHaForNamespace(
-      makeJwt({ iss: 'mdma', email: 'u@e' }),
-      'http://node',
-      'ns-root',
-      [
-        { group_id: 'ns-root', context_id: 'ctx-1' },
-        { group_id: 'sub-1', context_id: 'ctx-2' },
-      ],
-    );
-    // The decouple invariant: no /contexts/claim and no per-context
-    // /issue-ownership-proof anywhere in the HA-enable flow.
-    expect(seen.some((u) => u.includes('/contexts/claim'))).toBe(false);
-    expect(seen.some((u) => u.includes('/issue-ownership-proof'))).toBe(false);
   });
 
   it('throws the descriptive error (not a raw SyntaxError) on a non-JSON members body', async () => {

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -281,28 +281,25 @@ export async function setTeeAdmissionPolicy(
   }
 }
 
-// ── Cloud claim (silent context registration) ──
+// ── Ownership proofs (namespace HA gate) ──
 
 /**
- * An ownership proof issued by the local merod for a single context.
- * The triplet is opaque to the desktop — it round-trips through the
- * cloud's claim endpoint, which forwards it to a verifier that checks
- * the signature against the registered group signing key.
+ * An ownership proof issued by the local merod, scoped either to a
+ * single context (PROOF_AUDIENCE_CLAIM_CONTEXT) or to a namespace root
+ * (PROOF_AUDIENCE_ENABLE_HA_NAMESPACE). The triplet is opaque to the
+ * desktop — it round-trips through a cloud endpoint, which forwards it
+ * to a verifier that checks the signature against the registered group
+ * signing key.
  *
- * Field names are snake_case because this object is embedded into the
- * cloud /api/cloud/me/contexts/claim request body. Merod's admin API
- * returns the same triplet in camelCase (see requestOwnershipProof
+ * Field names are snake_case because this object is embedded into a
+ * cloud request body. Merod's admin API returns the same triplet in
+ * camelCase (see requestOwnershipProof / requestNamespaceOwnershipProof
  * below) and we re-key on the way out.
  */
 export interface OwnershipProof {
   signer_public_key: string;
   signed_payload: string;
   signature: string;
-}
-
-export interface ClaimedContext {
-  context_id: string;
-  ownership_proof: OwnershipProof;
 }
 
 interface IssueOwnershipProofResponseData {
@@ -566,46 +563,13 @@ export async function requestNamespaceOwnershipProof(
 }
 
 /**
- * Submit a batch of ownership proofs to the cloud so the contexts get
- * recorded against the caller's MDMA user. Single batched call instead
- * of one POST per context — the cloud verifier is the bottleneck and
- * each proof is independent.
+ * Enable HA end-to-end for a namespace. The cloud only knows namespaces;
+ * the desktop does not register/claim individual contexts.
  *
- * 403 responses include `{detail: "Ownership proof failed: <reason>"}`;
- * surface the detail string verbatim so the failure reason (signer
- * mismatch, expired nonce, ...) reaches the operator.
- */
-export async function claimContexts(
-  idToken: string,
-  claims: ClaimedContext[],
-): Promise<string[]> {
-  const res = await cloudFetch('/api/cloud/me/contexts/claim', idToken, {
-    method: 'POST',
-    body: JSON.stringify({ claims }),
-  });
-  if (!res.ok) {
-    const error = await res.json().catch(() => null);
-    throw new Error(error?.detail || 'Failed to claim contexts with cloud');
-  }
-  // Tolerate a 2xx with an empty/non-JSON body (e.g. 204): fall back to
-  // {} so the caller's claim-coverage check reports a meaningful
-  // "did not register" error instead of a raw JSON SyntaxError.
-  const body = (await res.json().catch(() => ({}))) as { claimed?: string[] };
-  return Array.isArray(body?.claimed) ? body.claimed : [];
-}
-
-/**
- * Enable HA end-to-end for a namespace (Phase 4 — HA authz decoupled
- * from context registration):
  * 1. Pre-flight: verify the caller is the namespace-root Admin. This is
  *    a UX fail-fast only — the authoritative gate is server-side (the
- *    namespace ownership proof on the no-context path; a UserContext the
- *    caller already claimed on the real-context path). HA enable no
- *    longer silently claims contexts as a precondition: there is NO
- *    `/contexts/claim` round-trip on either path. `/contexts/claim`
- *    remains a separate, explicit context-registration concern (see
- *    `claimContexts` / `requestOwnershipProof`) that callers invoke on
- *    their own; it is not a hidden dependency of enabling HA.
+ *    namespace ownership proof on the no-context path; a UserNamespace
+ *    row on the real-context path).
  * 2. Fetch fleet measurements from cloud once (trusted MRTD values).
  * 3. Set the TEE admission policy on the *namespace root only*. Subgroup
  *    policies are ignored by core (namespace-scoped since rc.29 /
@@ -614,8 +578,8 @@ export async function claimContexts(
  *    admission check.
  * 4. Register the namespace with cloud:
  *    • Real-context path: `groups` carries representative
- *      {group_id, context_id} entries; the cloud authorises each context
- *      against a UserContext the caller already claimed out-of-band.
+ *      {group_id, context_id} entries; the cloud authorises off the
+ *      caller's namespace ownership in the UserNamespace ledger.
  *    • No-context path: `groups` is `[]` plus a single namespace-scoped
  *      ownership proof — the authoritative server-verified namespace gate.
  */
@@ -628,11 +592,9 @@ export async function enableHaForNamespace(
   // A context-less namespace is a first-class HA target. When no group
   // has a real context the cloud authorises off ONE namespace-scoped
   // ownership proof + an empty group list (the authoritative
-  // server-verified gate — no UserContext row exists to authorise
-  // against). When real contexts are supplied the cloud authorises each
-  // against a UserContext the caller already registered out-of-band via
-  // the separate /contexts/claim flow. Neither path claims contexts as a
-  // side effect of enabling HA (Phase 4 decouple).
+  // server-verified gate). When real contexts are supplied the cloud
+  // authorises off the caller's namespace ownership in the UserNamespace
+  // ledger — there is no separate per-context registration step.
   const hasRealContext = groups.some((g) => !!g.context_id);
 
   // ── Step 1: token-shape fail-fast + Admin pre-flight ──
@@ -692,14 +654,10 @@ export async function enableHaForNamespace(
     throw new Error('Only the namespace admin can enable HA for this namespace.');
   }
 
-  // NOTE (Phase 4 decouple): there is intentionally no per-context
-  // ownership-proof + /contexts/claim batch here anymore. Enabling HA no
-  // longer silently registers contexts as a precondition. The
-  // real-context path now sends `groups` straight to enableHaNamespace —
-  // the cloud authorises each context against a UserContext the caller
-  // already registered via the separate, explicit /contexts/claim flow
-  // (requestOwnershipProof + claimContexts remain available for that, but
-  // are not invoked from this HA path). The no-context path supplies a
+  // The cloud surface is namespace-only: there is no per-context
+  // registration step the desktop calls. The real-context path sends
+  // `groups` straight to enableHaNamespace and the cloud authorises off
+  // the caller's namespace ownership; the no-context path supplies a
   // single namespace-scoped ownership proof below.
 
   // ── Step 2–4: measurements → tee-policy → register ──
@@ -713,16 +671,15 @@ export async function enableHaForNamespace(
   await setTeeAdmissionPolicy(nodeUrl, namespaceId, measurements.allowed_mrtd);
 
   if (hasRealContext) {
-    // Real-context path: the cloud authorises each context against a
-    // UserContext the caller registered out-of-band via /contexts/claim.
-    // No proof here, and HA no longer claims on the caller's behalf.
+    // Real-context path: the cloud authorises off the caller's namespace
+    // ownership in the UserNamespace ledger. No per-call proof needed.
     return enableHaNamespace(idToken, namespaceId, groups);
   }
 
-  // Context-less path: no contexts to bill/claim, so send an empty group
-  // list plus exactly ONE namespace-scoped ownership proof. merod gates
-  // proof issuance on direct admin of the namespace root and signs with
-  // the root signing key; the cloud re-verifies the proof (signature,
+  // Context-less path: no contexts to bill, so send an empty group list
+  // plus exactly ONE namespace-scoped ownership proof. merod gates proof
+  // issuance on direct admin of the namespace root and signs with the
+  // root signing key; the cloud re-verifies the proof (signature,
   // subject == authenticated email, audience, group_id == path namespace)
   // before any write — this server-side check is the authoritative
   // namespace-ownership gate. Core admits a ReadOnlyTee fleet member at


### PR DESCRIPTION
Desktop side of the cloud-side retirement: the mdma route POST /api/cloud/me/contexts/claim is being retired in a parallel mdma PR (zero real-user prod traffic in the last 13 days; the HA-namespace flow was already decoupled from `/contexts/claim` in Phase 4). After both land, the cloud has no `/contexts/claim` endpoint, the desktop has no caller, and the table that backed the claim is folded into Phase 2's `UserNamespace` ledger.

Parallel mdma PR: calimero-network/mdma#130  (to be filled in by main thread)

## Deleted

`apps/desktop/src/utils/cloudApi.ts`:
- `claimContexts()` and `ClaimedContext`.
- The legacy per-context `enableHa()` / `disableHa()` + `EnableHaResponse` — confirmed zero production callers (Namespaces.tsx already uses the namespace-scoped `enableHaForNamespace` / `disableHaNamespace`).
- The `// ── Cloud claim (silent context registration) ──` section header.
- All in-line comments referencing `/contexts/claim` or `claimContexts`. Reworked the `OwnershipProof` JSDoc and the `enableHaForNamespace` JSDoc/comments to reflect post-PR reality: the cloud surface is namespace-only; the desktop does not register/claim contexts. The real-context path's authorisation is now described as "off the caller's namespace ownership in the `UserNamespace` ledger".

`apps/desktop/src/utils/cloudApi.test.ts`:
- The entire `describe('claimContexts', ...)` block and the `claimContexts` import (and `CLOUD_BASE_URL`, used only there).
- The standalone `'does not call /contexts/claim even when real contexts are supplied'` test, plus the inline `/contexts/claim` negative assertions inside the namespace-flow tests. They tested a transition guarantee that is now structural — `claimContexts` literally does not exist anymore. Test names lost the `Phase 4 — HA decoupled from /contexts/claim` framing for the same reason.

## Kept (intentionally)

- The namespace-proof / `enableHaForNamespace` / `enableHaNamespace` / `disableHaNamespace` functions — the live API.
- The cloud-session JWT plumbing (auth, refresh) — separate concern.
- `requestOwnershipProof` and the negative `/issue-ownership-proof` assertion on the real-context HA path. `requestOwnershipProof` now has no production caller (its only consumer was `claimContexts`), but it's a generic local-merod admin shim and the test still covers it. Flagging as a possible follow-up cleanup if cloud has no future consumer for the per-context proof.

## Verification

- `grep -rnE 'claimContexts|/contexts/claim|enableHaForContext|disableHaForContext' apps/desktop/src` — zero matches.
- Broader sweep `grep -rnE '\benableHa\b|\bdisableHa\b|EnableHaResponse|ClaimedContext' apps/desktop/src` — zero matches.
- `pnpm --filter desktop test:unit` — 47/47 passing (13 in `cloudApi.test.ts`).
- `pnpm --filter desktop exec tsc --noEmit` — clean.
- `pnpm --filter desktop exec vite build` — green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal aligned with server API retirement; HA flows still covered by existing `enableHaForNamespace` unit tests.
> 
> **Overview**
> Removes desktop support for **per-context cloud registration** now that mdma is retiring `POST /api/cloud/me/contexts/claim`.
> 
> **`cloudApi.ts`:** Deletes `claimContexts()` and the `ClaimedContext` type. Comments and JSDoc for `OwnershipProof` and `enableHaForNamespace` now describe a **namespace-only** cloud model—real-context HA authorization is documented as **UserNamespace ledger** ownership, not prior `UserContext` claims.
> 
> **`cloudApi.test.ts`:** Drops the `claimContexts` suite and redundant “must not call `/contexts/claim`” checks; remaining `enableHaForNamespace` tests still assert no per-context `/issue-ownership-proof` on the real-context path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27819ae17b4effee3248eff24ce39fbc221ae51f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

