### PR TITLE
chore: bump desktop to 0.0.45 and merod to 0.10.1-rc.47

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.44"
+    "version": "0.0.45"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.10.1-rc.46"
+    "version": "0.10.1-rc.47"
 }


### PR DESCRIPTION
## Summary
- Desktop version: `0.0.44` → `0.0.45` (`apps/desktop/package.json`, `apps/desktop/src-tauri/tauri.conf.json`)
- Merod binary: `0.10.1-rc.46` → `0.10.1-rc.47` (`merod-config.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only bumps with no application logic changes; next build will pull the new merod RC.
> 
> **Overview**
> Bumps the **Calimero Desktop** release identity from `0.0.44` to **`0.0.45`** in `apps/desktop/package.json` and `apps/desktop/src-tauri/tauri.conf.json` so npm and Tauri package metadata stay aligned for builds and the configured Tauri updater.
> 
> Updates **`merod-config.json`** from `0.10.1-rc.46` to **`0.10.1-rc.47`**, which drives which `calimero-network/core` release `prepare-merod` fetches and the compile-time `MEROD_CONFIG_VERSION` embedded for runtime merod version checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f81e361f169db1ac485c915158718d73f69bd6bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->