### PR TITLE
chore: bump version to 0.0.48 and merod to 0.11.0-rc.4

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.47"
+    "version": "0.0.48"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.3"
+    "version": "0.11.0-rc.4"
 }


### PR DESCRIPTION
Bumps the desktop app version `0.0.47` → `0.0.48` and the bundled merod node version `0.11.0-rc.3` → `0.11.0-rc.4`, tracking the core release.

- `apps/desktop/package.json`, `apps/desktop/src-tauri/tauri.conf.json`: `0.0.47` → `0.0.48`
- `merod-config.json`: `0.11.0-rc.3` → `0.11.0-rc.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only release alignment with no code or security behavior changes; next builds will fetch and embed the newer merod RC.
> 
> **Overview**
> Aligns the Calimero Desktop release with the latest core node build by bumping version numbers only—no application logic changes.
> 
> **Desktop app** version moves from `0.0.47` to `0.0.48` in `apps/desktop/package.json` and `apps/desktop/src-tauri/tauri.conf.json` (Tauri package metadata and updater-facing version).
> 
> **Bundled merod** target moves from `0.11.0-rc.3` to `0.11.0-rc.4` in `merod-config.json`, which drives `pnpm merod:prepare` (GitHub release fetch) and the compile-time `MEROD_CONFIG_VERSION` embedded in the Tauri binary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed71acb960c8f48c0a93f6861ca304c151ffdcb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->