### PR TITLE
chore: bump version to 0.0.47 and merod to 0.11.0-rc.3

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.46"
+    "version": "0.0.47"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.2"
+    "version": "0.11.0-rc.3"
 }


### PR DESCRIPTION
Bumps the desktop app and bundled node (merod) versions:

- **Desktop app** `0.0.46` → `0.0.47` (`apps/desktop/package.json`, `apps/desktop/src-tauri/tauri.conf.json`)
- **merod (node)** `0.11.0-rc.2` → `0.11.0-rc.3` (`merod-config.json`)

The merod bump tracks core release `0.11.0-rc.3` (calimero-network/core#2757). Follows the established bump convention (see #108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes with no application logic; risk is limited to packaging the new merod release.
> 
> **Overview**
> Routine release alignment: **Calimero Desktop** is bumped from `0.0.46` to **`0.0.47`** in `apps/desktop/package.json` and `apps/desktop/src-tauri/tauri.conf.json` (npm/Tauri package version for builds and the updater).
> 
> The bundled **merod** node binary pin moves from `0.11.0-rc.2` to **`0.11.0-rc.3`** in `merod-config.json`, so `merod:prepare` fetches that core release and the Tauri build embeds the new `MEROD_CONFIG_VERSION` at compile time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 528f5294be81d00780345a4e44edccbac2b45732. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->