### PR TITLE
feat(marketplace): version picker to install a specific (older) version (#2539)

### DIFF
--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -93,7 +93,8 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
         }
       });
     return () => { cancelled = true; };
-  }, [selectedApp?.id, selectedApp?.registry]);
+    // toast.error is a stable useCallback ref; the whole `toast` object is not.
+  }, [selectedApp?.id, selectedApp?.registry, toast.error]);
 
   // -----------------------------------------------------------------------
   // Helper: build MarketplaceApp[] from raw registry results + installed set

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/tauri";
 import { getSettings } from "../utils/settings";
-import { fetchAppsFromAllRegistries, recordDownload, type AppSummary } from "../utils/registry";
+import { fetchAppsFromAllRegistries, fetchAppVersions, recordDownload, type AppSummary, type VersionInfo } from "../utils/registry";
 import { apiClient } from "../lib/mero-client";
 import { decodeMetadata } from "../utils/appUtils";
 import {
@@ -38,6 +38,10 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
   // Track whether a background refresh is in progress (no skeleton shown)
   const [refreshing, setRefreshing] = useState(false);
   const [selectedApp, setSelectedApp] = useState<MarketplaceApp | null>(null);
+  // Version picker for the detail modal: the versions the registry offers for
+  // the open app, and which one Install will fetch (defaults to latest).
+  const [availableVersions, setAvailableVersions] = useState<VersionInfo[]>([]);
+  const [selectedVersion, setSelectedVersion] = useState<string>("");
   const mountedRef = useRef(true);
 
   // Cleanup on unmount
@@ -52,6 +56,22 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
       loadInstalledApps();
     }
   }, [clientReady]);
+
+  // Load the open app's published versions for the picker; default the
+  // selection to its latest. Cleared when the modal closes.
+  useEffect(() => {
+    if (!selectedApp) {
+      setAvailableVersions([]);
+      setSelectedVersion("");
+      return;
+    }
+    setSelectedVersion(selectedApp.latest_version);
+    let cancelled = false;
+    fetchAppVersions(selectedApp.registry, selectedApp.id)
+      .then((vs) => { if (!cancelled) setAvailableVersions(vs); })
+      .catch(() => { if (!cancelled) setAvailableVersions([]); });
+    return () => { cancelled = true; };
+  }, [selectedApp]);
 
   // -----------------------------------------------------------------------
   // Helper: build MarketplaceApp[] from raw registry results + installed set
@@ -272,12 +292,13 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
     return sorted;
   }, [apps, filterInstalled, searchQuery]);
 
-  const handleInstall = async (app: MarketplaceApp) => {
+  const handleInstall = async (app: MarketplaceApp, version: string = app.latest_version) => {
     setInstallingAppId(app.id);
     try {
-      // Fetch the manifest to get the WASM artifact URL
+      // Fetch the manifest to get the WASM artifact URL. `version` defaults to
+      // the latest, but the detail modal lets the user pick an older one.
       const { fetchAppManifest } = await import("../utils/registry");
-      const manifest = await fetchAppManifest(app.registry, app.id, app.latest_version);
+      const manifest = await fetchAppManifest(app.registry, app.id, version);
       
       
       // Handle both v1 format (artifact) and v2 format (artifacts array)
@@ -345,7 +366,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
       const metadata = {
         name: app.name,
         description: manifest.metadata?.description || "",
-        version: app.latest_version,
+        version,
         developer: app.developer_pubkey,
         minRuntimeVersion: manifest.minRuntimeVersion,
       };
@@ -385,7 +406,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
       toast.success(`${app.alias || app.name} installed successfully!`);
 
       // Record download with registry (fire-and-forget)
-      recordDownload(app.registry, app.id, app.latest_version);
+      recordDownload(app.registry, app.id, version);
 
       // Update just the changed card — no full reload, no flicker.
       // loadInstalledApps updates installedAppIds, which the sync useEffect
@@ -645,6 +666,26 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
                 <span className="modal-meta-value">{(selectedApp.downloads ?? 0).toLocaleString()}</span>
               </div>
               <div className="modal-meta-row">
+                <span className="modal-meta-label">Version</span>
+                {availableVersions.length > 1 ? (
+                  <select
+                    className="modal-version-select"
+                    value={selectedVersion}
+                    onChange={(e) => setSelectedVersion(e.target.value)}
+                    disabled={installingAppId === selectedApp.id || selectedApp.installed}
+                    data-testid="version-picker"
+                  >
+                    {availableVersions.map((v) => (
+                      <option key={v.semver} value={v.semver}>
+                        {v.semver === selectedApp.latest_version ? `${v.semver} (latest)` : v.semver}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <span className="modal-meta-value">v{selectedVersion || selectedApp.latest_version}</span>
+                )}
+              </div>
+              <div className="modal-meta-row">
                 <span className="modal-meta-label">Registry</span>
                 <button
                   className="modal-meta-link"
@@ -666,7 +707,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
                 </button>
               ) : (
                 <button
-                  onClick={() => handleInstall(selectedApp)}
+                  onClick={() => handleInstall(selectedApp, selectedVersion || selectedApp.latest_version)}
                   className="button button-primary"
                   disabled={installingAppId === selectedApp.id}
                 >

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -76,7 +76,15 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
     setVersionsLoading(true);
     let cancelled = false;
     fetchAppVersions(selectedApp.registry, selectedApp.id)
-      .then((vs) => { if (!cancelled) { setAvailableVersions(vs); setVersionsLoading(false); } })
+      .then((vs) => {
+        if (!cancelled) {
+          setAvailableVersions(vs);
+          // Use the newest non-yanked version from the registry (may differ from
+          // the listing row's latest_version if that version is yanked).
+          setSelectedVersion(vs[0]?.semver ?? selectedApp.latest_version);
+          setVersionsLoading(false);
+        }
+      })
       .catch(() => {
         if (!cancelled) {
           setAvailableVersions([]);
@@ -685,7 +693,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
                   <span className="modal-meta-value modal-versions-loading">
                     <RefreshCw size={12} className="spinning" /> Loading…
                   </span>
-                ) : availableVersions.length > 0 ? (
+                ) : availableVersions.length > 1 ? (
                   <select
                     className="modal-version-select"
                     value={selectedVersion}
@@ -695,7 +703,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
                   >
                     {availableVersions.map((v) => (
                       <option key={v.semver} value={v.semver}>
-                        {v.semver === selectedApp.latest_version ? `${v.semver} (latest)` : v.semver}
+                        {v.semver === availableVersions[0]?.semver ? `${v.semver} (latest)` : v.semver}
                       </option>
                     ))}
                   </select>
@@ -725,7 +733,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
                 </button>
               ) : (
                 <button
-                  onClick={() => handleInstall(selectedApp, selectedVersion)}
+                  onClick={() => handleInstall(selectedApp, selectedVersion || selectedApp.latest_version)}
                   className="button button-primary"
                   disabled={installingAppId === selectedApp.id}
                 >

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -608,7 +608,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
                       </button>
                     ) : (
                       <button
-                        onClick={() => handleInstall(app)}
+                        onClick={() => setSelectedApp(app)}
                         className="button button-primary"
                         disabled={installingAppId === app.id}
                       >

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -59,14 +59,17 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
 
   // Load the open app's published versions for the picker; default the
   // selection to its latest. Cleared when the modal closes.
-  // Depends on selectedApp?.id (not the full object) so patching installed:true
+  // Depends on id+registry (not the full object) so patching installed:true
   // after an install doesn't re-run this and reset the user's version pick.
+  // Registry is included so the same package id from a different registry
+  // gets a fresh version list.
   useEffect(() => {
     if (!selectedApp) {
       setAvailableVersions([]);
       setSelectedVersion("");
       return;
     }
+    setAvailableVersions([]);
     setSelectedVersion(selectedApp.latest_version);
     let cancelled = false;
     fetchAppVersions(selectedApp.registry, selectedApp.id)
@@ -78,7 +81,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
         }
       });
     return () => { cancelled = true; };
-  }, [selectedApp?.id]);
+  }, [selectedApp?.id, selectedApp?.registry]);
 
   // -----------------------------------------------------------------------
   // Helper: build MarketplaceApp[] from raw registry results + installed set

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -735,10 +735,12 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
                 <button
                   onClick={() => handleInstall(selectedApp, selectedVersion || selectedApp.latest_version)}
                   className="button button-primary"
-                  disabled={installingAppId === selectedApp.id}
+                  disabled={installingAppId === selectedApp.id || versionsLoading}
                 >
                   {installingAppId === selectedApp.id ? (
                     <><RefreshCw size={16} className="spinning" /> Installing...</>
+                  ) : versionsLoading ? (
+                    <><RefreshCw size={16} className="spinning" /> Loading versions...</>
                   ) : (
                     <><span className="install-icon-wrap"><Download size={16} /></span>Install</>
                   )}

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/tauri";
 import { getSettings } from "../utils/settings";
-import { fetchAppsFromAllRegistries, fetchAppVersions, recordDownload, type AppSummary, type VersionInfo } from "../utils/registry";
+import { fetchAppsFromAllRegistries, fetchAppVersions, fetchAppManifest, recordDownload, type AppSummary, type VersionInfo } from "../utils/registry";
 import { apiClient } from "../lib/mero-client";
 import { decodeMetadata } from "../utils/appUtils";
 import {
@@ -59,6 +59,8 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
 
   // Load the open app's published versions for the picker; default the
   // selection to its latest. Cleared when the modal closes.
+  // Depends on selectedApp?.id (not the full object) so patching installed:true
+  // after an install doesn't re-run this and reset the user's version pick.
   useEffect(() => {
     if (!selectedApp) {
       setAvailableVersions([]);
@@ -69,9 +71,14 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
     let cancelled = false;
     fetchAppVersions(selectedApp.registry, selectedApp.id)
       .then((vs) => { if (!cancelled) setAvailableVersions(vs); })
-      .catch(() => { if (!cancelled) setAvailableVersions([]); });
+      .catch(() => {
+        if (!cancelled) {
+          setAvailableVersions([]);
+          toast.error("Failed to load version list");
+        }
+      });
     return () => { cancelled = true; };
-  }, [selectedApp]);
+  }, [selectedApp?.id]);
 
   // -----------------------------------------------------------------------
   // Helper: build MarketplaceApp[] from raw registry results + installed set
@@ -293,14 +300,14 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
   }, [apps, filterInstalled, searchQuery]);
 
   const handleInstall = async (app: MarketplaceApp, version: string = app.latest_version) => {
+    if (!/^[\w.+-]+$/.test(version)) {
+      toast.error("Invalid version string");
+      return;
+    }
     setInstallingAppId(app.id);
     try {
-      // Fetch the manifest to get the WASM artifact URL. `version` defaults to
-      // the latest, but the detail modal lets the user pick an older one.
-      const { fetchAppManifest } = await import("../utils/registry");
       const manifest = await fetchAppManifest(app.registry, app.id, version);
-      
-      
+
       // Handle both v1 format (artifact) and v2 format (artifacts array)
       let wasmUrl: string;
       let wasmHashHex: string | null = null;
@@ -682,7 +689,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
                     ))}
                   </select>
                 ) : (
-                  <span className="modal-meta-value">v{selectedVersion || selectedApp.latest_version}</span>
+                  <span className="modal-meta-value">{selectedVersion || selectedApp.latest_version}</span>
                 )}
               </div>
               <div className="modal-meta-row">
@@ -707,7 +714,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
                 </button>
               ) : (
                 <button
-                  onClick={() => handleInstall(selectedApp, selectedVersion || selectedApp.latest_version)}
+                  onClick={() => handleInstall(selectedApp, selectedVersion)}
                   className="button button-primary"
                   disabled={installingAppId === selectedApp.id}
                 >

--- a/apps/desktop/src/pages/Marketplace.tsx
+++ b/apps/desktop/src/pages/Marketplace.tsx
@@ -42,6 +42,7 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
   // the open app, and which one Install will fetch (defaults to latest).
   const [availableVersions, setAvailableVersions] = useState<VersionInfo[]>([]);
   const [selectedVersion, setSelectedVersion] = useState<string>("");
+  const [versionsLoading, setVersionsLoading] = useState(false);
   const mountedRef = useRef(true);
 
   // Cleanup on unmount
@@ -67,16 +68,19 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
     if (!selectedApp) {
       setAvailableVersions([]);
       setSelectedVersion("");
+      setVersionsLoading(false);
       return;
     }
     setAvailableVersions([]);
     setSelectedVersion(selectedApp.latest_version);
+    setVersionsLoading(true);
     let cancelled = false;
     fetchAppVersions(selectedApp.registry, selectedApp.id)
-      .then((vs) => { if (!cancelled) setAvailableVersions(vs); })
+      .then((vs) => { if (!cancelled) { setAvailableVersions(vs); setVersionsLoading(false); } })
       .catch(() => {
         if (!cancelled) {
           setAvailableVersions([]);
+          setVersionsLoading(false);
           toast.error("Failed to load version list");
         }
       });
@@ -677,7 +681,11 @@ export default function Marketplace({ clientReady = true }: MarketplaceProps) {
               </div>
               <div className="modal-meta-row">
                 <span className="modal-meta-label">Version</span>
-                {availableVersions.length > 1 ? (
+                {versionsLoading ? (
+                  <span className="modal-meta-value modal-versions-loading">
+                    <RefreshCw size={12} className="spinning" /> Loading…
+                  </span>
+                ) : availableVersions.length > 0 ? (
                   <select
                     className="modal-version-select"
                     value={selectedVersion}

--- a/apps/desktop/src/utils/registry.ts
+++ b/apps/desktop/src/utils/registry.ts
@@ -145,16 +145,25 @@ export async function fetchAppVersions(
     const bundles = await response.json();
     const bundlesArray = Array.isArray(bundles) ? bundles : [];
 
-    // Transform V2 bundles to VersionInfo format
-    return bundlesArray.map((bundle: any) => {
-      // Get artifact URL (convention: /artifacts/:package/:version/:package-:version.mpk)
-      const artifactUrl = `/artifacts/${bundle.package}/${bundle.appVersion}/${bundle.package}-${bundle.appVersion}.mpk`;
-      return {
-        semver: bundle.appVersion,
-        cid: artifactUrl,
+    // Deduplicate by semver (registry may return one entry per platform/arch),
+    // then sort descending so latest appears first.
+    const seen = new Set<string>();
+    return bundlesArray
+      .map((bundle: any) => ({
+        semver: bundle.appVersion as string,
+        cid: `/artifacts/${bundle.package}/${bundle.appVersion}/${bundle.package}-${bundle.appVersion}.mpk`,
         yanked: false,
-      };
-    });
+      }))
+      .filter((v) => !seen.has(v.semver) && seen.add(v.semver))
+      .sort((a, b) => {
+        const pa = a.semver.replace(/^v/, '').split('.').map(Number);
+        const pb = b.semver.replace(/^v/, '').split('.').map(Number);
+        for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+          const diff = (pb[i] ?? 0) - (pa[i] ?? 0);
+          if (diff !== 0) return diff;
+        }
+        return 0;
+      });
   } catch (error) {
     console.error(`Failed to fetch app versions from registry ${registryUrl}:`, error);
     throw error;

--- a/apps/desktop/src/utils/registry.ts
+++ b/apps/desktop/src/utils/registry.ts
@@ -118,9 +118,10 @@ export async function fetchAppsFromRegistry(
   }
 }
 
-// Package ids may be scoped (@org/name); both fetch helpers use this so the
-// version list and the manifest fetch agree on what's valid.
-const APP_ID_RE = /^[\w.@/-]+$/;
+// Package ids may be scoped (@org/name) but nothing more — this mirrors the
+// registry's own validation and blocks stray slashes / path-traversal. Both
+// fetch helpers use it so the version list and manifest fetch agree.
+const APP_ID_RE = /^(?:@[\w.-]+\/)?[\w.+-]+$/;
 const VERSION_RE = /^[\w.+-]+$/;
 
 /**

--- a/apps/desktop/src/utils/registry.ts
+++ b/apps/desktop/src/utils/registry.ts
@@ -127,9 +127,10 @@ export async function fetchAppVersions(
   appId: string
 ): Promise<VersionInfo[]> {
   try {
-    // Use V2 Bundle API - get all bundles for this package
+    // Use V2 Bundle API - get all published versions for this package
     const url = new URL('/api/v2/bundles', registryUrl);
-    url.searchParams.set('package', appId); // query param — encodeURIComponent handled by URLSearchParams
+    url.searchParams.set('package', appId); // encodeURIComponent handled by URLSearchParams
+    url.searchParams.set('all_versions', 'true');
 
     const response = await fetch(url.toString(), {
       method: 'GET',

--- a/apps/desktop/src/utils/registry.ts
+++ b/apps/desktop/src/utils/registry.ts
@@ -129,7 +129,7 @@ export async function fetchAppVersions(
   try {
     // Use V2 Bundle API - get all bundles for this package
     const url = new URL('/api/v2/bundles', registryUrl);
-    url.searchParams.set('package', appId);
+    url.searchParams.set('package', appId); // query param — encodeURIComponent handled by URLSearchParams
 
     const response = await fetch(url.toString(), {
       method: 'GET',
@@ -179,9 +179,11 @@ export async function fetchAppManifest(
   appId: string,
   version: string
 ): Promise<AppManifest> {
+  if (!/^[\w.+-]+$/.test(appId)) throw new Error(`Invalid appId: ${appId}`);
+  if (!/^[\w.+-]+$/.test(version)) throw new Error(`Invalid version: ${version}`);
   try {
-    // Use V2 Bundle API
-    const url = new URL(`/api/v2/bundles/${appId}/${version}`, registryUrl);
+    // Use V2 Bundle API — encodeURIComponent guards against path traversal in segments
+    const url = new URL(`/api/v2/bundles/${encodeURIComponent(appId)}/${encodeURIComponent(version)}`, registryUrl);
     
     const response = await fetch(url.toString(), {
       method: 'GET',

--- a/apps/desktop/src/utils/registry.ts
+++ b/apps/desktop/src/utils/registry.ts
@@ -147,15 +147,15 @@ export async function fetchAppVersions(
     const bundlesArray = Array.isArray(bundles) ? bundles : [];
 
     // Deduplicate by semver (registry may return one entry per platform/arch),
-    // then sort descending so latest appears first.
+    // filter yanked versions (unsupported by the developer), then sort descending.
     const seen = new Set<string>();
     return bundlesArray
       .map((bundle: any) => ({
         semver: bundle.appVersion as string,
         cid: `/artifacts/${bundle.package}/${bundle.appVersion}/${bundle.package}-${bundle.appVersion}.mpk`,
-        yanked: false,
+        yanked: bundle.yanked === true,
       }))
-      .filter((v) => !seen.has(v.semver) && seen.add(v.semver))
+      .filter((v) => !v.yanked && !seen.has(v.semver) && seen.add(v.semver))
       .sort((a, b) => {
         const pa = a.semver.replace(/^v/, '').split('.').map(Number);
         const pb = b.semver.replace(/^v/, '').split('.').map(Number);

--- a/apps/desktop/src/utils/registry.ts
+++ b/apps/desktop/src/utils/registry.ts
@@ -126,6 +126,7 @@ export async function fetchAppVersions(
   registryUrl: string,
   appId: string
 ): Promise<VersionInfo[]> {
+  if (!/^[\w.@/-]+$/.test(appId)) throw new Error(`Invalid appId: ${appId}`);
   try {
     // Use V2 Bundle API - get all published versions for this package
     const url = new URL('/api/v2/bundles', registryUrl);
@@ -150,6 +151,7 @@ export async function fetchAppVersions(
     // filter yanked versions (unsupported by the developer), then sort descending.
     const seen = new Set<string>();
     return bundlesArray
+      .filter((bundle: any) => /^[\w.+-]+$/.test(bundle.appVersion))
       .map((bundle: any) => ({
         semver: bundle.appVersion as string,
         cid: `/artifacts/${bundle.package}/${bundle.appVersion}/${bundle.package}-${bundle.appVersion}.mpk`,

--- a/apps/desktop/src/utils/registry.ts
+++ b/apps/desktop/src/utils/registry.ts
@@ -118,6 +118,58 @@ export async function fetchAppsFromRegistry(
   }
 }
 
+// Package ids may be scoped (@org/name); both fetch helpers use this so the
+// version list and the manifest fetch agree on what's valid.
+const APP_ID_RE = /^[\w.@/-]+$/;
+const VERSION_RE = /^[\w.+-]+$/;
+
+/**
+ * Compare two semver strings for a descending sort. Handles MAJOR.MINOR.PATCH
+ * plus pre-release identifiers (1.0.0-alpha sorts below 1.0.0). Build metadata
+ * (after '+') is ignored, per the semver spec.
+ */
+function compareSemverDesc(a: string, b: string): number {
+  const parse = (v: string) => {
+    const withoutBuild = v.replace(/^v/, '').split('+')[0];
+    const dash = withoutBuild.indexOf('-');
+    const core = dash === -1 ? withoutBuild : withoutBuild.slice(0, dash);
+    const pre = dash === -1 ? '' : withoutBuild.slice(dash + 1);
+    return { core: core.split('.').map(Number), pre };
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < Math.max(pa.core.length, pb.core.length); i++) {
+    const diff = (pb.core[i] ?? 0) - (pa.core[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  // Equal core: a release WITHOUT a pre-release outranks one WITH it.
+  if (pa.pre === '' && pb.pre !== '') return -1;
+  if (pa.pre !== '' && pb.pre === '') return 1;
+  if (pa.pre === pb.pre) return 0;
+  const ia = pa.pre.split('.');
+  const ib = pb.pre.split('.');
+  for (let i = 0; i < Math.max(ia.length, ib.length); i++) {
+    const xa = ia[i];
+    const xb = ib[i];
+    if (xa === undefined) return 1; // shorter pre-release has lower precedence
+    if (xb === undefined) return -1;
+    const na = Number(xa);
+    const nb = Number(xb);
+    const aNum = !Number.isNaN(na);
+    const bNum = !Number.isNaN(nb);
+    if (aNum && bNum) {
+      if (na !== nb) return nb - na;
+    } else if (aNum !== bNum) {
+      // numeric identifiers have lower precedence than alphanumeric ones
+      return aNum ? 1 : -1;
+    } else {
+      const cmp = xb.localeCompare(xa);
+      if (cmp !== 0) return cmp;
+    }
+  }
+  return 0;
+}
+
 /**
  * Fetch all versions of an application from a registry
  * Uses V2 Bundle API
@@ -126,7 +178,7 @@ export async function fetchAppVersions(
   registryUrl: string,
   appId: string
 ): Promise<VersionInfo[]> {
-  if (!/^[\w.@/-]+$/.test(appId)) throw new Error(`Invalid appId: ${appId}`);
+  if (!APP_ID_RE.test(appId)) throw new Error(`Invalid appId: ${appId}`);
   try {
     // Use V2 Bundle API - get all published versions for this package
     const url = new URL('/api/v2/bundles', registryUrl);
@@ -147,26 +199,23 @@ export async function fetchAppVersions(
     const bundles = await response.json();
     const bundlesArray = Array.isArray(bundles) ? bundles : [];
 
-    // Deduplicate by semver (registry may return one entry per platform/arch),
-    // filter yanked versions (unsupported by the developer), then sort descending.
+    // Drop yanked/invalid entries and deduplicate by semver (the registry may
+    // return one entry per platform/arch), then sort newest-first.
     const seen = new Set<string>();
-    return bundlesArray
-      .filter((bundle: any) => /^[\w.+-]+$/.test(bundle.appVersion))
-      .map((bundle: any) => ({
-        semver: bundle.appVersion as string,
-        cid: `/artifacts/${bundle.package}/${bundle.appVersion}/${bundle.package}-${bundle.appVersion}.mpk`,
-        yanked: bundle.yanked === true,
-      }))
-      .filter((v) => !v.yanked && !seen.has(v.semver) && seen.add(v.semver))
-      .sort((a, b) => {
-        const pa = a.semver.replace(/^v/, '').split('.').map(Number);
-        const pb = b.semver.replace(/^v/, '').split('.').map(Number);
-        for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-          const diff = (pb[i] ?? 0) - (pa[i] ?? 0);
-          if (diff !== 0) return diff;
-        }
-        return 0;
+    const versions: VersionInfo[] = [];
+    for (const bundle of bundlesArray as any[]) {
+      const semver = bundle.appVersion as string;
+      if (!VERSION_RE.test(semver)) continue;
+      if (bundle.yanked === true) continue;
+      if (seen.has(semver)) continue;
+      seen.add(semver);
+      versions.push({
+        semver,
+        cid: `/artifacts/${bundle.package}/${semver}/${bundle.package}-${semver}.mpk`,
+        yanked: false,
       });
+    }
+    return versions.sort((a, b) => compareSemverDesc(a.semver, b.semver));
   } catch (error) {
     console.error(`Failed to fetch app versions from registry ${registryUrl}:`, error);
     throw error;
@@ -182,8 +231,8 @@ export async function fetchAppManifest(
   appId: string,
   version: string
 ): Promise<AppManifest> {
-  if (!/^[\w.+-]+$/.test(appId)) throw new Error(`Invalid appId: ${appId}`);
-  if (!/^[\w.+-]+$/.test(version)) throw new Error(`Invalid version: ${version}`);
+  if (!APP_ID_RE.test(appId)) throw new Error(`Invalid appId: ${appId}`);
+  if (!VERSION_RE.test(version)) throw new Error(`Invalid version: ${version}`);
   try {
     // Use V2 Bundle API — encodeURIComponent guards against path traversal in segments
     const url = new URL(`/api/v2/bundles/${encodeURIComponent(appId)}/${encodeURIComponent(version)}`, registryUrl);


### PR DESCRIPTION
## What

The app detail modal now lets a user install a **specific version** of an app, not just the latest — the "download an older version" path.

- The modal fetches the package's published versions (`fetchAppVersions`) and shows a **Version** dropdown, defaulting to latest and labelling it `(latest)`. When only one version exists, it collapses to the static badge (no dropdown).
- `handleInstall` now takes an explicit `version` (defaulting to `latest_version`); the picked version flows through the manifest fetch, install metadata, and download-record.

## Why

Completes the developer-facing side of the migration-UX distribution flow: a developer publishes v2, but users (and the developer testing) can still pull a prior version on demand.

## Validation

- `tsc --noEmit` clean; full `tsc && vite build` green.
- Self-contained — uses the existing `registry.ts` utils and install path, no SDK bump required, so CI is green on its own.

Part of #2539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the app install path and registry HTTP behavior; validation/encoding reduce URL abuse risk but wrong-version installs are now user-driven.
> 
> **Overview**
> Adds **install-by-version** in the marketplace detail modal: opening an app loads published versions from the registry, shows a **Version** control (dropdown when multiple releases exist), and installs the chosen semver instead of always using the listing’s latest.
> 
> **Marketplace flow:** Grid **Install** now opens the detail modal (same as clicking the card) so version choice happens before install. `handleInstall` takes an explicit `version` (with a simple semver-string check) and threads it through manifest fetch, install metadata, and `recordDownload`. Install stays disabled while the version list is loading.
> 
> **Registry client:** `fetchAppVersions` calls the bundles API with `all_versions=true`, skips yanked/invalid entries, dedupes by semver, and sorts newest-first via a new `compareSemverDesc`. `fetchAppVersions` and `fetchAppManifest` validate package id/version and encode path segments to reduce path-traversal risk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 987becc8f59c1f3d2ec211ed520694ab7ee8aac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->