### PR TITLE
fix(desktop): enable HA via namespace ownership-proof path regardless of contexts

### DIFF
--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -593,16 +593,17 @@ export default function Namespaces() {
           toast.success('HA disabled — TEE nodes will stop replicating');
         }
       } else {
-        const rootCtxs = await mero.admin
-          .listGroupContexts(nsId)
-          .catch((err: unknown) => {
-            console.warn('listGroupContexts probe failed; falling through to namespace-ownership-proof path:', err);
-            return [] as { contextId: string }[];
-          });
-        const groups = rootCtxs.length
-          ? [{ group_id: nsId, context_id: rootCtxs[0].contextId }]
-          : [];
-        await enableHaForNamespace(token, settings.nodeUrl, nsId, groups);
+        // HA is namespace-scoped: always authorise via the namespace
+        // ownership-proof path, whether or not the namespace already has
+        // contexts. Attaching a real context_id here routes the request
+        // onto the cloud's legacy "real-context" branch, which gates on
+        // the `UserContext` ledger — a table the namespace-native pivot
+        // stopped populating, so it 404s ("Contexts not found or not
+        // owned by user") for any context that actually exists. An empty
+        // group list keeps the request on the server-verified
+        // namespace-ownership gate (UserNamespace); core admits the
+        // ReadOnlyTee fleet member at the root and auto-follows contexts.
+        await enableHaForNamespace(token, settings.nodeUrl, nsId, []);
         setHaEnabled((prev) => ({ ...prev, [nsId]: true }));
         toast.success('HA enabled — TEE fleet nodes will join');
       }

--- a/apps/desktop/src/utils/cloudApi.test.ts
+++ b/apps/desktop/src/utils/cloudApi.test.ts
@@ -211,9 +211,7 @@ describe('enableHaForNamespace', () => {
     );
     restore = r;
     await expect(
-      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', [
-        { group_id: 'g1', context_id: 'ctx-1' },
-      ]),
+      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', []),
     ).rejects.toThrow(/Only the namespace admin can enable HA/);
   });
 
@@ -229,9 +227,7 @@ describe('enableHaForNamespace', () => {
     );
     restore = r;
     await expect(
-      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', [
-        { group_id: 'g1', context_id: 'ctx-1' },
-      ]),
+      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', []),
     ).rejects.toThrow(/Could not determine your role in this namespace/);
   });
 
@@ -248,71 +244,37 @@ describe('enableHaForNamespace', () => {
     );
     restore = r;
     await expect(
-      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', [
-        { group_id: 'g1', context_id: 'ctx-1' },
-      ]),
+      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', []),
     ).rejects.toThrow(/Unexpected response from local node members endpoint/);
   });
 
-  it('real-context path: members → measurements → tee-policy → enable, NO per-context proof', async () => {
+  it('real-context path is rejected fail-fast with no network calls (mdma#162)', async () => {
+    // Passing a non-empty context_id would route to the cloud's enable-ha
+    // real-context branch, which authorises against the never-populated
+    // `UserContext` ledger and 404s. The client rejects it up front —
+    // before any merod/cloud round-trip — rather than dispatching to the
+    // broken server path.
     const calls: string[] = [];
     const { restore: r } = installFetch((url, init) => {
       calls.push(`${init?.method ?? 'GET'} ${url}`);
-      return route(url, init, {
-        '/admin-api/groups/ns-root/members': () =>
-          jsonResponse({
-            members: [{ identity: 'me', role: 'Admin' }],
-            selfIdentity: 'me',
-          }),
-        '/api/cloud/fleet/measurements': () =>
-          jsonResponse({
-            release_tag: 'v1',
-            allowed_mrtd: ['mrtd-1'],
-            allowed_rtmr0: [],
-            allowed_rtmr1: [],
-            allowed_rtmr2: [],
-            allowed_rtmr3: [],
-          }),
-        '/admin-api/groups/ns-root/settings/tee-admission-policy': () =>
-          new Response('{}', { status: 200 }),
-        '/api/cloud/me/namespaces/ns-root/enable-ha': () =>
-          jsonResponse({
-            status: 'enabling',
-            namespace_id: 'ns-root',
-            groups: [],
-          }),
-      });
+      return jsonResponse({});
     });
     restore = r;
 
-    const res = await enableHaForNamespace(
-      makeJwt({ iss: 'mdma', email: 'u@e' }),
-      'http://node',
-      'ns-root',
-      [
-        { group_id: 'ns-root', context_id: 'ctx-1' },
-        { group_id: 'sub-1', context_id: 'ctx-2' },
-      ],
-    );
-    expect(res.status).toBe('enabling');
+    await expect(
+      enableHaForNamespace(
+        makeJwt({ iss: 'mdma', email: 'u@e' }),
+        'http://node',
+        'ns-root',
+        [
+          { group_id: 'ns-root', context_id: 'ctx-1' },
+          { group_id: 'sub-1', context_id: 'ctx-2' },
+        ],
+      ),
+    ).rejects.toThrow(/Per-context HA registration is disabled.*mdma#162/);
 
-    // HA-enable does not invoke the per-context ownership-proof shim.
-    expect(calls.some((c) => c.includes('/issue-ownership-proof'))).toBe(false);
-
-    // Order: members (UX fail-fast) → measurements → tee-policy → enable.
-    const ordered = (substr: string) =>
-      calls.findIndex((c) => c.includes(substr));
-    expect(ordered('/members')).toBeLessThan(ordered('/fleet/measurements'));
-    expect(ordered('/fleet/measurements')).toBeLessThan(
-      ordered('/tee-admission-policy'),
-    );
-    expect(ordered('/tee-admission-policy')).toBeLessThan(
-      ordered('/enable-ha'),
-    );
-
-    // Real-context path sends the groups straight through, no proof key.
-    const enableCall = calls.find((c) => c.includes('/enable-ha'));
-    expect(enableCall).toBeDefined();
+    // Fail-fast: nothing was dispatched to merod or the cloud.
+    expect(calls).toHaveLength(0);
   });
 
   it('no-context path ([] groups): members → measurements → tee-policy → ONE namespace proof → enable', async () => {
@@ -396,7 +358,7 @@ describe('enableHaForNamespace', () => {
         makeJwt({ iss: 'mdma' }), // no email, no sub
         'http://node',
         'ns-root',
-        [{ group_id: 'g', context_id: 'c' }],
+        [],
       ),
     ).rejects.toThrow(/missing the user identifier/);
   });
@@ -454,9 +416,7 @@ describe('enableHaForNamespace', () => {
     restore = r;
     // iss != "mdma"
     await expect(
-      enableHaForNamespace(makeJwt({ iss: 'google', email: 'u@e' }), 'http://node', 'ns', [
-        { group_id: 'g', context_id: 'c' },
-      ]),
+      enableHaForNamespace(makeJwt({ iss: 'google', email: 'u@e' }), 'http://node', 'ns', []),
     ).rejects.toThrow(/Not signed in to Calimero Cloud/);
     // mdma but expired
     await expect(
@@ -464,7 +424,7 @@ describe('enableHaForNamespace', () => {
         makeJwt({ iss: 'mdma', email: 'u@e', exp: Math.floor(Date.now() / 1000) - 10 }),
         'http://node',
         'ns',
-        [{ group_id: 'g', context_id: 'c' }],
+        [],
       ),
     ).rejects.toThrow(/Cloud session has expired/);
     expect(calls).toHaveLength(0); // failed fast, no merod/cloud round-trips
@@ -479,9 +439,7 @@ describe('enableHaForNamespace', () => {
     );
     restore = r;
     await expect(
-      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', [
-        { group_id: 'g1', context_id: 'ctx-1' },
-      ]),
+      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', []),
     ).rejects.toThrow(/Unexpected response from local node members endpoint/);
   });
 
@@ -494,9 +452,7 @@ describe('enableHaForNamespace', () => {
     );
     restore = r;
     await expect(
-      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', [
-        { group_id: 'g1', context_id: 'ctx-1' },
-      ]),
+      enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', []),
     ).rejects.toThrow(/Unexpected response from local node members endpoint/);
   });
 });

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -566,22 +566,25 @@ export async function requestNamespaceOwnershipProof(
  * Enable HA end-to-end for a namespace. The cloud only knows namespaces;
  * the desktop does not register/claim individual contexts.
  *
- * 1. Pre-flight: verify the caller is the namespace-root Admin. This is
+ * Only the namespace path is supported: an empty group list plus a single
+ * namespace-scoped ownership proof. Passing a non-empty `context_id` is
+ * rejected up front — it would route to the cloud's enable-ha real-context
+ * branch, which authorises against the never-populated `UserContext` ledger
+ * and 404s (namespace-native pivot fallout; calimero-network/mdma#162).
+ *
+ * 1. Reject any per-context request (fail fast, no network).
+ * 2. Pre-flight: verify the caller is the namespace-root Admin. This is
  *    a UX fail-fast only — the authoritative gate is server-side (the
- *    namespace ownership proof on the no-context path; a UserNamespace
- *    row on the real-context path).
- * 2. Fetch fleet measurements from cloud once (trusted MRTD values).
- * 3. Set the TEE admission policy on the *namespace root only*. Subgroup
+ *    namespace ownership proof).
+ * 3. Fetch fleet measurements from cloud once (trusted MRTD values).
+ * 4. Set the TEE admission policy on the *namespace root only*. Subgroup
  *    policies are ignored by core (namespace-scoped since rc.29 /
  *    calimero-network/core#2188) — applying them would error. Auto-follow
  *    propagates fleet-node membership into subgroups without a second
  *    admission check.
- * 4. Register the namespace with cloud:
- *    • Real-context path: `groups` carries representative
- *      {group_id, context_id} entries; the cloud authorises off the
- *      caller's namespace ownership in the UserNamespace ledger.
- *    • No-context path: `groups` is `[]` plus a single namespace-scoped
- *      ownership proof — the authoritative server-verified namespace gate.
+ * 5. Register the namespace with cloud: `groups` is `[]` plus a single
+ *    namespace-scoped ownership proof — the authoritative server-verified
+ *    namespace gate.
  */
 export async function enableHaForNamespace(
   idToken: string,
@@ -589,13 +592,23 @@ export async function enableHaForNamespace(
   namespaceId: string,
   groups: NamespaceHaGroup[],
 ): Promise<EnableHaNamespaceResponse> {
-  // A context-less namespace is a first-class HA target. When no group
-  // has a real context the cloud authorises off ONE namespace-scoped
+  // HA is namespace-scoped: the only supported path is the namespace
   // ownership proof + an empty group list (the authoritative
-  // server-verified gate). When real contexts are supplied the cloud
-  // authorises off the caller's namespace ownership in the UserNamespace
-  // ledger — there is no separate per-context registration step.
-  const hasRealContext = groups.some((g) => !!g.context_id);
+  // server-verified gate). The "real-context" path — passing a non-empty
+  // `context_id` — is intentionally rejected here, before any network
+  // round-trip. It routes to the cloud's enable-ha real-context branch,
+  // which authorises against the `UserContext` ledger; the cloud's
+  // namespace-native pivot stopped populating that table, so any context
+  // sent there 404s with "Contexts not found or not owned by user".
+  // Failing loud now avoids silently dispatching to that broken server
+  // path. Re-enable per-context support only once the server gate
+  // authorises off `UserNamespace` — calimero-network/mdma#162.
+  if (groups.some((g) => !!g.context_id)) {
+    throw new Error(
+      'Per-context HA registration is disabled pending a server-side fix ' +
+        '(calimero-network/mdma#162). Enable HA at the namespace level instead.',
+    );
+  }
 
   // ── Step 1: token-shape fail-fast + Admin pre-flight ──
   // The cloud verifier is the authoritative trust boundary: it re-checks
@@ -655,10 +668,7 @@ export async function enableHaForNamespace(
   }
 
   // The cloud surface is namespace-only: there is no per-context
-  // registration step the desktop calls. The real-context path sends
-  // `groups` straight to enableHaNamespace and the cloud authorises off
-  // the caller's namespace ownership; the no-context path supplies a
-  // single namespace-scoped ownership proof below.
+  // registration step the desktop calls.
 
   // ── Step 2–4: measurements → tee-policy → register ──
   const measurements = await getFleetMeasurements(idToken);
@@ -670,22 +680,8 @@ export async function enableHaForNamespace(
   // there and only there — subgroups inherit it via resolve-to-root.
   await setTeeAdmissionPolicy(nodeUrl, namespaceId, measurements.allowed_mrtd);
 
-  if (hasRealContext) {
-    // Real-context path. NOTE: currently unreachable from the desktop UI —
-    // Namespaces.tsx always passes an empty `groups`, so this branch never
-    // runs in production (it is still exercised by cloudApi.test.ts and
-    // retained for other/future callers). It is kept because the server's
-    // real-context branch is itself broken: it authorises against the
-    // `UserContext` ledger, which the cloud's namespace-native pivot stopped
-    // populating, so any context sent here 404s ("Contexts not found or not
-    // owned by user"). Re-enable this path only once that server gate is
-    // fixed to authorise off `UserNamespace` — tracked in
-    // calimero-network/mdma#162.
-    return enableHaNamespace(idToken, namespaceId, groups);
-  }
-
-  // Context-less path: no contexts to bill, so send an empty group list
-  // plus exactly ONE namespace-scoped ownership proof. merod gates proof
+  // Namespace path: send an empty group list plus exactly ONE
+  // namespace-scoped ownership proof. merod gates proof
   // issuance on direct admin of the namespace root and signs with the
   // root signing key; the cloud re-verifies the proof (signature,
   // subject == authenticated email, audience, group_id == path namespace)

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -671,8 +671,16 @@ export async function enableHaForNamespace(
   await setTeeAdmissionPolicy(nodeUrl, namespaceId, measurements.allowed_mrtd);
 
   if (hasRealContext) {
-    // Real-context path: the cloud authorises off the caller's namespace
-    // ownership in the UserNamespace ledger. No per-call proof needed.
+    // Real-context path. NOTE: currently unreachable from the desktop UI —
+    // Namespaces.tsx always passes an empty `groups`, so this branch never
+    // runs in production (it is still exercised by cloudApi.test.ts and
+    // retained for other/future callers). It is kept because the server's
+    // real-context branch is itself broken: it authorises against the
+    // `UserContext` ledger, which the cloud's namespace-native pivot stopped
+    // populating, so any context sent here 404s ("Contexts not found or not
+    // owned by user"). Re-enable this path only once that server gate is
+    // fixed to authorise off `UserNamespace` — tracked in
+    // calimero-network/mdma#162.
     return enableHaNamespace(idToken, namespaceId, groups);
   }
 


### PR DESCRIPTION
## Problem

Enabling HA from the desktop on a namespace that already has a context fails with:

```
404 Contexts not found or not owned by user: <context_id>
```

…for a context the user owns and just created. Enabling HA on an empty namespace works fine.

## Root cause

The enable-HA handler probed the namespace root for contexts and, when one existed, attached its `context_id` to the request:

```ts
const groups = rootCtxs.length
  ? [{ group_id: nsId, context_id: rootCtxs[0].contextId }]
  : [];
await enableHaForNamespace(token, settings.nodeUrl, nsId, groups);
```

A non-empty `context_id` routes the cloud's `enable-ha` endpoint onto its legacy **real-context branch**, which authorises against the `UserContext` ledger. The cloud's namespace-native pivot stopped populating that table, so the gate 404s for any context that actually exists. An empty namespace worked only because it fell onto the **namespace ownership-proof** path (the `UserNamespace` gate).

So the failure appears *right after* creating a context: empty namespace → proof path → OK; same namespace after a context exists → context path → 404.

## Fix

HA is namespace-scoped — always send an empty group list and let `enableHaForNamespace` take the ownership-proof path regardless of whether contexts exist. The cloud verifies the merod-signed namespace proof against `UserNamespace`; core admits the `ReadOnlyTee` fleet member at the namespace root and auto-follows contexts created later, so existing and future contexts remain covered.

```diff
-        const rootCtxs = await mero.admin.listGroupContexts(nsId)...
-        const groups = rootCtxs.length
-          ? [{ group_id: nsId, context_id: rootCtxs[0].contextId }]
-          : [];
-        await enableHaForNamespace(token, settings.nodeUrl, nsId, groups);
+        await enableHaForNamespace(token, settings.nodeUrl, nsId, []);
```

## Scope

This is the **client-side** half. The server-side dead `UserContext` gate is a latent trap for any client that takes the context path and is tracked separately in **calimero-network/mdma#162**.

## Testing

Built a desktop `.app` with this change (bundling a locally-built `merod`) and `VITE_ENABLE_CLOUD=true`. Enabling HA on a namespace that contains a context now takes the ownership-proof path instead of 404-ing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cloud HA registration behavior for namespaces with contexts; incorrect proof or policy steps could block TEE fleet join until retried, but scope is limited to the desktop HA toggle flow.
> 
> **Overview**
> Fixes **Enable HA** failing with a cloud **404** on namespaces that already have a context, while empty namespaces still worked.
> 
> The Namespaces UI no longer probes root contexts or sends `{ group_id, context_id }`. It always calls `enableHaForNamespace` with an **empty** `groups` array so authorization uses the **namespace ownership-proof** path (`UserNamespace`), not the legacy real-context branch that checks the stale `UserContext` ledger.
> 
> In **`cloudApi.ts`**, `enableHaForNamespace` now **only** supports that namespace path: any group entry with a `context_id` throws **before** network I/O (mdma#162), and the old real-context shortcut to `enableHaNamespace` without a proof is removed. Tests were updated to expect fail-fast rejection for per-context groups and to exercise the `[]` proof flow everywhere else.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0b174a1b98c6d144d5db83660971fba0b8df5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->