### PR TITLE
fix(desktop): clear session tokens on full reset

### DIFF
--- a/apps/desktop/src/utils/settings.ts
+++ b/apps/desktop/src/utils/settings.ts
@@ -1,3 +1,5 @@
+import { clearAllTokens } from '../lib/token-storage';
+
 export interface AppSettings {
   nodeUrl: string;
   authUrl?: string; // Optional, defaults to nodeUrl if not set
@@ -126,8 +128,12 @@ export function clearSettings(): void {
 const THEME_KEY = 'calimero-desktop-theme';
 
 /**
- * Clear all app data (settings + theme + onboarding progress + cache). Use with stopMerod() for full reset.
- * Caller should reload the app after this.
+ * Clear all app data (settings + theme + onboarding progress + cache + session tokens).
+ * Use with stopMerod() for full reset. Caller should reload the app after this.
+ *
+ * Note: localStorage is partitioned per web origin, so this only clears the silo of the
+ * origin it runs in. Loaded app UIs served from other origins (each node URL is a distinct
+ * origin) keep their own tokens — wiping those requires clearing WebsiteData on disk.
  */
 export function clearAllAppData(): void {
   localStorage.removeItem(SETTINGS_KEY);
@@ -135,6 +141,11 @@ export function clearAllAppData(): void {
   localStorage.removeItem('calimero-onboarding-progress');
   localStorage.removeItem('calimero-autostart-default-applied');
   localStorage.removeItem('calimero-marketplace-cache');
+  localStorage.removeItem('calimero-error-log');
+  // Session tokens were left behind on reset, so a "reset" still resumed the old
+  // authenticated session against the node. Clear them too.
+  localStorage.removeItem('calimero-auth-tokens');
+  clearAllTokens();
 }
 
 


### PR DESCRIPTION
## Problem

\"Reset node and all settings\" and \"Total Nuke\" don't fully clean up localStorage — the **session survives a reset**, so the app resumes the previous authenticated session against the node. This is the reported \"deletion doesn't clean up localStorage\" behaviour.

`clearAllAppData()` (`apps/desktop/src/utils/settings.ts`) cleared settings, theme, onboarding, autostart and marketplace cache, but left behind:

- `calimero_access_token`
- `calimero_refresh_token`
- `calimero_token_expires_at`
- `calimero-auth-tokens` (legacy key)
- `calimero-error-log`

`clearAllTokens()` already existed in `apps/desktop/src/lib/token-storage.ts` but was never wired into the reset path.

## Fix

- Import and call `clearAllTokens()` from `clearAllAppData()`.
- Remove the remaining stale keys (`calimero-auth-tokens`, `calimero-error-log`).

## Known limitation (documented in code)

localStorage is **partitioned per web origin**. On disk this shows up as multiple silos under `~/Library/WebKit/network.calimero.desktop/WebsiteData/`, one per node URL / loaded app UI — each with its own token set (`mero-tokens`, `calimero_group_*`, a second `calimero_access_token`, etc.).

`clearAllAppData()` runs JS in a single origin, so it can only clear that origin's silo. Fully wiping sessions across all node-URL origins requires clearing WebKit `WebsiteData` on disk from the Rust side — left as a follow-up; noted in a code comment so it isn't lost.

## Test plan

- [ ] Log in, then hit \"Reset node and all settings\" → confirm `calimero_access_token` / `calimero_refresh_token` / `calimero_token_expires_at` are gone and the app returns to a logged-out state.
- [ ] \"Total Nuke\" → same, plus `~/.calimero` removed.
- [x] `tsc --noEmit` clean for touched files (pre-existing unrelated errors in `Namespaces.tsx` and `*.test.ts` remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local-only logout/reset behavior in desktop settings; no server auth or payment logic changed.
> 
> **Overview**
> **Reset flows now clear auth-related localStorage**, so “Reset node and all settings” / “Total Nuke” no longer leave the user logged in against the node.
> 
> `clearAllAppData()` now removes `calimero-error-log` and legacy `calimero-auth-tokens`, and calls **`clearAllTokens()`** (access/refresh/expiry keys). Docs note that **only the current web origin’s** localStorage is cleared; tokens in other node/app origins need a separate WebKit **WebsiteData** wipe (follow-up).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7e229d519698f30fb43df393326239d310a8311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->