### PR TITLE
feat(namespaces): evict TEE members from local merod on HA disable (closes #106)

### DIFF
--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -61,6 +61,24 @@ function parseApiError(e: any): string {
 
 const DEFAULT_NAMESPACE_CAPABILITIES = 1 | 2 | 8;
 
+/**
+ * Extract the `members` array from a merod `/admin-api/groups/{ns}/members`
+ * response. Mero-js's admin response shape varies across versions —
+ * direct `members` array on some routes, wrapped `data.members` on
+ * others — so both sites that consume this endpoint (the list-members
+ * useEffect and the post-disable eviction helper) hit the dual-path
+ * lookup. Centralised here so a future shape change is one edit.
+ *
+ * Returns `null` (not `[]`) when the response shape is unrecognised,
+ * so callers can distinguish "no members" from "couldn't tell" and
+ * fail closed where appropriate. tauri-app#107 v4 review.
+ */
+function extractMembersFromResponse(json: unknown): unknown[] | null {
+  const raw = (json as { members?: unknown; data?: { members?: unknown } })?.members
+    ?? (json as { data?: { members?: unknown } })?.data?.members;
+  return Array.isArray(raw) ? raw : null;
+}
+
 interface InstalledApp {
   id: string;
   name: string;
@@ -125,8 +143,7 @@ export default function Namespaces() {
     })
       .then((r) => { if (!r.ok) throw new Error(`${r.status}`); return r.json(); })
       .then((json) => {
-        const members = json?.members ?? json?.data?.members ?? [];
-        setNsMembers(Array.isArray(members) ? members : []);
+        setNsMembers(extractMembersFromResponse(json) ?? []);
       })
       .catch((e) => { if (e?.name !== 'AbortError') setNsMembers([]); })
       .finally(() => setNsMembersLoading(false));
@@ -323,6 +340,116 @@ export default function Namespaces() {
     }
   };
 
+  /**
+   * Evict every `ReadOnlyTee` member from the owner's local merod state for
+   * the given namespace. Called after a successful cloud `disable-ha` so the
+   * owner publishes `MemberRemoved` over gossip (which fires the existing
+   * key-rotation pipeline, granting forward secrecy on new namespace writes
+   * by excluding the evicted peer from the wrapped new key) and the fleet
+   * node's merod receives the eviction event.
+   *
+   * Auth: uses the **local node access token** (`getAccessToken()`), NOT
+   * the cloud session token. The admin API at `${settings.nodeUrl}/admin-api`
+   * lives on the user's own merod process and authenticates against its
+   * own token. v1 of this helper threaded the cloud token here by mistake
+   * (mirroring the wrong useEffect; the canonical list-members useEffect
+   * uses `getAccessToken()`). Caught in tauri-app#107 review.
+   *
+   * Best-effort: failures fall into two distinct buckets that the caller
+   * differentiates in the toast — `listFailed` (couldn't enumerate TEE
+   * members at all) vs `failed` (a specific remove call errored). Auto-
+   * retry is NOT available: by the time this runs, `haEnabled` has
+   * already flipped to false, so the disable branch can't be re-clicked.
+   * The user has to re-enable HA and disable again, or restart the
+   * desktop, to retry. The toast says so honestly.
+   *
+   * The list-members fetch has a 5s `AbortSignal.timeout` so a hung
+   * merod doesn't block the disable flow indefinitely.
+   *
+   * See: tauri-app#106, core ADR 0002, core PR #2653.
+   */
+  const evictTeeMembersAfterDisable = async (
+    nsId: string,
+  ): Promise<{ evicted: number; failed: number; listFailed: boolean }> => {
+    // Fail closed on every pre-flight that means "we couldn't check what
+    // was local" (mero client not ready, nodeUrl unconfigured, no node
+    // token). The toast then honestly says cleanup is pending instead
+    // of claiming success. tauri-app#107 v3 review (cursor + meroreviewer).
+    if (!mero) return { evicted: 0, failed: 0, listFailed: true };
+    const settings = getSettings();
+    if (!settings.nodeUrl) return { evicted: 0, failed: 0, listFailed: true };
+    const nodeToken = getAccessToken();
+    if (!nodeToken) return { evicted: 0, failed: 0, listFailed: true };
+
+    let teeMembers: { identity: string }[];
+    try {
+      const resp = await fetch(
+        `${settings.nodeUrl}/admin-api/groups/${encodeURIComponent(nsId)}/members`,
+        {
+          headers: { Authorization: `Bearer ${nodeToken}` },
+          signal: AbortSignal.timeout(5000),
+        },
+      );
+      if (!resp.ok) {
+        console.warn(
+          `evictTeeMembersAfterDisable: list-members http=${resp.status} for ns=${nsId} — cleanup pending`,
+        );
+        return { evicted: 0, failed: 0, listFailed: true };
+      }
+      const json = await resp.json();
+      // Fail closed on bad shape: missing or non-array `members` means
+      // we can't tell what role each entry has, so we cannot safely
+      // report "no TEE peers present" — we don't know. Treat as
+      // `listFailed`. The dual-path response normalisation lives in
+      // `extractMembersFromResponse` (top of file). tauri-app#107 v3
+      // review (cursor "Bad members body skips eviction") + v4 DRY.
+      const raw = extractMembersFromResponse(json);
+      if (raw === null) {
+        console.warn(
+          `evictTeeMembersAfterDisable: list-members body had no array \`members\` field for ns=${nsId} — cleanup pending`,
+        );
+        return { evicted: 0, failed: 0, listFailed: true };
+      }
+      teeMembers = raw
+        .filter(
+          (m: unknown): m is { identity: string; role: string } =>
+            typeof (m as { identity?: unknown })?.identity === 'string'
+            && (m as { role?: unknown })?.role === 'ReadOnlyTee',
+        )
+        .map((m) => ({ identity: m.identity }));
+    } catch (e) {
+      // Don't log the raw error object — it may contain headers/URL with
+      // the bearer token. Log a redacted summary instead.
+      console.warn(
+        `evictTeeMembersAfterDisable: list-members fetch threw for ns=${nsId} (${(e as Error)?.name ?? 'unknown'})`,
+      );
+      return { evicted: 0, failed: 0, listFailed: true };
+    }
+
+    if (teeMembers.length === 0) {
+      return { evicted: 0, failed: 0, listFailed: false };
+    }
+
+    let evicted = 0;
+    let failed = 0;
+    for (const m of teeMembers) {
+      try {
+        await mero.admin.removeGroupMembers(nsId, { members: [m.identity] });
+        evicted += 1;
+      } catch (e) {
+        // Truncate the identity (cryptographic public-key string) in the
+        // log: enough prefix to correlate with admin tooling, not enough
+        // to be a tracking primitive on its own. tauri-app#107 v3 review.
+        const idShort = `${m.identity.slice(0, 8)}…`;
+        console.warn(
+          `evictTeeMembersAfterDisable: remove failed for ns=${nsId} identity=${idShort} (${(e as Error)?.name ?? 'unknown'})`,
+        );
+        failed += 1;
+      }
+    }
+    return { evicted, failed, listFailed: false };
+  };
+
   const handleJoinNamespace = async (invitationText: string) => {
     if (!mero) return;
     setActionLoading(true);
@@ -395,7 +522,51 @@ export default function Namespaces() {
       if (isEnabled) {
         await disableHaNamespace(token, nsId);
         setHaEnabled((prev) => ({ ...prev, [nsId]: false }));
-        toast.success('HA disabled — TEE nodes will stop replicating');
+        // Cloud-side disable is done; now evict any admitted TEE members
+        // from this owner's local merod. Without this, `MemberRemoved` is
+        // never published, no key rotation fires, and the fleet node
+        // remains a `ReadOnlyTee` member of our local group state
+        // indefinitely (see tauri-app#106 + core ADR 0002).
+        const evictResult = await evictTeeMembersAfterDisable(nsId);
+        // Refresh the Members list if any remove call ran (success OR
+        // failure). On `failed > 0` the store state could still have
+        // changed in mero before the failure, and refetching reflects
+        // truth. On pure `listFailed` we have no removals to mirror, so
+        // skip the refresh. Mirrors the `handleRemoveMember` pattern.
+        // tauri-app#107 v3 review (cursor) + v5 review (defensive
+        // `failed > 0` arm per meroreviewer).
+        if (evictResult.evicted > 0 || evictResult.failed > 0) {
+          setNsMembersVersion((v) => v + 1);
+          refetchGroupMembers?.();
+        }
+        // Toast tiers — honest about what happened and what the user can do:
+        //   * everything succeeded → standard success
+        //   * list-members fetch failed → cloud is disabled but we don't
+        //     know what's local; user must re-enable + disable or restart
+        //     to retry (no auto-retry exists because haEnabled is already
+        //     false, so the disable branch is no longer reachable from
+        //     this UI control — tauri-app#107 review)
+        //   * partial per-member failure → same retry caveat applies
+        //   * zero TEE members found locally → nothing to evict (fleet
+        //     never admitted before disable, or gossip hadn't propagated)
+        if (evictResult.listFailed) {
+          toast.success(
+            'HA disabled cloud-side. Local membership cleanup failed — ' +
+              're-enable then disable HA, or restart the desktop, to retry.',
+          );
+        } else if (evictResult.failed > 0) {
+          toast.success(
+            `HA disabled — ${evictResult.evicted} TEE member(s) evicted, ` +
+              `${evictResult.failed} cleanup failed. Re-enable then disable HA to retry.`,
+          );
+        } else if (evictResult.evicted > 0) {
+          toast.success(
+            `HA disabled — ${evictResult.evicted} TEE member(s) evicted; ` +
+              'forward secrecy applied via key rotation',
+          );
+        } else {
+          toast.success('HA disabled — TEE nodes will stop replicating');
+        }
       } else {
         const rootCtxs = await mero.admin
           .listGroupContexts(nsId)


### PR DESCRIPTION
## Summary

Closes **#106**. After a successful cloud `disable-ha`, evict every `ReadOnlyTee` member from the owner's local merod state for the namespace. Triggers the existing `MemberRemoved` key-rotation pipeline (forward secrecy on new writes) and, in combination with the core self-purge listener (calimero-network/core#2653), propagates the cleanup to the fleet node's on-disk state.

Without this change, `disable-ha` was cloud-only: cloud state flipped, but the fleet TEE node remained a `GroupMember{ReadOnlyTee}` on the owner's local merod indefinitely. `list_group_members` kept returning it. Verified on prod 2026-06-01 against namespace `169bc523…`.

## What changes

Single file: `apps/desktop/src/pages/Namespaces.tsx`.

- New helper `evictTeeMembersAfterDisable(nsId, cloudToken)`:
  - Fetches members via the local merod admin API (mirrors the existing raw-fetch pattern at line ~121 — the TODO there is about the mero-react hook wrapper, not the underlying admin call).
  - Filters to entries with `role === 'ReadOnlyTee'`.
  - For each, calls `mero.admin.removeGroupMembers(nsId, { members: [identity] })`.
  - Returns `{evicted, failed}` counts.
- Called inside `toggleHa`'s disable branch after `disableHaNamespace(token, nsId)` succeeds.
- Toast updated to report the eviction outcome:
  - `n` evicted, `0` failed → "HA disabled — n TEE member(s) evicted; forward secrecy applied via key rotation"
  - `n` evicted, `m` failed → "HA disabled — n TEE member(s) evicted, m cleanup pending (will retry on next disable)"
  - 0 evicted, 0 failed → "HA disabled — TEE nodes will stop replicating" (unchanged from before)

## Why best-effort

Cloud state is already disabled by the time the eviction runs, so partial success is acceptable:
- `removeGroupMembers` is idempotent (no-op if the member is already gone), so a subsequent disable click cleanly retries any failed entries.
- Listing-members fetch failure is also OK — the next disable retry will try again. Documented in the helper's docstring and inline in the toast.

## How this composes with the rest of the cleanup chain

```
tauri click "disable HA"
  ├─ POST /api/cloud/me/namespaces/{ns}/disable-ha (mdma flips HaRequest + HaContextStatus to disabled)
  └─ THIS PR: list members, filter ReadOnlyTee, remove each
       ↓
       merod publishes MemberRemoved over gossip
         ├─ Key rotation: new group key wrapped for everyone except evicted (already in core)
         ├─ Owner's local: drops GroupMember row, adds to deny_list (already in core)
         └─ Fleet's local: receives gossip → core PR #2653 listener fires → drops signing keys, gov ops, namespace identity, full subtree cascade
```

## Tests

- `pnpm --filter desktop test:unit` — 50/50 pass (no test changes; existing suite still green).
- `tsc --noEmit` — clean.

End-to-end smoke is gated on this PR + core #2653 + the next desktop release. Once both land:

1. Enable HA on a fresh namespace via tauri.
2. Verify TEE fleet node admits (working recipe).
3. Disable HA via tauri.
4. Verify on the fleet node: `GET /admin-api/dev/groups/{ns}/members` returns empty, namespace identity gone, no residual signing keys.

## Failure handling

Three failure modes, all non-blocking:

| Scenario | UX | Recovery |
|---|---|---|
| List-members fetch fails (network, merod busy) | Toast: "cleanup pending; will retry on next disable" | Next disable click re-lists, re-removes |
| Per-peer `removeGroupMembers` fails (rare, e.g. owner key issue) | Toast reports `n` evicted + `m` failed | Same — next disable click retries the failed ones |
| No TEE members locally (e.g. fleet never admitted before disable) | Toast: "HA disabled — TEE nodes will stop replicating" (original copy) | Nothing to do; cloud state is the source of truth |

## Out of scope

- Hard local purge of encrypted blobs on the evicted fleet TEE node. Tracked separately as ADR 0002's "soft-vs-hard local cleanup" deferred decision. Forward secrecy on new writes is already given by the key rotation; the historical-blob retention is hygiene only and gated on a compliance/threat-model trigger.
- KMS-side key invalidation. ADR 0002 Tier C — deferred.

## Related

- core #2653 — fleet-side self-purge listener (the counterpart that drops the fleet's on-disk state when this PR publishes `MemberRemoved`)
- core ADR 0002 — architectural framing for the post-eviction cleanup work
- mdma#155 — cloud-side issue that surfaced the gap
- mdma#149 — sibling cleanup gap (cross-user HA tombstone transfer drift)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes namespace membership and crypto-related eviction after HA disable; mistakes could leave TEE peers admitted or mis-report cleanup, though scope is one UI flow with fail-closed listing.
> 
> **Overview**
> After cloud **disable HA** succeeds, the desktop now **evicts `ReadOnlyTee` members from the owner’s local merod** so `MemberRemoved` gossip and key rotation can run—fixing the case where fleet nodes stayed in local group state indefinitely.
> 
> A shared **`extractMembersFromResponse`** normalizes varying admin `members` JSON shapes and **fails closed** (`null`) when the body is unrecognized. **`evictTeeMembersAfterDisable`** lists members via the **local node token** (5s timeout), removes each TEE peer with `removeGroupMembers`, and returns **`listFailed` / per-member `failed`** counts. The HA disable path shows **tiered toasts** and refreshes the members UI when any remove was attempted; cleanup retry is documented as **re-enable then disable HA** (or restart), since the UI no longer offers a repeat disable click.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06d8925c8290c91f95f2f3935228be36864e6d79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->