### PR TITLE
feat(desktop): make cloud feature flag a runtime toggle

### DIFF
--- a/apps/desktop/src/hooks/useCloudEnabled.ts
+++ b/apps/desktop/src/hooks/useCloudEnabled.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+import {
+  CLOUD_ENABLED_CHANGED_EVENT,
+  isCloudEnabled,
+} from "../utils/featureFlags";
+
+/**
+ * Reactive read of the cloud feature flag.
+ *
+ * Returns the current `isCloudEnabled()` value and re-renders the consuming
+ * component whenever the flag changes at runtime (e.g. the Settings "Enable Cloud"
+ * toggle calls `notifyCloudEnabledChanged()`). Recomputes on mount in case the flag
+ * changed before this component subscribed.
+ *
+ * For non-React callers, use the plain `isCloudEnabled()` function directly.
+ */
+export function useCloudEnabled(): boolean {
+  const [enabled, setEnabled] = useState<boolean>(isCloudEnabled);
+
+  useEffect(() => {
+    // Recompute on mount to catch any change between initial state and subscription.
+    setEnabled(isCloudEnabled());
+
+    const handler = () => setEnabled(isCloudEnabled());
+    window.addEventListener(CLOUD_ENABLED_CHANGED_EVENT, handler);
+    return () => {
+      window.removeEventListener(CLOUD_ENABLED_CHANGED_EVENT, handler);
+    };
+  }, []);
+
+  return enabled;
+}

--- a/apps/desktop/src/hooks/useCloudEnabled.ts
+++ b/apps/desktop/src/hooks/useCloudEnabled.ts
@@ -19,7 +19,9 @@ export function useCloudEnabled(): boolean {
   const [enabled, setEnabled] = useState<boolean>(isCloudEnabled);
 
   useEffect(() => {
-    // Recompute on mount to catch any change between initial state and subscription.
+    // The useState initializer runs during render, but the listener below only
+    // registers after commit. Re-read here so a flag change dispatched in that gap
+    // is not missed. No-op when unchanged (React bails via Object.is).
     setEnabled(isCloudEnabled());
 
     const handler = () => setEnabled(isCloudEnabled());

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -26,7 +26,7 @@ import {
 import { getCloudIdToken } from "../utils/cloudAuth";
 import { getAccessToken } from "../lib/token-storage";
 import { parseJwtPayload } from "../utils/jwt";
-import { isCloudEnabled } from "../utils/featureFlags";
+import { useCloudEnabled } from "../hooks/useCloudEnabled";
 import "./Namespaces.css";
 
 function parseApiError(e: any): string {
@@ -132,6 +132,7 @@ type GroupInfoExt = Omit<GroupInfo, "metadata"> & {
 export default function Namespaces() {
   const toast = useToast();
   const { mero } = useMero();
+  const cloudEnabled = useCloudEnabled();
   const [view, setView] = useState<View>({ type: "list" });
 
   const activeNsId = view.type === "namespace" || view.type === "group" ? view.ns.namespaceId : null;
@@ -948,7 +949,7 @@ export default function Namespaces() {
             )}
           </div>
 
-          {isCloudEnabled() && (() => {
+          {cloudEnabled && (() => {
             const cloudConnected = !!getCloudIdToken();
             const nsHaEnabled = !!haEnabled[ns.namespaceId];
             const nsHaEnabling = !!haEnabling[ns.namespaceId];

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { checkOnboardingState, getOnboardingMessage, type OnboardingState } from "../utils/onboarding";
 import { apiClient } from "../lib/mero-client";
 import { LoginView } from "../components/LoginView";
@@ -23,16 +23,24 @@ interface OnboardingProps {
 
 type OnboardingStep = 'welcome' | 'what-is' | 'node-setup' | 'cloud-connect' | 'login' | 'install-app';
 
-const ONBOARDING_STEPS: OnboardingStep[] = isCloudEnabled()
-  ? ['welcome', 'what-is', 'node-setup', 'cloud-connect', 'login', 'install-app']
-  : ['welcome', 'what-is', 'node-setup', 'login', 'install-app'];
-
-const STEP_AFTER_NODE_SETUP: OnboardingStep = isCloudEnabled() ? 'cloud-connect' : 'login';
-
-
 export default function Onboarding({ onComplete, onSettings }: OnboardingProps) {
   const toast = useToast();
   const { setTheme } = useTheme();
+
+  // Evaluated at runtime so the cloud feature flag (which is now a runtime toggle)
+  // takes effect without a rebuild. Step ordering is preserved exactly per enabled/disabled case.
+  const ONBOARDING_STEPS = useMemo<OnboardingStep[]>(
+    () =>
+      isCloudEnabled()
+        ? ['welcome', 'what-is', 'node-setup', 'cloud-connect', 'login', 'install-app']
+        : ['welcome', 'what-is', 'node-setup', 'login', 'install-app'],
+    [],
+  );
+
+  const STEP_AFTER_NODE_SETUP = useMemo<OnboardingStep>(
+    () => (isCloudEnabled() ? 'cloud-connect' : 'login'),
+    [],
+  );
   const [state, setState] = useState<OnboardingState | null>(null);
   const [loading, setLoading] = useState(true);
   const [currentStep, setCurrentStep] = useState<OnboardingStep>(() => {

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -45,7 +45,13 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
   const [loading, setLoading] = useState(true);
   const [currentStep, setCurrentStep] = useState<OnboardingStep>(() => {
     const saved = loadOnboardingProgress();
-    return saved?.currentStep ?? 'welcome';
+    const savedStep = saved?.currentStep ?? 'welcome';
+    // Cloud was disabled at runtime after progress was saved on the cloud step;
+    // that step is no longer in the list, so skip it.
+    if (savedStep === 'cloud-connect' && !isCloudEnabled()) {
+      return 'login';
+    }
+    return savedStep;
   });
 
   // Force dark mode during onboarding - override any theme changes

--- a/apps/desktop/src/pages/Settings.tsx
+++ b/apps/desktop/src/pages/Settings.tsx
@@ -5,7 +5,7 @@ import { invoke } from "@tauri-apps/api/tauri";
 import { killAllMerodProcesses, deleteCalimeroDataDir, stopMerod, getMerodStatus } from "../utils/merod";
 import { startCloudLogin, disconnectCloud } from "../utils/cloudAuth";
 import { getCloudSubscription, CloudSessionExpiredError } from "../utils/cloudApi";
-import { isCloudEnabled } from "../utils/featureFlags";
+import { isCloudEnabled, notifyCloudEnabledChanged } from "../utils/featureFlags";
 import { useTheme } from "../contexts/ThemeContext";
 import { useToast } from "../contexts/ToastContext";
 import { ArrowLeft, RotateCcw, Trash2, Cloud } from "lucide-react";
@@ -25,6 +25,7 @@ export default function Settings({ onBack }: SettingsProps) {
   const [activeTab, setActiveTab] = useState<'general' | 'registries' | 'cloud'>('general');
   const [developerMode, setDeveloperMode] = useState(false);
   const [debugLogs, setDebugLogs] = useState(false);
+  const [cloudEnabled, setCloudEnabled] = useState(false);
   const [cloudConnected, setCloudConnected] = useState(false);
   const [cloudEmail, setCloudEmail] = useState<string | undefined>();
   const [cloudName, setCloudName] = useState<string | undefined>();
@@ -47,6 +48,8 @@ export default function Settings({ onBack }: SettingsProps) {
     setRegistries(settings.registries || []);
     setDeveloperMode(settings.developerMode ?? false);
     setDebugLogs(settings.debugLogs ?? false);
+    // Effective cloud flag: explicit runtime override if set, else the build-time default.
+    setCloudEnabled(typeof settings.cloudEnabled === 'boolean' ? settings.cloudEnabled : isCloudEnabled());
     setCloudConnected(settings.cloudConnected ?? false);
     setCloudEmail(settings.cloudUserEmail);
     setCloudName(settings.cloudUserName);
@@ -119,6 +122,18 @@ export default function Settings({ onBack }: SettingsProps) {
       debugLogs: newValue,
     });
     toast.success(`Debug logs ${newValue ? 'enabled' : 'disabled'}. Restart the node for changes to take effect.`);
+  };
+
+  const handleCloudEnabledToggle = () => {
+    const newValue = !cloudEnabled;
+    setCloudEnabled(newValue);
+    const settings = getSettings();
+    saveSettings({
+      ...settings,
+      cloudEnabled: newValue,
+    });
+    notifyCloudEnabledChanged();
+    toast.success(`Calimero Cloud ${newValue ? 'enabled' : 'disabled'}`);
   };
 
   const handleAddRegistry = () => {
@@ -271,6 +286,26 @@ export default function Settings({ onBack }: SettingsProps) {
             <p className="field-hint">
                   Enable debug-level logging for the merod node. Produces more verbose logs useful for troubleshooting.
                   Restart the node for changes to take effect.
+            </p>
+          </div>
+          <div className="settings-field">
+                <span className="settings-field-label">Enable Cloud</span>
+                <div className="toggle-switch">
+            <input
+                    id="cloud-enabled"
+                    type="checkbox"
+                    checked={cloudEnabled}
+                    onChange={handleCloudEnabledToggle}
+                  />
+                  <label htmlFor="cloud-enabled" className="toggle-label">
+                    <span className="toggle-slider"></span>
+                    <span className="toggle-text">
+                      {cloudEnabled ? 'Enabled' : 'Disabled'}
+                    </span>
+                  </label>
+                </div>
+            <p className="field-hint">
+                  Show Calimero Cloud sign-in and High Availability features. Takes effect immediately.
             </p>
           </div>
               <div className="settings-field" style={{ marginTop: '16px', paddingTop: '16px', borderTop: '1px solid var(--border-color, #333)' }}>

--- a/apps/desktop/src/utils/featureFlags.ts
+++ b/apps/desktop/src/utils/featureFlags.ts
@@ -1,8 +1,47 @@
 /// <reference types="vite/client" />
 
+import { getSettings } from "./settings";
+
 const RAW_CLOUD = import.meta.env.VITE_ENABLE_CLOUD as string | undefined;
 
-export function isCloudEnabled(): boolean {
+/**
+ * Build-time default for the cloud feature flag.
+ * If VITE_ENABLE_CLOUD is "true"/"1" -> true; if explicitly other non-empty -> false;
+ * if unset/empty -> defaults to import.meta.env.DEV.
+ */
+function buildTimeDefault(): boolean {
   if (RAW_CLOUD === undefined || RAW_CLOUD === "") return Boolean(import.meta.env.DEV);
   return RAW_CLOUD === "true" || RAW_CLOUD === "1";
+}
+
+/**
+ * Runtime read of the cloud feature flag.
+ *
+ * A persisted runtime override (settings.cloudEnabled) wins when it is an explicit
+ * boolean; otherwise we fall back to the build-time default. Callable on each render —
+ * the result is intentionally not cached at module load so the Settings toggle takes
+ * effect immediately without a rebuild.
+ */
+export function isCloudEnabled(): boolean {
+  const { cloudEnabled } = getSettings();
+  if (typeof cloudEnabled === "boolean") return cloudEnabled;
+  return buildTimeDefault();
+}
+
+/**
+ * Event name dispatched on `window` when the cloud feature flag changes at runtime.
+ * Subscribers (e.g. the `useCloudEnabled` React hook) listen for this to re-read
+ * `isCloudEnabled()` and re-render without requiring a navigation.
+ */
+export const CLOUD_ENABLED_CHANGED_EVENT = "calimero:cloud-enabled-changed";
+
+/**
+ * Notify subscribers that the cloud feature flag changed.
+ *
+ * Implemented as a custom DOM event on `window` so the pub/sub stays framework-agnostic.
+ * No-op in non-browser environments (SSR / tests without a DOM).
+ */
+export function notifyCloudEnabledChanged(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(CLOUD_ENABLED_CHANGED_EVENT));
 }

--- a/apps/desktop/src/utils/featureFlags.ts
+++ b/apps/desktop/src/utils/featureFlags.ts
@@ -21,6 +21,12 @@ function buildTimeDefault(): boolean {
  * boolean; otherwise we fall back to the build-time default. Callable on each render —
  * the result is intentionally not cached at module load so the Settings toggle takes
  * effect immediately without a rebuild.
+ *
+ * NOTE: This flag is a UI-only convenience, NOT a security boundary. It is read from
+ * localStorage (user-writable via settings) and only gates whether cloud UI surfaces
+ * are shown. Every actual cloud operation independently enforces auth by validating the
+ * MDMA session token (isMdmaSessionToken / isTokenExpired) regardless of this flag, so
+ * flipping it cannot grant or bypass access to cloud functionality.
  */
 export function isCloudEnabled(): boolean {
   const { cloudEnabled } = getSettings();

--- a/apps/desktop/src/utils/settings.ts
+++ b/apps/desktop/src/utils/settings.ts
@@ -10,6 +10,7 @@ export interface AppSettings {
   embeddedNodeName?: string; // Node name for embedded node
   developerMode?: boolean; // Developer mode - shows advanced features like multiple nodes and contexts
   debugLogs?: boolean; // Enable debug-level logging for the merod node
+  cloudEnabled?: boolean; // Runtime override for the cloud feature flag. undefined = use build-time default (VITE_ENABLE_CLOUD / DEV)
   onboardingCompleted?: boolean; // True once user has completed first-time setup - never show onboarding again
   cloudConnected?: boolean; // Whether user is connected to Calimero Cloud
   cloudIdToken?: string; // MDMA session token for Cloud API auth (7d TTL, rolling refresh). During the migration window may hold a Google ID token until exchange lands.
@@ -86,6 +87,8 @@ export function getSettings(): AppSettings {
         embeddedNodeName: rawSettings.embeddedNodeName,
         developerMode: rawSettings.developerMode ?? false, // Default to false
         debugLogs: rawSettings.debugLogs ?? false,
+        cloudEnabled: rawSettings.cloudEnabled, // Passthrough: keep undefined when unset so featureFlags can fall back to build-time default
+
         onboardingCompleted: rawSettings.onboardingCompleted ?? false,
         cloudConnected: rawSettings.cloudConnected ?? false,
         cloudIdToken: rawSettings.cloudIdToken,


### PR DESCRIPTION
## What

Converts the desktop cloud feature flag from **build-time-only** (`VITE_ENABLE_CLOUD`) to a **runtime toggle** persisted in app settings. A shipped release build can now enable/disable Calimero Cloud + High Availability from the UI without rebuilding.

## Why

Previously cloud was gated purely by `VITE_ENABLE_CLOUD` at build time (defaulting to `import.meta.env.DEV`), so release bundles always shipped with cloud OFF and there was no way to turn it on without a custom build. This makes it accessible at runtime.

## Changes

- **`settings.ts`** — add optional `cloudEnabled` to `AppSettings` (stays `undefined` when unset, so "no choice" is distinct from "explicitly off").
- **`featureFlags.ts`** — `isCloudEnabled()` now reads the runtime override first, falling back to the existing `VITE_ENABLE_CLOUD` / `import.meta.env.DEV` build-time default. Adds a `window`-event pub/sub (`notifyCloudEnabledChanged`).
- **`hooks/useCloudEnabled.ts`** (new) — reactive hook so consumers re-render the moment the flag changes (keeps `featureFlags.ts` React-free for non-component callers).
- **`Settings.tsx`** — adds an "Enable Cloud" toggle in **General → Advanced** (outside the cloud-gated Cloud tab, so it can be turned on while off), persisting the override and notifying live.
- **`Namespaces.tsx`** — HA section now uses `useCloudEnabled()` and flips **live** while the page is open.
- **`Onboarding.tsx`** — cloud-gated steps were frozen at module-import time; now computed at runtime via `useMemo`.

## Default behavior preserved

With no override set: cloud ON in `vite dev`, OFF in release builds — same as before. The override only takes effect once the user toggles it.

## Testing

- `tsc --noEmit` passes clean (`tsconfig` has `noUnusedLocals`/`noUnusedParameters` on).
- Built a release `.app` (cloud OFF by build default) and verified the in-app toggle turns the Cloud tab and the Namespaces HA section on/off **live**, no rebuild/navigation needed; override persists across restarts.

## Notes

- Stacked on #107 (both touch `Namespaces.tsx`); base will auto-retarget to `master` when #107 merges.
- An unrelated working-tree change to `src-tauri/Cargo.toml` (removing the `http-all` tauri feature) was intentionally **excluded** from this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only feature gating with documented non-security boundary; cloud APIs still require session tokens. No auth or data-path changes.
> 
> **Overview**
> Turns the desktop **Calimero Cloud** gate from a **build-time-only** `VITE_ENABLE_CLOUD` check into a **persisted runtime setting** (`settings.cloudEnabled`), with the same default when unset (on in dev, off in release).
> 
> **`isCloudEnabled()`** now prefers the saved override, then falls back to the Vite/dev default, and **`notifyCloudEnabledChanged()`** broadcasts a window event so UI can react without a rebuild. New **`useCloudEnabled`** hook subscribes to that event.
> 
> **Settings → General → Advanced** adds an **Enable Cloud** toggle (outside the Cloud tab so cloud can be turned on while hidden). **Namespaces** HA UI uses the hook so it appears/disappears live. **Onboarding** step lists are computed at runtime (not at module load), with a guard when saved progress points at `cloud-connect` but cloud is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0468b39839864312fcfbac6e56478fad7b8d46be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->