### PR TITLE
chore: bump version to 0.0.46

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.45"
+    "version": "0.0.46"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.1"
+    "version": "0.11.0-rc.2"
 }

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.10.1-rc.47"
+    "version": "0.11.0-rc.1"
 }


### PR DESCRIPTION
## Summary
- Bumps desktop app version from 0.0.45 to 0.0.46 in package.json and tauri.conf.json

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes with no application logic; the merod bump may affect node/runtime behavior at release time.
> 
> **Overview**
> Bumps the **Calimero Desktop** release from **0.0.45** to **0.0.46** in `apps/desktop/package.json` and `apps/desktop/src-tauri/tauri.conf.json` so npm and Tauri packaging stay aligned.
> 
> Also updates **`merod-config.json`** to pin the bundled **merod** binary from **0.10.1-rc.47** to **0.11.0-rc.2**, which affects what `merod:prepare` pulls into the desktop bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05729552208f13cd77576e97d85766cd181e89e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->