### PR TITLE
chore: bump bundled merod to 0.11.0-rc.5

### DIFF
--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.4"
+    "version": "0.11.0-rc.5"
 }


### PR DESCRIPTION
Bumps the bundled merod baseline in \`merod-config.json\` from \`0.11.0-rc.4\` to \`0.11.0-rc.5\` (latest core release; carries TEE-lifecycle work + everything since the prior pin).

## What changed
- \`merod-config.json\` \`version\`: \`0.11.0-rc.4\` → \`0.11.0-rc.5\` (single source of truth; \`prepare-merod.mjs\`, all three build workflows, and the Windows source-build read this field).

## Feasibility / risk
- **Assets exist**: core release \`0.11.0-rc.5\` is published (not mid-build) and ships the same merod asset set as rc.4: \`merod_aarch64-apple-darwin.tar.gz\`, \`merod_aarch64-unknown-linux-gnu.tar.gz\`, \`merod_x86_64-unknown-linux-gnu.tar.gz\`. Asset-neutral bump — no new platform gap introduced.
- **macOS (universal build)**: CI runs on an arm64 runner, so \`prepare-merod.mjs\` downloads only \`merod_aarch64-apple-darwin.tar.gz\`. core does NOT ship \`merod_x86_64-apple-darwin\` — this is unchanged from rc.4 (pre-existing: the universal .app bundles an arm64-only merod). Not a regression from this bump.
- **Linux x64**: \`merod_x86_64-unknown-linux-gnu.tar.gz\` present. OK.
- **Windows**: core publishes no merod Windows archive (by design); the Windows workflow builds merod from source via \`git clone --branch <version> calimero-network/core && cargo build -p merod\`. The git tag \`0.11.0-rc.5\` exists, so the source build will resolve.
- **Checksum**: no sha/checksum is pinned anywhere in this repo (asset selection is by name pattern in \`prepare-merod.mjs\`). Nothing else to update.

## Compat notes (human call)
- Jump is small in practice (rc.4 → rc.5), so config.toml-schema / admin-api-route drift risk is low, but not exhaustively audited here. The desktop drives the bundled merod's admin API; reviewers should confirm rc.5 didn't change config.toml shape or admin-api routes/ports the desktop relies on.

Do not merge until the compat call above is made.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps the embedded node binary and admin API surface; config.toml or admin route drift vs the desktop is possible and should be sanity-checked before merge.
> 
> **Overview**
> Updates the single source of truth for the bundled **merod** baseline: `merod-config.json` **`version`** goes from **`0.11.0-rc.4`** to **`0.11.0-rc.5`**.
> 
> That pin drives **`prepare-merod.mjs`** (GitHub release download), compile-time **`MEROD_CONFIG_VERSION`** in the Tauri build, and the Windows CI path that clones **`calimero-network/core`** at this tag. No other files change in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49133b154920ff7bcfe5388063dc3dd03585ec20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->