### PR TITLE
fix(desktop): reliable owner-side TEE eviction on HA disable (full-tree + reconcile)

### DIFF
--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -69,6 +69,12 @@ function parseApiError(e: any): string {
 
 const DEFAULT_NAMESPACE_CAPABILITIES = 1 | 2 | 8;
 
+// Bounded self-heal for the reconcile (see the reconcile effect): retry a
+// namespace whose cleanup left work undone up to this many times, spaced by
+// this interval, before surfacing the "couldn't finish" toast.
+const RECONCILE_MAX_RETRIES = 5;
+const RECONCILE_RETRY_MS = 30_000;
+
 interface InstalledApp {
   id: string;
   name: string;
@@ -507,8 +513,11 @@ export default function Namespaces() {
   // inside the effect — instead of a separate `[haEnabled]` effect — keeps
   // the reset from racing the in-flight pass's retry bookkeeping (mero).
   const reconcileBudgetKeyRef = useRef(haEnabled);
-  const RECONCILE_MAX_RETRIES = 5;
-  const RECONCILE_RETRY_MS = 30_000;
+  // Stays true for the component's lifetime; flipped false only on unmount,
+  // so the reconcile `.finally` can skip a post-unmount `triggerReconcile`
+  // (setState) without breaking the in-flight pending-rerun handoff — which
+  // runs while `cancelled` is true and so can't be guarded by `cancelled`.
+  const reconcileMountedRef = useRef(true);
   const [reconcileTick, setReconcileTick] = useState(0);
   const triggerReconcile = useCallback(() => setReconcileTick((t) => t + 1), []);
   const clearReconcileRetryTimer = useCallback(() => {
@@ -607,8 +616,14 @@ export default function Namespaces() {
       .finally(() => {
         reconcileBusyRef.current = Math.max(0, reconcileBusyRef.current - 1);
         // All owners released and a trigger arrived mid-pass — re-run
-        // against the latest state.
-        if (reconcileBusyRef.current === 0 && reconcilePendingRef.current) {
+        // against the latest state. Skip after unmount (no live component to
+        // re-render); `cancelled` can't gate this because the pending-rerun
+        // handoff legitimately fires while `cancelled` is true.
+        if (
+          reconcileMountedRef.current &&
+          reconcileBusyRef.current === 0 &&
+          reconcilePendingRef.current
+        ) {
           reconcilePendingRef.current = false;
           triggerReconcile();
         }
@@ -624,8 +639,14 @@ export default function Namespaces() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [haEnabled, mero, reconcileTick]);
 
-  // Clear any pending reconcile retry timer on unmount.
-  useEffect(() => clearReconcileRetryTimer, [clearReconcileRetryTimer]);
+  // On unmount: mark unmounted and clear any pending reconcile retry timer.
+  useEffect(
+    () => () => {
+      reconcileMountedRef.current = false;
+      clearReconcileRetryTimer();
+    },
+    [clearReconcileRetryTimer],
+  );
 
   const toggleHa = useCallback(async (ns: Namespace) => {
     const token = getCloudIdToken();

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -477,24 +477,44 @@ export default function Namespaces() {
   // mops up subgroup rows the root-only v1 left behind (Bug 2). Idempotent
   // and skips namespaces with no local TEE members, so the steady state is
   // a cheap no-op.
-  const reconcileRunningRef = useRef(false);
-  // A trigger arriving while a pass is in flight must NOT be dropped: the
-  // in-flight pass may be working off now-stale `haEnabled`, and if this is
-  // the last trigger the namespace would be stranded forever. Record it and
-  // re-run once the current pass settles (cursor + meroreviewer).
+  // Eviction concurrency guard. This is a *counting* semaphore, NOT a
+  // boolean: both the reconcile effect and the `toggleHa` disable fast-path
+  // are eviction "owners", and a boolean let an in-flight reconcile's
+  // `finally` clear a flag that `toggleHa` had set — re-opening the gate
+  // mid-disable and allowing a concurrent tree walk (cursor). A counter
+  // only re-opens once every owner has released. A new reconcile pass
+  // starts only when the count is 0.
+  const reconcileBusyRef = useRef(0);
+  // A trigger arriving while an eviction is in flight must NOT be dropped:
+  // the in-flight pass may be working off now-stale `haEnabled`, and if this
+  // is the last trigger the namespace would be stranded forever. Record it
+  // and re-run once the count drains to 0 (cursor + meroreviewer).
   const reconcilePendingRef = useRef(false);
-  // Bounded self-heal for the `listFailed` case (transient node token /
-  // hung merod / gossip lag): when a completed pass couldn't fully
-  // enumerate local state and no other trigger is coming, retry on a timer
-  // up to a cap so the "retries automatically" promise actually holds —
-  // without polling forever (meroreviewer). Reset once a pass fully
-  // enumerates every disabled namespace.
+  // Bounded self-heal: when a completed pass left work undone (couldn't
+  // enumerate local state → `listFailed`, OR a `removeGroupMembers` call
+  // kept failing → `failed > 0`) and no other trigger is coming, retry on a
+  // timer up to a cap so the "retries automatically" promise actually holds
+  // — without polling forever (cursor + meroreviewer). The budget resets on
+  // every genuine `haEnabled` change (see the reset effect below), so each
+  // new disable round gets a fresh set of retries and a persistently-failing
+  // namespace can't starve a newly-disabled one.
   const reconcileRetryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconcileRetryCount = useRef(0);
+  const reconcileExhaustedRef = useRef(false);
   const RECONCILE_MAX_RETRIES = 5;
   const RECONCILE_RETRY_MS = 30_000;
   const [reconcileTick, setReconcileTick] = useState(0);
   const triggerReconcile = useCallback(() => setReconcileTick((t) => t + 1), []);
+
+  // Reset the retry budget whenever the cloud-derived `haEnabled` map
+  // changes — a genuine state change (new disable / cloud refresh) warrants
+  // a fresh set of automatic retries (meroreviewer). Retry-driven re-runs go
+  // through `reconcileTick`, not `haEnabled`, so they don't reset the budget.
+  useEffect(() => {
+    reconcileRetryCount.current = 0;
+    reconcileExhaustedRef.current = false;
+  }, [haEnabled]);
+
   useEffect(() => {
     if (!mero) return;
     const settings = getSettings();
@@ -505,14 +525,14 @@ export default function Namespaces() {
     // HA state we haven't confirmed is off.
     const hasDisabled = Object.values(haEnabled).some((v) => v === false);
     if (!hasDisabled) return;
-    if (reconcileRunningRef.current) {
-      // Defer instead of dropping — re-run after the in-flight pass settles.
+    if (reconcileBusyRef.current > 0) {
+      // Defer instead of dropping — re-run after the count drains to 0.
       reconcilePendingRef.current = true;
       return;
     }
 
     let cancelled = false;
-    reconcileRunningRef.current = true;
+    reconcileBusyRef.current += 1;
     reconcilePendingRef.current = false;
     const deps = buildEvictionDeps({
       mero,
@@ -532,31 +552,41 @@ export default function Namespaces() {
             `Cleaned up ${evicted} stranded TEE member(s) from HA-disabled namespace(s)`,
           );
         }
-        // Fully enumerated → clear the retry budget. Otherwise schedule a
-        // bounded retry so a transient failure self-heals even when
-        // `haEnabled` never changes again (no cloud-status polling exists).
-        if (touched.some((r) => r.listFailed)) {
-          if (
-            reconcileRetryTimer.current === null &&
-            reconcileRetryCount.current < RECONCILE_MAX_RETRIES
-          ) {
+        // "Done" means every disabled namespace was fully enumerated AND had
+        // no failed removes. Anything short of that (listFailed OR a leftover
+        // remove failure) schedules a bounded retry, so the self-heal also
+        // covers the case where enumeration succeeds but removal keeps
+        // failing (cursor). On success, clear the budget.
+        const needsRetry = touched.some((r) => r.listFailed || r.failed > 0);
+        if (!needsRetry) {
+          reconcileRetryCount.current = 0;
+          reconcileExhaustedRef.current = false;
+        } else if (reconcileRetryTimer.current === null) {
+          if (reconcileRetryCount.current < RECONCILE_MAX_RETRIES) {
             reconcileRetryCount.current += 1;
             reconcileRetryTimer.current = setTimeout(() => {
               reconcileRetryTimer.current = null;
               triggerReconcile();
             }, RECONCILE_RETRY_MS);
+          } else if (!reconcileExhaustedRef.current) {
+            // Out of automatic retries — surface it once so the user isn't
+            // left believing cleanup is still in progress (meroreviewer).
+            reconcileExhaustedRef.current = true;
+            toast.error(
+              'Automatic TEE cleanup did not finish after several retries. ' +
+                'Toggle HA off again, or restart the app, to retry.',
+            );
           }
-        } else {
-          reconcileRetryCount.current = 0;
         }
       })
       .catch(() => {
         // Best-effort; never surface a reconcile failure as an error toast.
       })
       .finally(() => {
-        reconcileRunningRef.current = false;
-        // A trigger arrived mid-pass — re-run against the latest state.
-        if (reconcilePendingRef.current) {
+        reconcileBusyRef.current = Math.max(0, reconcileBusyRef.current - 1);
+        // All owners released and a trigger arrived mid-pass — re-run
+        // against the latest state.
+        if (reconcileBusyRef.current === 0 && reconcilePendingRef.current) {
           reconcilePendingRef.current = false;
           triggerReconcile();
         }
@@ -590,15 +620,16 @@ export default function Namespaces() {
     try {
       if (isEnabled) {
         await disableHaNamespace(token, nsId);
-        // Claim the reconcile mutex BEFORE flipping `haEnabled` to false.
-        // That state change triggers the reconcile effect; without the
-        // claim it would walk the same namespace tree concurrently with
-        // our own eviction below, double-issuing removes and duplicating
-        // the success toast (cursor). With the claim, the effect defers
-        // (pending-rerun); the inner `finally` releases it and triggers a
-        // single reconcile pass to mop up any leftovers / retry a
-        // listFailed.
-        reconcileRunningRef.current = true;
+        // Acquire the eviction semaphore BEFORE flipping `haEnabled` to
+        // false. That state change triggers the reconcile effect; without
+        // the claim it would walk the same namespace tree concurrently with
+        // our own eviction below, double-issuing removes and duplicating the
+        // success toast (cursor). Because it's a counter (not a boolean), an
+        // unrelated in-flight reconcile releasing its own hold can't re-open
+        // the gate while we still hold it. The effect defers (pending-rerun)
+        // until the count drains; the inner `finally` releases our hold and
+        // triggers a single reconcile pass to mop up leftovers / retry.
+        reconcileBusyRef.current += 1;
         setHaEnabled((prev) => ({ ...prev, [nsId]: false }));
         try {
           // Cloud-side disable is done; now evict any admitted TEE members
@@ -648,11 +679,19 @@ export default function Namespaces() {
             toast.success('HA disabled — TEE nodes will stop replicating');
           }
         } finally {
-          // Release the mutex and let the reconcile run once against the
+          // Release our hold and let the reconcile run once against the
           // latest state (idempotent no-op if we already cleaned up; a
-          // genuine retry if our fast-path eviction hit listFailed).
-          reconcileRunningRef.current = false;
-          triggerReconcile();
+          // genuine retry if our fast-path eviction left work undone). If
+          // another eviction is still in flight, the count stays > 0 and the
+          // pending-rerun mechanism re-triggers once it drains.
+          reconcileBusyRef.current = Math.max(0, reconcileBusyRef.current - 1);
+          if (reconcileBusyRef.current === 0) {
+            triggerReconcile();
+          } else {
+            // Another eviction is still in flight — let it re-trigger once
+            // the count drains, rather than racing a pass against it now.
+            reconcilePendingRef.current = true;
+          }
         }
       } else {
         // HA is namespace-scoped: always authorise via the namespace

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -579,6 +579,9 @@ export default function Namespaces() {
           reconcileExhaustedRef.current = false;
           clearReconcileRetryTimer();
         } else if (reconcileRetryTimer.current === null) {
+          // A timer already pending from a previous pass is left to fire on
+          // its original schedule rather than resetting the interval — the
+          // retry still happens, just not re-deferred by a later pass.
           if (reconcileRetryCount.current < RECONCILE_MAX_RETRIES) {
             reconcileRetryCount.current += 1;
             reconcileRetryTimer.current = setTimeout(() => {

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -26,6 +26,13 @@ import {
 import { getCloudIdToken } from "../utils/cloudAuth";
 import { getAccessToken } from "../lib/token-storage";
 import { parseJwtPayload } from "../utils/jwt";
+import {
+  buildEvictionDeps,
+  evictTeeMembersFromTree,
+  extractMembersFromResponse,
+  reconcileDisabledNamespaces,
+  type EvictionResult,
+} from "../utils/teeEviction";
 import { useCloudEnabled } from "../hooks/useCloudEnabled";
 import "./Namespaces.css";
 
@@ -61,24 +68,6 @@ function parseApiError(e: any): string {
 }
 
 const DEFAULT_NAMESPACE_CAPABILITIES = 1 | 2 | 8;
-
-/**
- * Extract the `members` array from a merod `/admin-api/groups/{ns}/members`
- * response. Mero-js's admin response shape varies across versions —
- * direct `members` array on some routes, wrapped `data.members` on
- * others — so both sites that consume this endpoint (the list-members
- * useEffect and the post-disable eviction helper) hit the dual-path
- * lookup. Centralised here so a future shape change is one edit.
- *
- * Returns `null` (not `[]`) when the response shape is unrecognised,
- * so callers can distinguish "no members" from "couldn't tell" and
- * fail closed where appropriate. tauri-app#107 v4 review.
- */
-function extractMembersFromResponse(json: unknown): unknown[] | null {
-  const raw = (json as { members?: unknown; data?: { members?: unknown } })?.members
-    ?? (json as { data?: { members?: unknown } })?.data?.members;
-  return Array.isArray(raw) ? raw : null;
-}
 
 interface InstalledApp {
   id: string;
@@ -366,113 +355,55 @@ export default function Namespaces() {
   };
 
   /**
-   * Evict every `ReadOnlyTee` member from the owner's local merod state for
-   * the given namespace. Called after a successful cloud `disable-ha` so the
-   * owner publishes `MemberRemoved` over gossip (which fires the existing
-   * key-rotation pipeline, granting forward secrecy on new namespace writes
-   * by excluding the evicted peer from the wrapped new key) and the fleet
-   * node's merod receives the eviction event.
+   * Evict every `ReadOnlyTee` member from the owner's local merod state
+   * across the namespace's *entire* group tree — root + all subgroups,
+   * recursively. Called after a successful cloud `disable-ha` so the
+   * owner publishes `MemberRemoved` over gossip for each.
    *
-   * Auth: uses the **local node access token** (`getAccessToken()`), NOT
-   * the cloud session token. The admin API at `${settings.nodeUrl}/admin-api`
-   * lives on the user's own merod process and authenticates against its
-   * own token. v1 of this helper threaded the cloud token here by mistake
-   * (mirroring the wrong useEffect; the canonical list-members useEffect
-   * uses `getAccessToken()`). Caught in tauri-app#107 review.
+   * Two distinct effects, both required (tauri-app#106):
+   *   • The ROOT removal drives the TEE's own `self_purge` (core: one
+   *     root removal triggers `PurgeAction::Namespace`, tearing down keys
+   *     + storage for the whole namespace + subgroups) and fires the
+   *     key-rotation pipeline (forward secrecy on new writes).
+   *   • The PER-SUBGROUP removals clear the OWNER's own ledger. A root
+   *     `MemberRemoved` does NOT cascade to subgroups on the owner's side
+   *     (only the TEE's self-`MemberLeft` cascades), so without these the
+   *     owner still shows the fleet node in private channels — the exact
+   *     symptom this fixes (Bug 2).
    *
-   * Best-effort: failures fall into two distinct buckets that the caller
-   * differentiates in the toast — `listFailed` (couldn't enumerate TEE
-   * members at all) vs `failed` (a specific remove call errored). Auto-
-   * retry is NOT available: by the time this runs, `haEnabled` has
-   * already flipped to false, so the disable branch can't be re-clicked.
-   * The user has to re-enable HA and disable again, or restart the
-   * desktop, to retry. The toast says so honestly.
+   * Auth: the per-group members listing uses the **local node access
+   * token** (`getAccessToken()`), NOT the cloud session token — the same
+   * canonical path the list-members `useEffect` uses (tauri-app#107
+   * review). A missing/expired node token, a hung merod (5s timeout), or
+   * an unreadable subgroup surfaces as `listFailed: true`; the reconcile
+   * on the next namespace/HA-status load retries automatically, so a
+   * single transient failure no longer strands the TEE forever (Bug 1).
    *
-   * The list-members fetch has a 5s `AbortSignal.timeout` so a hung
-   * merod doesn't block the disable flow indefinitely.
+   * Best-effort: never throws. The tree walk + idempotent removals live
+   * in `utils/teeEviction.ts` (pure, unit-tested). Returns counts +
+   * `listFailed` for the caller's honest toast tiers.
    *
-   * See: tauri-app#106, core ADR 0002, core PR #2653.
+   * See: tauri-app#106/#107, core ADR 0002, core PR #2653.
    */
   const evictTeeMembersAfterDisable = async (
     nsId: string,
-  ): Promise<{ evicted: number; failed: number; listFailed: boolean }> => {
+  ): Promise<EvictionResult> => {
     // Fail closed on every pre-flight that means "we couldn't check what
-    // was local" (mero client not ready, nodeUrl unconfigured, no node
-    // token). The toast then honestly says cleanup is pending instead
-    // of claiming success. tauri-app#107 v3 review (cursor + meroreviewer).
-    if (!mero) return { evicted: 0, failed: 0, listFailed: true };
+    // was local" (mero client not ready, nodeUrl unconfigured). The toast
+    // then honestly says cleanup is pending instead of claiming success;
+    // the reconcile retries. A missing node token is handled inside the
+    // deps (→ listFailed), not here, so the reconcile path shares it.
+    // tauri-app#107 v3 review (cursor + meroreviewer).
+    if (!mero) return { evicted: 0, failed: 0, listFailed: true, groupsVisited: 0 };
     const settings = getSettings();
-    if (!settings.nodeUrl) return { evicted: 0, failed: 0, listFailed: true };
-    const nodeToken = getAccessToken();
-    if (!nodeToken) return { evicted: 0, failed: 0, listFailed: true };
+    if (!settings.nodeUrl) return { evicted: 0, failed: 0, listFailed: true, groupsVisited: 0 };
 
-    let teeMembers: { identity: string }[];
-    try {
-      const resp = await fetch(
-        `${settings.nodeUrl}/admin-api/groups/${encodeURIComponent(nsId)}/members`,
-        {
-          headers: { Authorization: `Bearer ${nodeToken}` },
-          signal: AbortSignal.timeout(5000),
-        },
-      );
-      if (!resp.ok) {
-        console.warn(
-          `evictTeeMembersAfterDisable: list-members http=${resp.status} for ns=${nsId} — cleanup pending`,
-        );
-        return { evicted: 0, failed: 0, listFailed: true };
-      }
-      const json = await resp.json();
-      // Fail closed on bad shape: missing or non-array `members` means
-      // we can't tell what role each entry has, so we cannot safely
-      // report "no TEE peers present" — we don't know. Treat as
-      // `listFailed`. The dual-path response normalisation lives in
-      // `extractMembersFromResponse` (top of file). tauri-app#107 v3
-      // review (cursor "Bad members body skips eviction") + v4 DRY.
-      const raw = extractMembersFromResponse(json);
-      if (raw === null) {
-        console.warn(
-          `evictTeeMembersAfterDisable: list-members body had no array \`members\` field for ns=${nsId} — cleanup pending`,
-        );
-        return { evicted: 0, failed: 0, listFailed: true };
-      }
-      teeMembers = raw
-        .filter(
-          (m: unknown): m is { identity: string; role: string } =>
-            typeof (m as { identity?: unknown })?.identity === 'string'
-            && (m as { role?: unknown })?.role === 'ReadOnlyTee',
-        )
-        .map((m) => ({ identity: m.identity }));
-    } catch (e) {
-      // Don't log the raw error object — it may contain headers/URL with
-      // the bearer token. Log a redacted summary instead.
-      console.warn(
-        `evictTeeMembersAfterDisable: list-members fetch threw for ns=${nsId} (${(e as Error)?.name ?? 'unknown'})`,
-      );
-      return { evicted: 0, failed: 0, listFailed: true };
-    }
-
-    if (teeMembers.length === 0) {
-      return { evicted: 0, failed: 0, listFailed: false };
-    }
-
-    let evicted = 0;
-    let failed = 0;
-    for (const m of teeMembers) {
-      try {
-        await mero.admin.removeGroupMembers(nsId, { members: [m.identity] });
-        evicted += 1;
-      } catch (e) {
-        // Truncate the identity (cryptographic public-key string) in the
-        // log: enough prefix to correlate with admin tooling, not enough
-        // to be a tracking primitive on its own. tauri-app#107 v3 review.
-        const idShort = `${m.identity.slice(0, 8)}…`;
-        console.warn(
-          `evictTeeMembersAfterDisable: remove failed for ns=${nsId} identity=${idShort} (${(e as Error)?.name ?? 'unknown'})`,
-        );
-        failed += 1;
-      }
-    }
-    return { evicted, failed, listFailed: false };
+    const deps = buildEvictionDeps({
+      mero,
+      nodeUrl: settings.nodeUrl,
+      getNodeToken: getAccessToken,
+    });
+    return evictTeeMembersFromTree(deps, nsId);
   };
 
   const handleJoinNamespace = async (invitationText: string) => {
@@ -532,6 +463,65 @@ export default function Namespaces() {
     return () => { cancelled = true; };
   }, []);
 
+  // ── Reconcile: self-heal stranded TEE members ──
+  // The post-toggle eviction (in `toggleHa`) is the fast path, but it can
+  // bail transiently (expired node token, hung merod, gossip not yet
+  // propagated) and — because `haEnabled` has already flipped to false —
+  // the disable branch can no longer be re-clicked. Without a retry the
+  // TEE is stranded in the owner's ledger forever (Bug 1).
+  //
+  // This reconcile runs whenever the cloud-derived `haEnabled` map changes
+  // (namespace load / HA-status refresh) and re-evicts any `ReadOnlyTee`
+  // member that is still present locally for a namespace the cloud reports
+  // as HA-DISABLED. It walks the whole tree (root + subgroups), so it also
+  // mops up subgroup rows the root-only v1 left behind (Bug 2). Idempotent
+  // and skips namespaces with no local TEE members, so the steady state is
+  // a cheap no-op.
+  const reconcileRunningRef = useRef(false);
+  useEffect(() => {
+    if (!mero) return;
+    const settings = getSettings();
+    if (!settings.nodeUrl) return;
+    // Only act when the cloud has actually told us at least one namespace
+    // is disabled. `=== false` (not `undefined`) gates this — `undefined`
+    // means "unknown / not in cloud", and we must not evict a TEE whose
+    // HA state we haven't confirmed is off.
+    const hasDisabled = Object.values(haEnabled).some((v) => v === false);
+    if (!hasDisabled) return;
+    if (reconcileRunningRef.current) return;
+
+    let cancelled = false;
+    reconcileRunningRef.current = true;
+    const deps = buildEvictionDeps({
+      mero,
+      nodeUrl: settings.nodeUrl,
+      getNodeToken: getAccessToken,
+    });
+    reconcileDisabledNamespaces(deps, haEnabled)
+      .then((results) => {
+        if (cancelled) return;
+        const touched = Object.values(results);
+        const evicted = touched.reduce((n, r) => n + r.evicted, 0);
+        if (evicted > 0) {
+          // We changed local membership — mirror it into the UI.
+          setNsMembersVersion((v) => v + 1);
+          refetchGroupMembers?.();
+          toast.success(
+            `Cleaned up ${evicted} stranded TEE member(s) from HA-disabled namespace(s)`,
+          );
+        }
+      })
+      .catch(() => {
+        // Best-effort; never surface a reconcile failure as an error toast.
+        // The next `haEnabled` change retries.
+      })
+      .finally(() => {
+        reconcileRunningRef.current = false;
+      });
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [haEnabled, mero]);
+
   const toggleHa = useCallback(async (ns: Namespace) => {
     const token = getCloudIdToken();
     if (!token) { toast.error('Connect to Calimero Cloud first (Settings → Cloud)'); return; }
@@ -564,25 +554,26 @@ export default function Namespaces() {
           setNsMembersVersion((v) => v + 1);
           refetchGroupMembers?.();
         }
-        // Toast tiers — honest about what happened and what the user can do:
+        // Toast tiers — honest about what happened. Unlike v1, a transient
+        // failure here is NOT a dead end: the reconcile (which runs on
+        // namespace/HA-status load) retries automatically, so the copy now
+        // says "will retry" rather than "restart to retry" (tauri-app#106).
         //   * everything succeeded → standard success
-        //   * list-members fetch failed → cloud is disabled but we don't
-        //     know what's local; user must re-enable + disable or restart
-        //     to retry (no auto-retry exists because haEnabled is already
-        //     false, so the disable branch is no longer reachable from
-        //     this UI control — tauri-app#107 review)
-        //   * partial per-member failure → same retry caveat applies
+        //   * list-members fetch / subgroup walk failed → cloud is
+        //     disabled but we couldn't fully enumerate what's local; the
+        //     reconcile retries on next load
+        //   * partial per-member failure → reconcile retries the leftovers
         //   * zero TEE members found locally → nothing to evict (fleet
         //     never admitted before disable, or gossip hadn't propagated)
         if (evictResult.listFailed) {
           toast.success(
-            'HA disabled cloud-side. Local membership cleanup failed — ' +
-              're-enable then disable HA, or restart the desktop, to retry.',
+            'HA disabled cloud-side. Local membership cleanup is incomplete — ' +
+              'it will retry automatically on the next refresh.',
           );
         } else if (evictResult.failed > 0) {
           toast.success(
             `HA disabled — ${evictResult.evicted} TEE member(s) evicted, ` +
-              `${evictResult.failed} cleanup failed. Re-enable then disable HA to retry.`,
+              `${evictResult.failed} cleanup failed; will retry automatically.`,
           );
         } else if (evictResult.evicted > 0) {
           toast.success(

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -586,7 +586,8 @@ export default function Namespaces() {
             reconcileRetryCount.current += 1;
             reconcileRetryTimer.current = setTimeout(() => {
               reconcileRetryTimer.current = null;
-              triggerReconcile();
+              // Mirror the `.finally` guard: don't re-trigger after unmount.
+              if (reconcileMountedRef.current) triggerReconcile();
             }, RECONCILE_RETRY_MS);
           } else if (!reconcileExhaustedRef.current) {
             // Out of automatic retries — surface it once so the user isn't

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -495,30 +495,42 @@ export default function Namespaces() {
   // kept failing → `failed > 0`) and no other trigger is coming, retry on a
   // timer up to a cap so the "retries automatically" promise actually holds
   // — without polling forever (cursor + meroreviewer). The budget resets on
-  // every genuine `haEnabled` change (see the reset effect below), so each
-  // new disable round gets a fresh set of retries and a persistently-failing
-  // namespace can't starve a newly-disabled one.
+  // every genuine `haEnabled` change, so each new disable round gets a fresh
+  // set of retries and a persistently-failing namespace can't starve a
+  // newly-disabled one.
   const reconcileRetryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconcileRetryCount = useRef(0);
   const reconcileExhaustedRef = useRef(false);
+  // The `haEnabled` reference the retry budget was last reset for. Reset on a
+  // genuine reference change (new disable / cloud refresh) but NOT on retry-
+  // driven re-runs (same reference, only `reconcileTick` bumps). Doing this
+  // inside the effect — instead of a separate `[haEnabled]` effect — keeps
+  // the reset from racing the in-flight pass's retry bookkeeping (mero).
+  const reconcileBudgetKeyRef = useRef(haEnabled);
   const RECONCILE_MAX_RETRIES = 5;
   const RECONCILE_RETRY_MS = 30_000;
   const [reconcileTick, setReconcileTick] = useState(0);
   const triggerReconcile = useCallback(() => setReconcileTick((t) => t + 1), []);
-
-  // Reset the retry budget whenever the cloud-derived `haEnabled` map
-  // changes — a genuine state change (new disable / cloud refresh) warrants
-  // a fresh set of automatic retries (meroreviewer). Retry-driven re-runs go
-  // through `reconcileTick`, not `haEnabled`, so they don't reset the budget.
-  useEffect(() => {
-    reconcileRetryCount.current = 0;
-    reconcileExhaustedRef.current = false;
-  }, [haEnabled]);
+  const clearReconcileRetryTimer = useCallback(() => {
+    if (reconcileRetryTimer.current !== null) {
+      clearTimeout(reconcileRetryTimer.current);
+      reconcileRetryTimer.current = null;
+    }
+  }, []);
 
   useEffect(() => {
     if (!mero) return;
     const settings = getSettings();
     if (!settings.nodeUrl) return;
+    // Fresh retry budget on a genuine `haEnabled` change; retry-driven
+    // re-runs (same reference, new tick) keep the current budget. The prior
+    // pass is already `cancelled` by the time we get here, so this can't
+    // race its bookkeeping (mero).
+    if (reconcileBudgetKeyRef.current !== haEnabled) {
+      reconcileBudgetKeyRef.current = haEnabled;
+      reconcileRetryCount.current = 0;
+      reconcileExhaustedRef.current = false;
+    }
     // Only act when the cloud has actually told us at least one namespace
     // is disabled. `=== false` (not `undefined`) gates this — `undefined`
     // means "unknown / not in cloud", and we must not evict a TEE whose
@@ -532,6 +544,7 @@ export default function Namespaces() {
     }
 
     let cancelled = false;
+    const controller = new AbortController();
     reconcileBusyRef.current += 1;
     reconcilePendingRef.current = false;
     const deps = buildEvictionDeps({
@@ -539,28 +552,22 @@ export default function Namespaces() {
       nodeUrl: settings.nodeUrl,
       getNodeToken: getAccessToken,
     });
-    reconcileDisabledNamespaces(deps, haEnabled)
+    reconcileDisabledNamespaces(deps, haEnabled, {
+      shouldAbort: () => controller.signal.aborted,
+    })
       .then((results) => {
         if (cancelled) return;
         const touched = Object.values(results);
-        const evicted = touched.reduce((n, r) => n + r.evicted, 0);
-        if (evicted > 0) {
-          // We changed local membership — mirror it into the UI.
-          setNsMembersVersion((v) => v + 1);
-          refetchGroupMembers?.();
-          toast.success(
-            `Cleaned up ${evicted} stranded TEE member(s) from HA-disabled namespace(s)`,
-          );
-        }
-        // "Done" means every disabled namespace was fully enumerated AND had
-        // no failed removes. Anything short of that (listFailed OR a leftover
-        // remove failure) schedules a bounded retry, so the self-heal also
-        // covers the case where enumeration succeeds but removal keeps
-        // failing (cursor). On success, clear the budget.
+        // Schedule the retry / clear the budget BEFORE the UI mirroring
+        // below, so a throw from a `toast`/refetch call can never drop a
+        // needed retry (mero). "Done" = every disabled namespace fully
+        // enumerated with no failed removes; anything short of that
+        // (listFailed OR `failed > 0`) schedules a bounded retry (cursor).
         const needsRetry = touched.some((r) => r.listFailed || r.failed > 0);
         if (!needsRetry) {
           reconcileRetryCount.current = 0;
           reconcileExhaustedRef.current = false;
+          clearReconcileRetryTimer();
         } else if (reconcileRetryTimer.current === null) {
           if (reconcileRetryCount.current < RECONCILE_MAX_RETRIES) {
             reconcileRetryCount.current += 1;
@@ -578,9 +585,23 @@ export default function Namespaces() {
             );
           }
         }
+        const evicted = touched.reduce((n, r) => n + r.evicted, 0);
+        if (evicted > 0) {
+          // We changed local membership — mirror it into the UI.
+          setNsMembersVersion((v) => v + 1);
+          refetchGroupMembers?.();
+          toast.success(
+            `Cleaned up ${evicted} stranded TEE member(s) from HA-disabled namespace(s)`,
+          );
+        }
       })
-      .catch(() => {
-        // Best-effort; never surface a reconcile failure as an error toast.
+      .catch((e) => {
+        // `reconcileDisabledNamespaces` is best-effort and should not
+        // reject; a rejection here signals a programming error, so log it
+        // (no user-facing toast) rather than swallowing it silently (mero).
+        console.warn(
+          `reconcile: unexpected rejection (${(e as Error)?.name ?? 'unknown'})`,
+        );
       })
       .finally(() => {
         reconcileBusyRef.current = Math.max(0, reconcileBusyRef.current - 1);
@@ -591,20 +612,19 @@ export default function Namespaces() {
           triggerReconcile();
         }
       });
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+      // Stop the in-flight mutating walk for this now-superseded snapshot
+      // (e.g. HA was re-enabled mid-walk) and drop any pending retry timer;
+      // the re-run reschedules a retry if one is still needed (cursor + mero).
+      controller.abort();
+      clearReconcileRetryTimer();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [haEnabled, mero, reconcileTick]);
 
   // Clear any pending reconcile retry timer on unmount.
-  useEffect(
-    () => () => {
-      if (reconcileRetryTimer.current !== null) {
-        clearTimeout(reconcileRetryTimer.current);
-        reconcileRetryTimer.current = null;
-      }
-    },
-    [],
-  );
+  useEffect(() => clearReconcileRetryTimer, [clearReconcileRetryTimer]);
 
   const toggleHa = useCallback(async (ns: Namespace) => {
     const token = getCloudIdToken();

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -478,6 +478,23 @@ export default function Namespaces() {
   // and skips namespaces with no local TEE members, so the steady state is
   // a cheap no-op.
   const reconcileRunningRef = useRef(false);
+  // A trigger arriving while a pass is in flight must NOT be dropped: the
+  // in-flight pass may be working off now-stale `haEnabled`, and if this is
+  // the last trigger the namespace would be stranded forever. Record it and
+  // re-run once the current pass settles (cursor + meroreviewer).
+  const reconcilePendingRef = useRef(false);
+  // Bounded self-heal for the `listFailed` case (transient node token /
+  // hung merod / gossip lag): when a completed pass couldn't fully
+  // enumerate local state and no other trigger is coming, retry on a timer
+  // up to a cap so the "retries automatically" promise actually holds —
+  // without polling forever (meroreviewer). Reset once a pass fully
+  // enumerates every disabled namespace.
+  const reconcileRetryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconcileRetryCount = useRef(0);
+  const RECONCILE_MAX_RETRIES = 5;
+  const RECONCILE_RETRY_MS = 30_000;
+  const [reconcileTick, setReconcileTick] = useState(0);
+  const triggerReconcile = useCallback(() => setReconcileTick((t) => t + 1), []);
   useEffect(() => {
     if (!mero) return;
     const settings = getSettings();
@@ -488,10 +505,15 @@ export default function Namespaces() {
     // HA state we haven't confirmed is off.
     const hasDisabled = Object.values(haEnabled).some((v) => v === false);
     if (!hasDisabled) return;
-    if (reconcileRunningRef.current) return;
+    if (reconcileRunningRef.current) {
+      // Defer instead of dropping — re-run after the in-flight pass settles.
+      reconcilePendingRef.current = true;
+      return;
+    }
 
     let cancelled = false;
     reconcileRunningRef.current = true;
+    reconcilePendingRef.current = false;
     const deps = buildEvictionDeps({
       mero,
       nodeUrl: settings.nodeUrl,
@@ -510,17 +532,49 @@ export default function Namespaces() {
             `Cleaned up ${evicted} stranded TEE member(s) from HA-disabled namespace(s)`,
           );
         }
+        // Fully enumerated → clear the retry budget. Otherwise schedule a
+        // bounded retry so a transient failure self-heals even when
+        // `haEnabled` never changes again (no cloud-status polling exists).
+        if (touched.some((r) => r.listFailed)) {
+          if (
+            reconcileRetryTimer.current === null &&
+            reconcileRetryCount.current < RECONCILE_MAX_RETRIES
+          ) {
+            reconcileRetryCount.current += 1;
+            reconcileRetryTimer.current = setTimeout(() => {
+              reconcileRetryTimer.current = null;
+              triggerReconcile();
+            }, RECONCILE_RETRY_MS);
+          }
+        } else {
+          reconcileRetryCount.current = 0;
+        }
       })
       .catch(() => {
         // Best-effort; never surface a reconcile failure as an error toast.
-        // The next `haEnabled` change retries.
       })
       .finally(() => {
         reconcileRunningRef.current = false;
+        // A trigger arrived mid-pass — re-run against the latest state.
+        if (reconcilePendingRef.current) {
+          reconcilePendingRef.current = false;
+          triggerReconcile();
+        }
       });
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [haEnabled, mero]);
+  }, [haEnabled, mero, reconcileTick]);
+
+  // Clear any pending reconcile retry timer on unmount.
+  useEffect(
+    () => () => {
+      if (reconcileRetryTimer.current !== null) {
+        clearTimeout(reconcileRetryTimer.current);
+        reconcileRetryTimer.current = null;
+      }
+    },
+    [],
+  );
 
   const toggleHa = useCallback(async (ns: Namespace) => {
     const token = getCloudIdToken();
@@ -536,52 +590,69 @@ export default function Namespaces() {
     try {
       if (isEnabled) {
         await disableHaNamespace(token, nsId);
+        // Claim the reconcile mutex BEFORE flipping `haEnabled` to false.
+        // That state change triggers the reconcile effect; without the
+        // claim it would walk the same namespace tree concurrently with
+        // our own eviction below, double-issuing removes and duplicating
+        // the success toast (cursor). With the claim, the effect defers
+        // (pending-rerun); the inner `finally` releases it and triggers a
+        // single reconcile pass to mop up any leftovers / retry a
+        // listFailed.
+        reconcileRunningRef.current = true;
         setHaEnabled((prev) => ({ ...prev, [nsId]: false }));
-        // Cloud-side disable is done; now evict any admitted TEE members
-        // from this owner's local merod. Without this, `MemberRemoved` is
-        // never published, no key rotation fires, and the fleet node
-        // remains a `ReadOnlyTee` member of our local group state
-        // indefinitely (see tauri-app#106 + core ADR 0002).
-        const evictResult = await evictTeeMembersAfterDisable(nsId);
-        // Refresh the Members list if any remove call ran (success OR
-        // failure). On `failed > 0` the store state could still have
-        // changed in mero before the failure, and refetching reflects
-        // truth. On pure `listFailed` we have no removals to mirror, so
-        // skip the refresh. Mirrors the `handleRemoveMember` pattern.
-        // tauri-app#107 v3 review (cursor) + v5 review (defensive
-        // `failed > 0` arm per meroreviewer).
-        if (evictResult.evicted > 0 || evictResult.failed > 0) {
-          setNsMembersVersion((v) => v + 1);
-          refetchGroupMembers?.();
-        }
-        // Toast tiers — honest about what happened. Unlike v1, a transient
-        // failure here is NOT a dead end: the reconcile (which runs on
-        // namespace/HA-status load) retries automatically, so the copy now
-        // says "will retry" rather than "restart to retry" (tauri-app#106).
-        //   * everything succeeded → standard success
-        //   * list-members fetch / subgroup walk failed → cloud is
-        //     disabled but we couldn't fully enumerate what's local; the
-        //     reconcile retries on next load
-        //   * partial per-member failure → reconcile retries the leftovers
-        //   * zero TEE members found locally → nothing to evict (fleet
-        //     never admitted before disable, or gossip hadn't propagated)
-        if (evictResult.listFailed) {
-          toast.success(
-            'HA disabled cloud-side. Local membership cleanup is incomplete — ' +
-              'it will retry automatically on the next refresh.',
-          );
-        } else if (evictResult.failed > 0) {
-          toast.success(
-            `HA disabled — ${evictResult.evicted} TEE member(s) evicted, ` +
-              `${evictResult.failed} cleanup failed; will retry automatically.`,
-          );
-        } else if (evictResult.evicted > 0) {
-          toast.success(
-            `HA disabled — ${evictResult.evicted} TEE member(s) evicted; ` +
-              'forward secrecy applied via key rotation',
-          );
-        } else {
-          toast.success('HA disabled — TEE nodes will stop replicating');
+        try {
+          // Cloud-side disable is done; now evict any admitted TEE members
+          // from this owner's local merod. Without this, `MemberRemoved` is
+          // never published, no key rotation fires, and the fleet node
+          // remains a `ReadOnlyTee` member of our local group state
+          // indefinitely (see tauri-app#106 + core ADR 0002).
+          const evictResult = await evictTeeMembersAfterDisable(nsId);
+          // Refresh the Members list if any remove call ran (success OR
+          // failure). On `failed > 0` the store state could still have
+          // changed in mero before the failure, and refetching reflects
+          // truth. On pure `listFailed` we have no removals to mirror, so
+          // skip the refresh. Mirrors the `handleRemoveMember` pattern.
+          // tauri-app#107 v3 review (cursor) + v5 review (defensive
+          // `failed > 0` arm per meroreviewer).
+          if (evictResult.evicted > 0 || evictResult.failed > 0) {
+            setNsMembersVersion((v) => v + 1);
+            refetchGroupMembers?.();
+          }
+          // Toast tiers — honest about what happened. Unlike v1, a transient
+          // failure here is NOT a dead end: the reconcile (which runs on
+          // namespace/HA-status load) retries automatically, so the copy now
+          // says "will retry" rather than "restart to retry" (tauri-app#106).
+          //   * everything succeeded → standard success
+          //   * list-members fetch / subgroup walk failed → cloud is
+          //     disabled but we couldn't fully enumerate what's local; the
+          //     reconcile retries on next load
+          //   * partial per-member failure → reconcile retries the leftovers
+          //   * zero TEE members found locally → nothing to evict (fleet
+          //     never admitted before disable, or gossip hadn't propagated)
+          if (evictResult.listFailed) {
+            toast.success(
+              'HA disabled cloud-side. Local membership cleanup is incomplete — ' +
+                'it will retry automatically on the next refresh.',
+            );
+          } else if (evictResult.failed > 0) {
+            toast.success(
+              `HA disabled — ${evictResult.evicted} TEE member(s) evicted, ` +
+                `${evictResult.failed} cleanup failed; will retry automatically.`,
+            );
+          } else if (evictResult.evicted > 0) {
+            toast.success(
+              `HA disabled — ${evictResult.evicted} TEE member(s) evicted; ` +
+                'forward secrecy applied via key rotation',
+            );
+          } else {
+            toast.success('HA disabled — TEE nodes will stop replicating');
+          }
+        } finally {
+          // Release the mutex and let the reconcile run once against the
+          // latest state (idempotent no-op if we already cleaned up; a
+          // genuine retry if our fast-path eviction hit listFailed).
+          reconcileRunningRef.current = false;
+          triggerReconcile();
         }
       } else {
         // HA is namespace-scoped: always authorise via the namespace
@@ -607,7 +678,7 @@ export default function Namespaces() {
     } finally {
       setHaEnabling((prev) => { const next = { ...prev }; delete next[nsId]; return next; });
     }
-  }, [haEnabled, mero, toast]);
+  }, [haEnabled, mero, toast, triggerReconcile]);
 
   // ── Nav ──
   const openNamespace = (ns: Namespace) => { setActionsMenuOpen(false); setView({ type: "namespace", ns }); };

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -551,6 +551,7 @@ export default function Namespaces() {
       mero,
       nodeUrl: settings.nodeUrl,
       getNodeToken: getAccessToken,
+      signal: controller.signal,
     });
     reconcileDisabledNamespaces(deps, haEnabled, {
       shouldAbort: () => controller.signal.aborted,

--- a/apps/desktop/src/utils/teeEviction.test.ts
+++ b/apps/desktop/src/utils/teeEviction.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  enumerateGroupTree,
+  evictTeeMembersFromTree,
+  reconcileDisabledNamespaces,
+  teeIdentitiesFromMembers,
+  extractMembersFromResponse,
+  buildEvictionDeps,
+  type EvictionDeps,
+} from './teeEviction';
+
+// ── A tiny in-memory merod model ──────────────────────────────────────
+//
+// Models the owner's local group ledger: a tree of groups, each with a
+// members list. Lets the tests assert exactly which (group, identity)
+// removals the kick issues across the whole namespace tree.
+
+interface FakeMember {
+  identity: string;
+  role: string;
+}
+
+function makeModel(spec: {
+  // groupId -> direct child groupIds
+  tree: Record<string, string[]>;
+  // groupId -> members
+  members: Record<string, FakeMember[]>;
+}): {
+  deps: EvictionDeps;
+  removed: { groupId: string; identities: string[] }[];
+} {
+  const tree = spec.tree;
+  const members = structuredClone(spec.members);
+  const removed: { groupId: string; identities: string[] }[] = [];
+  const deps: EvictionDeps = {
+    listSubgroups: async (groupId) => tree[groupId] ?? [],
+    listGroupMembers: async (groupId) => members[groupId] ?? [],
+    removeGroupMembers: async (groupId, identities) => {
+      removed.push({ groupId, identities });
+      const present = members[groupId] ?? [];
+      members[groupId] = present.filter((m) => !identities.includes(m.identity));
+    },
+  };
+  return { deps, removed };
+}
+
+describe('extractMembersFromResponse', () => {
+  it('reads a direct members array', () => {
+    expect(extractMembersFromResponse({ members: [{ identity: 'a' }] })).toEqual([
+      { identity: 'a' },
+    ]);
+  });
+  it('reads a wrapped data.members array', () => {
+    expect(
+      extractMembersFromResponse({ data: { members: [{ identity: 'b' }] } }),
+    ).toEqual([{ identity: 'b' }]);
+  });
+  it('returns null on unrecognised shape (fail-closed)', () => {
+    expect(extractMembersFromResponse({})).toBeNull();
+    expect(extractMembersFromResponse(null)).toBeNull();
+    expect(extractMembersFromResponse({ members: 'nope' })).toBeNull();
+  });
+});
+
+describe('teeIdentitiesFromMembers', () => {
+  it('keeps only ReadOnlyTee identities', () => {
+    const raw = [
+      { identity: 'admin1', role: 'Admin' },
+      { identity: 'tee1', role: 'ReadOnlyTee' },
+      { identity: 'ro1', role: 'ReadOnly' },
+      { identity: 'tee2', role: 'ReadOnlyTee' },
+      { role: 'ReadOnlyTee' }, // missing identity → dropped
+      { identity: 42, role: 'ReadOnlyTee' }, // non-string identity → dropped
+    ];
+    expect(teeIdentitiesFromMembers(raw)).toEqual(['tee1', 'tee2']);
+  });
+});
+
+describe('enumerateGroupTree', () => {
+  it('walks root + nested subgroups, deduped, cycle-safe', async () => {
+    const { deps } = makeModel({
+      tree: {
+        root: ['a', 'b'],
+        a: ['a1'],
+        a1: ['root'], // cycle back to root — must not loop
+        b: [],
+      },
+      members: {},
+    });
+    const { groupIds, incomplete } = await enumerateGroupTree(deps, 'root');
+    expect(incomplete).toBe(false);
+    expect(new Set(groupIds)).toEqual(new Set(['root', 'a', 'b', 'a1']));
+    // root is visited first (drives the TEE self-purge)
+    expect(groupIds[0]).toBe('root');
+  });
+
+  it('marks incomplete when a subgroup listing throws but keeps the rest', async () => {
+    const deps: Pick<EvictionDeps, 'listSubgroups'> = {
+      listSubgroups: async (groupId) => {
+        if (groupId === 'root') return ['ok', 'bad'];
+        if (groupId === 'bad') throw new Error('boom');
+        return [];
+      },
+    };
+    const { groupIds, incomplete } = await enumerateGroupTree(deps, 'root');
+    expect(incomplete).toBe(true);
+    expect(new Set(groupIds)).toEqual(new Set(['root', 'ok', 'bad']));
+  });
+});
+
+describe('evictTeeMembersFromTree', () => {
+  it('removes ReadOnlyTee from the root AND every subgroup (Bug 2)', async () => {
+    const { deps, removed } = makeModel({
+      tree: {
+        ns: ['private', 'public'],
+        private: ['private-nested'],
+        public: [],
+        'private-nested': [],
+      },
+      members: {
+        ns: [
+          { identity: 'owner', role: 'Admin' },
+          { identity: 'fleet', role: 'ReadOnlyTee' },
+        ],
+        private: [
+          { identity: 'owner', role: 'Admin' },
+          { identity: 'fleet', role: 'ReadOnlyTee' },
+        ],
+        'private-nested': [{ identity: 'fleet', role: 'ReadOnlyTee' }],
+        public: [{ identity: 'owner', role: 'Admin' }], // no TEE
+      },
+    });
+
+    const result = await evictTeeMembersFromTree(deps, 'ns');
+
+    expect(result.listFailed).toBe(false);
+    expect(result.groupsVisited).toBe(4);
+    expect(result.evicted).toBe(3);
+    expect(result.failed).toBe(0);
+
+    // The TEE was removed from ns root, private subgroup, AND the nested
+    // private subgroup — but never from `public` (no TEE there).
+    const byGroup = removed.map((r) => r.groupId).sort();
+    expect(byGroup).toEqual(['ns', 'private', 'private-nested']);
+    for (const r of removed) expect(r.identities).toEqual(['fleet']);
+  });
+
+  it('is idempotent — a clean tree is a no-op', async () => {
+    const { deps, removed } = makeModel({
+      tree: { ns: ['private'], private: [] },
+      members: {
+        ns: [{ identity: 'owner', role: 'Admin' }],
+        private: [{ identity: 'owner', role: 'Admin' }],
+      },
+    });
+    const result = await evictTeeMembersFromTree(deps, 'ns');
+    expect(result.evicted).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.listFailed).toBe(false);
+    expect(removed).toHaveLength(0);
+  });
+
+  it('counts a benign remove error as failed (already-gone member)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const deps: EvictionDeps = {
+      listSubgroups: async () => [],
+      listGroupMembers: async () => [{ identity: 'fleet', role: 'ReadOnlyTee' }],
+      removeGroupMembers: async () => {
+        throw new Error('not a member');
+      },
+    };
+    const result = await evictTeeMembersFromTree(deps, 'ns');
+    expect(result.evicted).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(result.listFailed).toBe(false);
+    warn.mockRestore();
+  });
+
+  it('reports listFailed when the root members listing fails (fail-closed)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const deps: EvictionDeps = {
+      listSubgroups: async () => [],
+      listGroupMembers: async () => null, // couldn't tell
+      removeGroupMembers: async () => {},
+    };
+    const result = await evictTeeMembersFromTree(deps, 'ns');
+    expect(result.listFailed).toBe(true);
+    expect(result.evicted).toBe(0);
+    warn.mockRestore();
+  });
+
+  it('propagates incomplete enumeration as listFailed', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const deps: EvictionDeps = {
+      listSubgroups: async (g) => {
+        if (g === 'ns') return ['bad'];
+        throw new Error('subgroup unreadable');
+      },
+      listGroupMembers: async () => [],
+      removeGroupMembers: async () => {},
+    };
+    const result = await evictTeeMembersFromTree(deps, 'ns');
+    expect(result.listFailed).toBe(true);
+    warn.mockRestore();
+  });
+});
+
+describe('reconcileDisabledNamespaces', () => {
+  it('evicts only for namespaces the cloud reports as HA-disabled', async () => {
+    const { deps, removed } = makeModel({
+      tree: { 'ns-off': ['sub-off'], 'sub-off': [], 'ns-on': [], 'ns-unknown': [] },
+      members: {
+        // disabled-in-cloud namespace still has a stranded TEE in a subgroup
+        'ns-off': [{ identity: 'owner', role: 'Admin' }],
+        'sub-off': [{ identity: 'fleet', role: 'ReadOnlyTee' }],
+        // enabled namespace also has a TEE — must NOT be touched
+        'ns-on': [{ identity: 'fleet2', role: 'ReadOnlyTee' }],
+        // unknown (undefined) state — must NOT be touched
+        'ns-unknown': [{ identity: 'fleet3', role: 'ReadOnlyTee' }],
+      },
+    });
+
+    const results = await reconcileDisabledNamespaces(deps, {
+      'ns-off': false,
+      'ns-on': true,
+      // 'ns-unknown' intentionally absent → undefined
+    });
+
+    // Only the disabled namespace's TEE (in its subgroup) was removed.
+    expect(removed).toEqual([{ groupId: 'sub-off', identities: ['fleet'] }]);
+    expect(results['ns-off']?.evicted).toBe(1);
+    expect(results['ns-on']).toBeUndefined();
+    expect(results['ns-unknown']).toBeUndefined();
+  });
+
+  it('skips disabled namespaces with no local TEE members (steady state)', async () => {
+    const { deps, removed } = makeModel({
+      tree: { ns: [] },
+      members: { ns: [{ identity: 'owner', role: 'Admin' }] },
+    });
+    const results = await reconcileDisabledNamespaces(deps, { ns: false });
+    expect(removed).toHaveLength(0);
+    expect(results.ns).toBeUndefined();
+  });
+});
+
+describe('buildEvictionDeps', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('lists members via the local node token (fail-closed when no token)', async () => {
+    const fetchImpl = vi.fn();
+    const deps = buildEvictionDeps({
+      mero: { admin: { listSubgroups: async () => [], removeGroupMembers: async () => {} } },
+      nodeUrl: 'http://node',
+      getNodeToken: () => null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const res = await deps.listGroupMembers('ns');
+    expect(res).toBeNull();
+    // No token → we must not even hit the network.
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('lists members with a Bearer node token and normalises the body', async () => {
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect((init?.headers as Record<string, string>).Authorization).toBe(
+        'Bearer node-tok',
+      );
+      return new Response(
+        JSON.stringify({ members: [{ identity: 'fleet', role: 'ReadOnlyTee' }] }),
+        { status: 200 },
+      );
+    });
+    const deps = buildEvictionDeps({
+      mero: { admin: { listSubgroups: async () => [], removeGroupMembers: async () => {} } },
+      nodeUrl: 'http://node',
+      getNodeToken: () => 'node-tok',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const res = await deps.listGroupMembers('ns');
+    expect(res).toEqual([{ identity: 'fleet', role: 'ReadOnlyTee' }]);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('returns null on a non-ok members response', async () => {
+    const fetchImpl = vi.fn(async () => new Response('nope', { status: 401 }));
+    const deps = buildEvictionDeps({
+      mero: { admin: { listSubgroups: async () => [], removeGroupMembers: async () => {} } },
+      nodeUrl: 'http://node',
+      getNodeToken: () => 'node-tok',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(await deps.listGroupMembers('ns')).toBeNull();
+  });
+
+  it('maps SubgroupEntry[] to a string[] of group ids', async () => {
+    const deps = buildEvictionDeps({
+      mero: {
+        admin: {
+          listSubgroups: async () => [
+            { groupId: 'a', name: 'A' },
+            { groupId: 'b' },
+            { groupId: '' }, // dropped
+          ],
+          removeGroupMembers: async () => {},
+        },
+      },
+      nodeUrl: 'http://node',
+      getNodeToken: () => 'node-tok',
+    });
+    expect(await deps.listSubgroups('ns')).toEqual(['a', 'b']);
+  });
+
+  it('forwards removals to mero.admin.removeGroupMembers', async () => {
+    const removeGroupMembers = vi.fn(async () => {});
+    const deps = buildEvictionDeps({
+      mero: { admin: { listSubgroups: async () => [], removeGroupMembers } },
+      nodeUrl: 'http://node',
+      getNodeToken: () => 'node-tok',
+    });
+    await deps.removeGroupMembers('ns', ['fleet']);
+    expect(removeGroupMembers).toHaveBeenCalledWith('ns', { members: ['fleet'] });
+  });
+});

--- a/apps/desktop/src/utils/teeEviction.test.ts
+++ b/apps/desktop/src/utils/teeEviction.test.ts
@@ -267,6 +267,21 @@ describe('buildEvictionDeps', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it('fails closed without touching the network when nodeUrl is not http(s)', async () => {
+    const fetchImpl = vi.fn();
+    for (const nodeUrl of ['javascript:alert(1)', 'data:text/html,x', 'not a url', '']) {
+      const deps = buildEvictionDeps({
+        mero: { admin: { listSubgroups: async () => [], removeGroupMembers: async () => {} } },
+        nodeUrl,
+        getNodeToken: () => 'node-tok',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      expect(await deps.listGroupMembers('ns')).toBeNull();
+    }
+    // An invalid base URL must never reach a token-bearing fetch.
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it('lists members with a Bearer node token and normalises the body', async () => {
     const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
       expect((init?.headers as Record<string, string>).Authorization).toBe(

--- a/apps/desktop/src/utils/teeEviction.test.ts
+++ b/apps/desktop/src/utils/teeEviction.test.ts
@@ -189,6 +189,32 @@ describe('evictTeeMembersFromTree', () => {
     warn.mockRestore();
   });
 
+  it('stops issuing removes once shouldAbort flips true (e.g. HA re-enabled)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { deps, removed } = makeModel({
+      tree: { ns: ['sub'], sub: [] },
+      members: {
+        ns: [{ identity: 'fleet', role: 'ReadOnlyTee' }],
+        sub: [{ identity: 'fleet', role: 'ReadOnlyTee' }],
+      },
+    });
+    let aborted = false;
+    const origRemove = deps.removeGroupMembers;
+    deps.removeGroupMembers = async (g, ids) => {
+      await origRemove(g, ids);
+      aborted = true; // abort right after the first (root) remove
+    };
+    const result = await evictTeeMembersFromTree(deps, 'ns', {
+      shouldAbort: () => aborted,
+    });
+    // Root was evicted, but the subgroup walk stopped — never touched `sub`.
+    expect(result.evicted).toBe(1);
+    expect(removed).toEqual([{ groupId: 'ns', identities: ['fleet'] }]);
+    // Aborting leaves the tree partially walked → reported incomplete.
+    expect(result.listFailed).toBe(true);
+    warn.mockRestore();
+  });
+
   it('propagates incomplete enumeration as listFailed', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const deps: EvictionDeps = {

--- a/apps/desktop/src/utils/teeEviction.test.ts
+++ b/apps/desktop/src/utils/teeEviction.test.ts
@@ -356,6 +356,28 @@ describe('buildEvictionDeps', () => {
     expect(await deps.listGroupMembers('ns')).toBeNull();
   });
 
+  it('rejects listSubgroups when the admin call hangs (deadline)', async () => {
+    vi.useFakeTimers();
+    try {
+      const deps = buildEvictionDeps({
+        mero: {
+          admin: {
+            listSubgroups: () => new Promise<{ groupId: string }[]>(() => {}), // never resolves
+            removeGroupMembers: async () => {},
+          },
+        },
+        nodeUrl: 'http://node',
+        getNodeToken: () => 'node-tok',
+      });
+      const pending = deps.listSubgroups('ns');
+      const assertion = expect(pending).rejects.toThrow();
+      await vi.advanceTimersByTimeAsync(5000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('maps SubgroupEntry[] to a string[] of group ids', async () => {
     const deps = buildEvictionDeps({
       mero: {

--- a/apps/desktop/src/utils/teeEviction.test.ts
+++ b/apps/desktop/src/utils/teeEviction.test.ts
@@ -189,6 +189,22 @@ describe('evictTeeMembersFromTree', () => {
     warn.mockRestore();
   });
 
+  it('does no enumeration or removes when shouldAbort is already true at entry', async () => {
+    const { deps, removed } = makeModel({
+      tree: { ns: ['sub'], sub: [] },
+      members: { ns: [{ identity: 'fleet', role: 'ReadOnlyTee' }] },
+    });
+    const listSubgroups = vi.fn(deps.listSubgroups);
+    const result = await evictTeeMembersFromTree(
+      { ...deps, listSubgroups: listSubgroups as typeof deps.listSubgroups },
+      'ns',
+      { shouldAbort: () => true },
+    );
+    expect(result).toEqual({ evicted: 0, failed: 0, listFailed: true, groupsVisited: 0 });
+    expect(listSubgroups).not.toHaveBeenCalled();
+    expect(removed).toHaveLength(0);
+  });
+
   it('stops issuing removes once shouldAbort flips true (e.g. HA re-enabled)', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { deps, removed } = makeModel({

--- a/apps/desktop/src/utils/teeEviction.ts
+++ b/apps/desktop/src/utils/teeEviction.ts
@@ -238,13 +238,22 @@ export async function reconcileDisabledNamespaces(
 ): Promise<Record<string, EvictionResult>> {
   const results: Record<string, EvictionResult> = {};
   const disabled = Object.keys(haEnabled).filter((nsId) => haEnabled[nsId] === false);
-  for (const nsId of disabled) {
-    // Cheap pre-check on the root only: if the root listing shows no TEE
-    // member AND has no subgroups with TEE members, the full walk would
-    // be a no-op. But a subgroup can hold a stranded TEE even when the
-    // root is clean (Bug 2), so we can't short-circuit on the root alone.
-    // Run the full walk; it skips groups with no TEE members anyway.
-    const result = await evictTeeMembersFromTree(deps, nsId);
+  // Each namespace is an independent tree, so evict them concurrently —
+  // for a user with many HA-disabled namespaces this avoids serialising the
+  // walks. `evictTeeMembersFromTree` is best-effort and never throws, but we
+  // still use `allSettled` so one namespace's failure can never abort the
+  // others. (No root short-circuit: a subgroup can hold a stranded TEE even
+  // when the root is clean — Bug 2 — and the walk already skips groups with
+  // no TEE members.)
+  const settled = await Promise.allSettled(
+    disabled.map(async (nsId): Promise<[string, EvictionResult]> => [
+      nsId,
+      await evictTeeMembersFromTree(deps, nsId),
+    ]),
+  );
+  for (const outcome of settled) {
+    if (outcome.status !== 'fulfilled') continue;
+    const [nsId, result] = outcome.value;
     if (result.evicted > 0 || result.failed > 0 || result.listFailed) {
       results[nsId] = result;
     }
@@ -299,8 +308,32 @@ export function buildEvictionDeps(args: {
 }): EvictionDeps {
   const { mero, nodeUrl, getNodeToken } = args;
   const doFetch = args.fetchImpl ?? fetch;
+  // Validate the node URL once up front: it is interpolated into the
+  // members fetch URL right next to the local node bearer token, so a
+  // malformed / non-http(s) value (e.g. a `javascript:` or `data:` scheme
+  // from a tampered settings store) must never reach `fetch`. We accept any
+  // http/https origin and deliberately do NOT pin loopback — merod can be
+  // configured on a remote/LAN host (the rest of the app interpolates the
+  // same `settings.nodeUrl` without a loopback constraint), so pinning it
+  // would break valid remote-node setups. An invalid URL fails closed
+  // (listGroupMembers → null → listFailed) and the reconcile surfaces it as
+  // "cleanup pending". (meroreviewer review.)
+  let nodeUrlOk = false;
+  try {
+    const proto = new URL(nodeUrl).protocol;
+    nodeUrlOk = proto === 'http:' || proto === 'https:';
+  } catch {
+    nodeUrlOk = false;
+  }
   return {
     listGroupMembers: async (groupId) => {
+      if (!nodeUrlOk) {
+        // Never interpolate an unvalidated URL into a token-bearing fetch.
+        console.warn(
+          'buildEvictionDeps: nodeUrl is not a valid http(s) URL — cleanup pending',
+        );
+        return null;
+      }
       const token = getNodeToken();
       if (!token) {
         // No node token → fail-closed. Reconcile retries once a token

--- a/apps/desktop/src/utils/teeEviction.ts
+++ b/apps/desktop/src/utils/teeEviction.ts
@@ -1,0 +1,347 @@
+// TEE-member eviction / reconcile for the namespace HA-disable flow.
+//
+// Background: HA is namespace-scoped and the namespace is *client-rooted*
+// — the cloud (mdma) has no namespace identity, so it cannot author
+// governance ops. When HA is disabled cloud-side, the OWNER node must be
+// the one to publish `MemberRemoved` for every admitted `ReadOnlyTee`
+// fleet member. The root `MemberRemoved` is what drives the TEE's own
+// `self_purge` (core: one root removal triggers `PurgeAction::Namespace`,
+// tearing down keys + storage for the whole namespace + subgroups). The
+// per-subgroup removals do NOT cascade on the OWNER's side — only the
+// TEE's self-`MemberLeft` cascades — so the owner must remove the TEE
+// from each subgroup explicitly to clear its OWN ledger, otherwise the
+// owner still shows the fleet node in private channels (the symptom this
+// module fixes).
+//
+// This module is intentionally dependency-injected and free of React /
+// DOM globals so it can be unit-tested under the repo's `node`-env vitest
+// (`src/**/*.test.ts`). `Namespaces.tsx` builds the deps from the live
+// `mero` admin client + settings via `buildEvictionDeps`.
+//
+// See: tauri-app#106/#107, core ADR 0002, core PR #2653.
+
+/**
+ * Extract the `members` array from a merod
+ * `GET /admin-api/groups/{id}/members` response. Mero-js's admin response
+ * shape varies across versions — a direct `members` array on some routes,
+ * a wrapped `data.members` on others — so every consumer hits the
+ * dual-path lookup. Centralised here so a future shape change is one edit.
+ *
+ * Returns `null` (not `[]`) when the response shape is unrecognised, so
+ * callers can distinguish "no members" from "couldn't tell" and fail
+ * closed where appropriate. tauri-app#107 v4 review.
+ */
+export function extractMembersFromResponse(json: unknown): unknown[] | null {
+  const raw =
+    (json as { members?: unknown; data?: { members?: unknown } })?.members ??
+    (json as { data?: { members?: unknown } })?.data?.members;
+  return Array.isArray(raw) ? raw : null;
+}
+
+/**
+ * Filter a raw member array down to the `ReadOnlyTee` identities. The
+ * role is serialised by core as the bare string `"ReadOnlyTee"`
+ * (GroupMemberRole, #[serde] unit variant). Anything whose `identity`
+ * isn't a string or whose `role` isn't exactly `ReadOnlyTee` is dropped.
+ */
+export function teeIdentitiesFromMembers(raw: unknown[]): string[] {
+  return raw
+    .filter(
+      (m: unknown): m is { identity: string; role: string } =>
+        typeof (m as { identity?: unknown })?.identity === 'string' &&
+        (m as { role?: unknown })?.role === 'ReadOnlyTee',
+    )
+    .map((m) => m.identity);
+}
+
+/**
+ * Side-effecting primitives the eviction logic needs, injected so the
+ * core walk is pure and unit-testable. All three are scoped to the
+ * caller's local merod (node token auth); none touch the cloud.
+ */
+export interface EvictionDeps {
+  /**
+   * List a group's members. Returns the raw (un-filtered) member array,
+   * or `null` when the listing could not be performed / the response
+   * shape was unrecognised (fail-closed signal — caller treats it as
+   * "couldn't tell", never "no TEE members").
+   */
+  listGroupMembers: (groupId: string) => Promise<unknown[] | null>;
+  /**
+   * List a group's *direct* subgroups (one level). The walk recurses to
+   * cover nesting. Returns the child group ids; an empty array means a
+   * leaf. Throwing is treated as "subtree unknown" (fail-closed).
+   */
+  listSubgroups: (groupId: string) => Promise<string[]>;
+  /**
+   * Remove members from a group by identity. Removing an already-removed
+   * member is expected to be a harmless no-op / benign error.
+   */
+  removeGroupMembers: (groupId: string, identities: string[]) => Promise<void>;
+}
+
+export interface EvictionResult {
+  /** Number of (group, identity) removals that succeeded. */
+  evicted: number;
+  /** Number of individual remove calls that errored. */
+  failed: number;
+  /**
+   * `true` when we could not enumerate what was local (the root member
+   * listing failed, or the subgroup walk could not be completed). The
+   * caller's toast / reconcile uses this to say "cleanup pending" rather
+   * than claiming success — and the reconcile will retry on next load.
+   */
+  listFailed: boolean;
+  /** Distinct group ids visited (root + reachable subgroups). */
+  groupsVisited: number;
+}
+
+/**
+ * Enumerate the namespace's full group tree — root + every subgroup,
+ * recursively (subgroups can nest) — deduping by group id and guarding
+ * against cycles. Built on the well-defined `listSubgroups` ("direct
+ * children of a group") primitive rather than assuming a flat
+ * `listNamespaceGroups` includes the root or recurses.
+ *
+ * On any `listSubgroups` failure we record `incomplete = true` and stop
+ * descending that branch but keep the groups we already found, so a
+ * partial walk still evicts from what we could see while the caller
+ * knows the picture was incomplete (→ retry via reconcile).
+ */
+export async function enumerateGroupTree(
+  deps: Pick<EvictionDeps, 'listSubgroups'>,
+  rootId: string,
+): Promise<{ groupIds: string[]; incomplete: boolean }> {
+  const seen = new Set<string>();
+  const order: string[] = [];
+  let incomplete = false;
+  const queue: string[] = [rootId];
+  while (queue.length > 0) {
+    const gid = queue.shift() as string;
+    if (seen.has(gid)) continue;
+    seen.add(gid);
+    order.push(gid);
+    let children: string[];
+    try {
+      children = await deps.listSubgroups(gid);
+    } catch {
+      // Can't see this group's children — record incompleteness, keep
+      // walking the rest of the queue (other branches may still resolve).
+      incomplete = true;
+      continue;
+    }
+    for (const c of children) {
+      if (typeof c === 'string' && c && !seen.has(c)) queue.push(c);
+    }
+  }
+  return { groupIds: order, incomplete };
+}
+
+/**
+ * Evict every `ReadOnlyTee` member from the owner's local merod state
+ * across the *entire* namespace tree (root + all subgroups). The root
+ * removal drives the TEE's self-purge; the per-subgroup removals clear
+ * the owner's own ledger so private channels no longer show the fleet
+ * node (tauri-app#106).
+ *
+ * Idempotent: a group with no TEE members is a no-op; a remove that
+ * targets an already-gone member is counted as failed-but-benign (core
+ * returns an error for "not a member", which is the expected steady
+ * state on a retry). Best-effort — never throws; surfaces counts +
+ * `listFailed` for the caller's honest toast.
+ *
+ * Security: never logs bearer tokens or full identities. Identities are
+ * truncated to an 8-char prefix (enough to correlate with admin tooling,
+ * not a standalone tracking primitive). tauri-app#107 v3 review.
+ */
+export async function evictTeeMembersFromTree(
+  deps: EvictionDeps,
+  nsId: string,
+): Promise<EvictionResult> {
+  const { groupIds, incomplete } = await enumerateGroupTree(deps, nsId);
+
+  let evicted = 0;
+  let failed = 0;
+  let anyListFailed = incomplete;
+
+  for (const groupId of groupIds) {
+    let raw: unknown[] | null;
+    try {
+      raw = await deps.listGroupMembers(groupId);
+    } catch (e) {
+      anyListFailed = true;
+      console.warn(
+        `evictTeeMembersFromTree: list-members threw for group=${short(groupId)} ` +
+          `(${(e as Error)?.name ?? 'unknown'}) — cleanup pending`,
+      );
+      continue;
+    }
+    if (raw === null) {
+      // For the namespace ROOT a null listing is fail-closed (we can't
+      // tell whether a TEE is present, and the root removal is what
+      // drives the TEE self-purge). For subgroups it likewise means
+      // "couldn't tell" → mark incomplete so the reconcile retries.
+      anyListFailed = true;
+      console.warn(
+        `evictTeeMembersFromTree: list-members body unrecognised for group=${short(
+          groupId,
+        )} — cleanup pending`,
+      );
+      continue;
+    }
+    const teeIds = teeIdentitiesFromMembers(raw);
+    if (teeIds.length === 0) continue;
+
+    for (const identity of teeIds) {
+      try {
+        await deps.removeGroupMembers(groupId, [identity]);
+        evicted += 1;
+      } catch (e) {
+        console.warn(
+          `evictTeeMembersFromTree: remove failed for group=${short(
+            groupId,
+          )} identity=${short(identity)} (${(e as Error)?.name ?? 'unknown'})`,
+        );
+        failed += 1;
+      }
+    }
+  }
+
+  return {
+    evicted,
+    failed,
+    listFailed: anyListFailed,
+    groupsVisited: groupIds.length,
+  };
+}
+
+/**
+ * Reconcile: for every namespace that is HA-DISABLED in cloud state but
+ * still has at least one local `ReadOnlyTee` member somewhere in its
+ * tree, run the eviction. This is the self-healing path — a transient
+ * failure in the fast post-toggle eviction (expired node token, hung
+ * merod, gossip not yet propagated) no longer strands the TEE forever:
+ * the next namespace load / HA-status refresh retries.
+ *
+ * `haEnabled` is the cloud-derived map: `false` means "cloud says HA is
+ * off for this namespace". We only act on explicit `false` (not
+ * `undefined`, which means "unknown / not in cloud") to avoid evicting a
+ * TEE whose namespace HA state we haven't confirmed is disabled.
+ *
+ * Returns per-namespace results for the namespaces we actually touched
+ * (had local TEE members). Namespaces with no local TEE members are
+ * skipped silently — the steady state once eviction has succeeded.
+ */
+export async function reconcileDisabledNamespaces(
+  deps: EvictionDeps,
+  haEnabled: Record<string, boolean>,
+): Promise<Record<string, EvictionResult>> {
+  const results: Record<string, EvictionResult> = {};
+  const disabled = Object.keys(haEnabled).filter((nsId) => haEnabled[nsId] === false);
+  for (const nsId of disabled) {
+    // Cheap pre-check on the root only: if the root listing shows no TEE
+    // member AND has no subgroups with TEE members, the full walk would
+    // be a no-op. But a subgroup can hold a stranded TEE even when the
+    // root is clean (Bug 2), so we can't short-circuit on the root alone.
+    // Run the full walk; it skips groups with no TEE members anyway.
+    const result = await evictTeeMembersFromTree(deps, nsId);
+    if (result.evicted > 0 || result.failed > 0 || result.listFailed) {
+      results[nsId] = result;
+    }
+  }
+  return results;
+}
+
+/** Truncate an opaque id (group id / identity public key) for logging. */
+function short(id: string): string {
+  return `${id.slice(0, 8)}…`;
+}
+
+/**
+ * Minimal shape of the live `mero` admin client this module depends on.
+ * Declared locally (rather than importing the SDK type) so the eviction
+ * module stays free of the heavyweight mero-js type graph and its unit
+ * tests can pass a plain object.
+ */
+export interface MeroAdminLike {
+  admin: {
+    listSubgroups: (groupId: string) => Promise<{ groupId: string }[]>;
+    removeGroupMembers: (
+      groupId: string,
+      request: { members: string[] },
+    ) => Promise<void>;
+  };
+}
+
+/**
+ * Build `EvictionDeps` from the live runtime pieces.
+ *
+ * Auth: the members listing hits the local node's admin API directly via
+ * `fetch` with the **local node access token** — the same canonical path
+ * the list-members `useEffect` uses (NOT the cloud session token; that
+ * was the Bug-1-adjacent mistake caught in tauri-app#107 review). A
+ * missing/expired node token surfaces as a `listFailed` result, which
+ * the reconcile retries — it no longer silently strands the TEE.
+ *
+ * The members fetch carries a 5s `AbortSignal.timeout` so a hung merod
+ * doesn't wedge the disable / reconcile flow. Removal + subgroup
+ * enumeration go through the mero admin client (which manages its own
+ * auth/headers).
+ *
+ * `nodeToken` is read lazily via the supplied getter on every listing so
+ * a token that rotates between reconcile passes is picked up fresh.
+ */
+export function buildEvictionDeps(args: {
+  mero: MeroAdminLike;
+  nodeUrl: string;
+  getNodeToken: () => string | null;
+  fetchImpl?: typeof fetch;
+}): EvictionDeps {
+  const { mero, nodeUrl, getNodeToken } = args;
+  const doFetch = args.fetchImpl ?? fetch;
+  return {
+    listGroupMembers: async (groupId) => {
+      const token = getNodeToken();
+      if (!token) {
+        // No node token → fail-closed. Reconcile retries once a token
+        // is available. Never log the (absent) token.
+        return null;
+      }
+      let resp: Response;
+      try {
+        resp = await doFetch(
+          `${nodeUrl}/admin-api/groups/${encodeURIComponent(groupId)}/members`,
+          {
+            headers: { Authorization: `Bearer ${token}` },
+            signal: AbortSignal.timeout(5000),
+          },
+        );
+      } catch (e) {
+        // Don't log the raw error — it can carry headers/URL with the
+        // bearer token. Redacted summary only.
+        console.warn(
+          `buildEvictionDeps: members fetch threw for group=${short(groupId)} ` +
+            `(${(e as Error)?.name ?? 'unknown'})`,
+        );
+        return null;
+      }
+      if (!resp.ok) {
+        console.warn(
+          `buildEvictionDeps: members http=${resp.status} for group=${short(groupId)}`,
+        );
+        return null;
+      }
+      const json = await resp.json().catch(() => null);
+      return extractMembersFromResponse(json);
+    },
+    listSubgroups: async (groupId) => {
+      const entries = await mero.admin.listSubgroups(groupId);
+      return (entries ?? [])
+        .map((e) => e?.groupId)
+        .filter((g): g is string => typeof g === 'string' && !!g);
+    },
+    removeGroupMembers: async (groupId, identities) => {
+      await mero.admin.removeGroupMembers(groupId, { members: identities });
+    },
+  };
+}

--- a/apps/desktop/src/utils/teeEviction.ts
+++ b/apps/desktop/src/utils/teeEviction.ts
@@ -134,10 +134,14 @@ export async function enumerateGroupTree(
     let children: string[];
     try {
       children = await deps.listSubgroups(gid);
-    } catch {
-      // Can't see this group's children — record incompleteness, keep
-      // walking the rest of the queue (other branches may still resolve).
+    } catch (e) {
+      // Can't see this group's children — record incompleteness.
       incomplete = true;
+      // An abort means the whole pass is superseded; stop draining the
+      // queue (every remaining `listSubgroups` would just throw too)
+      // rather than spinning through the rest of the BFS (meroreviewer).
+      if ((e as Error)?.name === 'AbortError') break;
+      // Otherwise keep walking — other branches may still resolve.
       continue;
     }
     for (const c of children) {
@@ -170,6 +174,11 @@ export async function evictTeeMembersFromTree(
   opts?: EvictionOpts,
 ): Promise<EvictionResult> {
   const shouldAbort = opts?.shouldAbort;
+  // Bail before any enumeration if the caller is already superseded, so a
+  // pass that lost its race never even walks the tree (meroreviewer).
+  if (shouldAbort?.()) {
+    return { evicted: 0, failed: 0, listFailed: true, groupsVisited: 0 };
+  }
   const { groupIds, incomplete } = await enumerateGroupTree(deps, nsId);
 
   let evicted = 0;
@@ -387,15 +396,19 @@ export function buildEvictionDeps(args: {
         signal && typeof AbortSignal.any === 'function'
           ? AbortSignal.any([signal, timeout])
           : timeout;
+      // Build via `new URL` rather than string interpolation so a nodeUrl
+      // with a trailing slash (or base path) doesn't produce a double-slash
+      // / double-path URL (meroreviewer).
+      const membersUrl = new URL(
+        `/admin-api/groups/${encodeURIComponent(groupId)}/members`,
+        nodeUrl,
+      ).toString();
       let resp: Response;
       try {
-        resp = await doFetch(
-          `${nodeUrl}/admin-api/groups/${encodeURIComponent(groupId)}/members`,
-          {
-            headers: { Authorization: `Bearer ${token}` },
-            signal: fetchSignal,
-          },
-        );
+        resp = await doFetch(membersUrl, {
+          headers: { Authorization: `Bearer ${token}` },
+          signal: fetchSignal,
+        });
       } catch (e) {
         // Don't log the raw error — it can carry headers/URL with the
         // bearer token. Redacted summary only.

--- a/apps/desktop/src/utils/teeEviction.ts
+++ b/apps/desktop/src/utils/teeEviction.ts
@@ -80,6 +80,16 @@ export interface EvictionDeps {
   removeGroupMembers: (groupId: string, identities: string[]) => Promise<void>;
 }
 
+/**
+ * Cross-cutting options for an eviction run. `shouldAbort` is polled
+ * before each group and before each individual remove so a superseded
+ * caller (e.g. the namespace was re-enabled mid-walk) can stop issuing
+ * further `MemberRemoved` ops without leaving a half-mutated tree.
+ */
+export interface EvictionOpts {
+  shouldAbort?: () => boolean;
+}
+
 export interface EvictionResult {
   /** Number of (group, identity) removals that succeeded. */
   evicted: number;
@@ -157,7 +167,9 @@ export async function enumerateGroupTree(
 export async function evictTeeMembersFromTree(
   deps: EvictionDeps,
   nsId: string,
+  opts?: EvictionOpts,
 ): Promise<EvictionResult> {
+  const shouldAbort = opts?.shouldAbort;
   const { groupIds, incomplete } = await enumerateGroupTree(deps, nsId);
 
   let evicted = 0;
@@ -165,6 +177,17 @@ export async function evictTeeMembersFromTree(
   let anyListFailed = incomplete;
 
   for (const groupId of groupIds) {
+    // Bail out of the (mutating) walk if the caller has been superseded —
+    // e.g. the namespace's HA state changed (re-enabled) while we were
+    // mid-walk. Without this, an in-flight reconcile would keep issuing
+    // `MemberRemoved` for a namespace that is no longer HA-disabled,
+    // evicting a TEE that was just re-admitted (cursor). `listFailed`
+    // marks the partial result incomplete; the caller discards it anyway
+    // once superseded.
+    if (shouldAbort?.()) {
+      anyListFailed = true;
+      break;
+    }
     let raw: unknown[] | null;
     try {
       raw = await deps.listGroupMembers(groupId);
@@ -193,6 +216,10 @@ export async function evictTeeMembersFromTree(
     if (teeIds.length === 0) continue;
 
     for (const identity of teeIds) {
+      if (shouldAbort?.()) {
+        anyListFailed = true;
+        break;
+      }
       try {
         await deps.removeGroupMembers(groupId, [identity]);
         evicted += 1;
@@ -235,9 +262,11 @@ export async function evictTeeMembersFromTree(
 export async function reconcileDisabledNamespaces(
   deps: EvictionDeps,
   haEnabled: Record<string, boolean>,
+  opts?: EvictionOpts,
 ): Promise<Record<string, EvictionResult>> {
   const results: Record<string, EvictionResult> = {};
   const disabled = Object.keys(haEnabled).filter((nsId) => haEnabled[nsId] === false);
+  if (opts?.shouldAbort?.()) return results;
   // Each namespace is an independent tree, so evict them concurrently —
   // for a user with many HA-disabled namespaces this avoids serialising the
   // walks. `evictTeeMembersFromTree` is best-effort and never throws, but we
@@ -248,7 +277,7 @@ export async function reconcileDisabledNamespaces(
   const settled = await Promise.allSettled(
     disabled.map(async (nsId): Promise<[string, EvictionResult]> => [
       nsId,
-      await evictTeeMembersFromTree(deps, nsId),
+      await evictTeeMembersFromTree(deps, nsId, opts),
     ]),
   );
   for (const outcome of settled) {

--- a/apps/desktop/src/utils/teeEviction.ts
+++ b/apps/desktop/src/utils/teeEviction.ts
@@ -415,6 +415,12 @@ export function buildEvictionDeps(args: {
       return extractMembersFromResponse(json);
     },
     listSubgroups: async (groupId) => {
+      // Mirror the fetch-side abort check: stop enumerating the tree via the
+      // mero admin client once the caller is superseded. Throwing makes
+      // `enumerateGroupTree` mark the walk incomplete and stop descending,
+      // so a cancelled pass doesn't keep issuing admin calls down a deep
+      // tree (meroreviewer).
+      if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
       const entries = await mero.admin.listSubgroups(groupId);
       return (entries ?? [])
         .map((e) => e?.groupId)

--- a/apps/desktop/src/utils/teeEviction.ts
+++ b/apps/desktop/src/utils/teeEviction.ts
@@ -176,7 +176,7 @@ export async function evictTeeMembersFromTree(
   let failed = 0;
   let anyListFailed = incomplete;
 
-  for (const groupId of groupIds) {
+  walk: for (const groupId of groupIds) {
     // Bail out of the (mutating) walk if the caller has been superseded —
     // e.g. the namespace's HA state changed (re-enabled) while we were
     // mid-walk. Without this, an in-flight reconcile would keep issuing
@@ -217,8 +217,9 @@ export async function evictTeeMembersFromTree(
 
     for (const identity of teeIds) {
       if (shouldAbort?.()) {
+        // Abort the whole walk, not just this group's remaining identities.
         anyListFailed = true;
-        break;
+        break walk;
       }
       try {
         await deps.removeGroupMembers(groupId, [identity]);
@@ -322,9 +323,11 @@ export interface MeroAdminLike {
  * the reconcile retries — it no longer silently strands the TEE.
  *
  * The members fetch carries a 5s `AbortSignal.timeout` so a hung merod
- * doesn't wedge the disable / reconcile flow. Removal + subgroup
- * enumeration go through the mero admin client (which manages its own
- * auth/headers).
+ * doesn't wedge the disable / reconcile flow. An optional caller `signal`
+ * (the reconcile pass's AbortController) is merged in, so a superseded
+ * pass cancels its in-flight fetch immediately rather than waiting out the
+ * 5s timeout (meroreviewer). Removal + subgroup enumeration go through the
+ * mero admin client (which manages its own auth/headers).
  *
  * `nodeToken` is read lazily via the supplied getter on every listing so
  * a token that rotates between reconcile passes is picked up fresh.
@@ -334,8 +337,9 @@ export function buildEvictionDeps(args: {
   nodeUrl: string;
   getNodeToken: () => string | null;
   fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
 }): EvictionDeps {
-  const { mero, nodeUrl, getNodeToken } = args;
+  const { mero, nodeUrl, getNodeToken, signal } = args;
   const doFetch = args.fetchImpl ?? fetch;
   // Validate the node URL once up front: it is interpolated into the
   // members fetch URL right next to the local node bearer token, so a
@@ -363,19 +367,33 @@ export function buildEvictionDeps(args: {
         );
         return null;
       }
+      if (signal?.aborted) {
+        // Caller already superseded (e.g. HA re-enabled) — don't start a
+        // token-bearing fetch we'd only discard.
+        return null;
+      }
       const token = getNodeToken();
       if (!token) {
         // No node token → fail-closed. Reconcile retries once a token
         // is available. Never log the (absent) token.
         return null;
       }
+      // Merge the caller's abort signal with the per-request 5s timeout so
+      // the fetch is cancelled the moment either fires. `AbortSignal.any`
+      // is used when available; otherwise we fall back to the timeout
+      // (caller abort is still honoured at the walk's `shouldAbort` checks).
+      const timeout = AbortSignal.timeout(5000);
+      const fetchSignal =
+        signal && typeof AbortSignal.any === 'function'
+          ? AbortSignal.any([signal, timeout])
+          : timeout;
       let resp: Response;
       try {
         resp = await doFetch(
           `${nodeUrl}/admin-api/groups/${encodeURIComponent(groupId)}/members`,
           {
             headers: { Authorization: `Bearer ${token}` },
-            signal: AbortSignal.timeout(5000),
+            signal: fetchSignal,
           },
         );
       } catch (e) {

--- a/apps/desktop/src/utils/teeEviction.ts
+++ b/apps/desktop/src/utils/teeEviction.ts
@@ -306,6 +306,47 @@ function short(id: string): string {
 }
 
 /**
+ * Race a promise against a deadline (and an optional abort signal). Used to
+ * bound the `mero.admin.listSubgroups` admin call, which — unlike the members
+ * fetch — carries no timeout of its own, so a hung merod could otherwise wedge
+ * the whole eviction walk and leave the HA toggle stuck (cursor). Racing the
+ * signal in as well means an abort mid-call is honoured immediately rather
+ * than only at the next `shouldAbort` poll (meroreviewer). On timeout/abort it
+ * rejects; `enumerateGroupTree` treats either as "couldn't enumerate this
+ * branch" (incomplete → the reconcile retries).
+ */
+function withDeadline<T>(p: Promise<T>, ms: number, signal?: AbortSignal): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const onAbort = () => settle(() => reject(new DOMException('Aborted', 'AbortError')));
+    const cleanup = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+    };
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn();
+    };
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+    timer = setTimeout(
+      () => settle(() => reject(new DOMException('Timed out', 'TimeoutError'))),
+      ms,
+    );
+    signal?.addEventListener('abort', onAbort, { once: true });
+    p.then(
+      (v) => settle(() => resolve(v)),
+      (e) => settle(() => reject(e)),
+    );
+  });
+}
+
+/**
  * Minimal shape of the live `mero` admin client this module depends on.
  * Declared locally (rather than importing the SDK type) so the eviction
  * module stays free of the heavyweight mero-js type graph and its unit
@@ -434,7 +475,14 @@ export function buildEvictionDeps(args: {
       // so a cancelled pass doesn't keep issuing admin calls down a deep
       // tree (meroreviewer).
       if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
-      const entries = await mero.admin.listSubgroups(groupId);
+      // Bound the admin call: it carries no timeout of its own, so a hung
+      // merod must not wedge the walk (cursor). The signal is raced in too,
+      // so an abort mid-call is honoured immediately (meroreviewer).
+      const entries = await withDeadline(
+        mero.admin.listSubgroups(groupId),
+        5000,
+        signal,
+      );
       return (entries ?? [])
         .map((e) => e?.groupId)
         .filter((g): g is string => typeof g === 'string' && !!g);


### PR DESCRIPTION
## Summary
Fixes "TEE fleet node not leaving private channels after HA disable", root-caused on a live fleet node. The owner-side eviction (`evictTeeMembersAfterDisable`) had two bugs that together = the symptom:

1. **It never fired in practice** — any transient local-node-token / fetch bail returned `listFailed` with no retry path; once `haEnabled` flipped false the disable branch was unreachable, stranding the TEE forever.
2. **Root-only** — it removed `ReadOnlyTee` members only at the namespace root, so the owner's private-subgroup rows survived (a root `MemberRemoved` does not cascade on the owner's side).

Changes:
- New `apps/desktop/src/utils/teeEviction.ts`: walks the namespace tree (root + subgroups via `listSubgroups`, BFS) and removes `ReadOnlyTee` members from each group. The root removal drives the TEE's self-purge.
- A reconcile effect re-runs the kick whenever a cloud-HA-disabled namespace still has local `ReadOnlyTee` members → self-healing / retriable instead of fire-once.

Pairs with calimero-network/core#2809 (scoped ReadOnlyTee root-removal cascade): once a cascade-bearing `merod` is bundled, a single root removal evicts namespace-wide (including non-owner Restricted subgroups the desktop cannot reach directly) and the subgroup walk degrades to harmless no-ops.

## Test plan
- 18 new unit tests in `teeEviction.test.ts` (full-tree walk + reconcile gating); 67 total pass; `tsc --noEmit` clean.
- Full cloud-OAuth E2E needs a bundled `.app` run (dev mode cannot complete the OAuth callback).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes local merod membership and gossip `MemberRemoved` on HA disable (governance + forward secrecy), but logic is fail-closed, idempotent, abort-aware, and heavily unit-tested.
> 
> **Overview**
> Fixes stranded **ReadOnlyTee** fleet members after HA disable by replacing root-only, fire-once eviction with a **full namespace group-tree walk** (root + nested subgroups) and a **self-healing reconcile** path.
> 
> **`teeEviction.ts`** centralizes member-response parsing, BFS tree enumeration, per-group `ReadOnlyTee` removal, and `reconcileDisabledNamespaces` (only when cloud `haEnabled` is explicitly `false`). Runtime wiring uses the **local node token** for member listing, 5s timeouts, abort support, and fail-closed handling for bad URLs / missing tokens.
> 
> **`Namespaces.tsx`** delegates post-disable eviction to that module, adds a reconcile `useEffect` (bounded retries, counting semaphore so disable + reconcile don’t race, pending re-run when triggers overlap), and updates HA-disable toasts to promise **automatic retry** instead of manual restart-only recovery.
> 
> **`teeEviction.test.ts`** adds unit coverage for tree walk, reconcile gating, abort, and `buildEvictionDeps` safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6d9795c12d05f3c978d53a13eb68684ae84126c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->