### PR TITLE
chore: bump bundled merod to 0.11.0-rc.6

### DIFF
--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.5"
+    "version": "0.11.0-rc.6"
 }


### PR DESCRIPTION
## What

Bumps the bundled `merod` pin in `merod-config.json` from `0.11.0-rc.5` → `0.11.0-rc.6`.

This picks up the just-released core fix: the scoped ReadOnlyTee root-removal cascade (core#2809), which gives the owner/desktop the Fix A cascade behavior.

## How it's consumed

`apps/desktop/scripts/prepare-merod.mjs` reads the `version` field and resolves the core release via `GET /repos/calimero-network/core/releases/tags/0.11.0-rc.6`, then selects the `merod-<target-triple>` asset by name (same naming contract as rc.5). No checksum/hash is pinned in `merod-config.json`, so no additional hash update is required.

## Dependency / merge gate

Depends on the **core 0.11.0-rc.6 release assets existing**. The release is building now and is **not yet visible** via the GitHub API.

**Do not merge** until:

```
gh release view 0.11.0-rc.6 --repo calimero-network/core
```

shows the `merod-*` assets for all bundled targets. Merging before the assets publish would break `prepare-merod.mjs` (404 on the tags endpoint / no asset found).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-version pin change with no app logic edits; risk is operational if merged before core release assets exist.
> 
> **Overview**
> Updates the bundled **`merod`** pin in `merod-config.json` from **`0.11.0-rc.5`** to **`0.11.0-rc.6`**, so desktop builds and runtime fetch that core release instead of rc.5.
> 
> That release includes the scoped **ReadOnlyTee** root-removal cascade fix (core#2809). **`prepare-merod.mjs`**, CI cache keys, and compile-time **`MEROD_CONFIG_VERSION`** all follow this field unchanged—only the semver string moves.
> 
> **Merge only after** `calimero-network/core` tag **`0.11.0-rc.6`** has published `merod-*` assets; otherwise prepare/download will 404.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3124cd8fd4e5ced72eb0f791c0e056905d496e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->