### PR TITLE
ci(desktop): add Chromebook (Linux ARM64) build target

### DIFF
--- a/.github/workflows/build-chromebook.yml
+++ b/.github/workflows/build-chromebook.yml
@@ -1,0 +1,245 @@
+name: Build Chromebook
+
+# Chromebooks run Linux apps via the Crostini (Debian) container. Intel/AMD
+# Chromebooks are already covered by the x86_64 Linux build; this workflow
+# produces the ARM64 (aarch64) artifacts that ARM Chromebooks need. The primary
+# deliverable is the .deb (double-click install in the ChromeOS Files app); the
+# AppImage feeds the Tauri updater (linux-aarch64).
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version number (e.g., 1.0.0)"
+        required: true
+        type: string
+    secrets:
+      # Tauri updater signing (required for auto-updates)
+      TAURI_PRIVATE_KEY:
+        required: true
+      TAURI_KEY_PASSWORD:
+        required: false
+      TAURI_PUBLIC_KEY:
+        required: true
+    outputs:
+      artifact-name:
+        description: "Name of the uploaded artifact"
+        value: ${{ jobs.build.outputs.artifact-name }}
+  pull_request:
+    branches:
+      - master
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build Chromebook (Linux ARM64)
+    # Native ARM64 GitHub-hosted runner. Matches the x86_64 build's ubuntu-22.04
+    # so the webkit2gtk 0.18.2 wry patch below applies identically.
+    runs-on: ubuntu-22.04-arm
+    outputs:
+      artifact-name: chromebook-build
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine build mode
+        id: build-mode
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "mode=validation" >> $GITHUB_OUTPUT
+            echo "version=0.0.0-dev" >> $GITHUB_OUTPUT
+          else
+            echo "mode=release" >> $GITHUB_OUTPUT
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Validate required secrets for release
+        if: steps.build-mode.outputs.mode == 'release'
+        env:
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_PUBLIC_KEY: ${{ secrets.TAURI_PUBLIC_KEY }}
+        run: |
+          MISSING=""
+          [ -z "$TAURI_PRIVATE_KEY" ] && MISSING="$MISSING TAURI_PRIVATE_KEY"
+          [ -z "$TAURI_PUBLIC_KEY" ] && MISSING="$MISSING TAURI_PUBLIC_KEY"
+
+          if [ -n "$MISSING" ]; then
+            echo "Error: Missing required secrets for signed release:$MISSING"
+            echo "All releases must be signed. Set up the required secrets before releasing."
+            exit 1
+          fi
+          echo "All required secrets are configured"
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.0-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Get pnpm store directory
+        id: get-pnpm-store
+        shell: bash
+        run: |
+          STORE_PATH=$(pnpm store path --silent || echo "$HOME/.pnpm-store")
+          echo "path=$STORE_PATH" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.get-pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-arm64-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-arm64-pnpm-store-
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri
+          key: arm64
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace packages
+        run: |
+          pnpm build:mero-react
+
+      - name: Generate icons
+        working-directory: apps/desktop
+        run: pnpm tauri icon src-tauri/icons/icon.png
+
+      - name: Prepare merod binary
+        working-directory: apps/desktop
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm merod:prepare
+
+      - name: Strip merod binary
+        run: |
+          MEROD_BINARY="apps/desktop/src-tauri/merod/merod"
+          if [ -f "$MEROD_BINARY" ]; then
+            BEFORE=$(stat --printf="%s" "$MEROD_BINARY")
+            strip "$MEROD_BINARY"
+            AFTER=$(stat --printf="%s" "$MEROD_BINARY")
+            echo "Stripped merod: $(( BEFORE / 1024 / 1024 ))MB → $(( AFTER / 1024 / 1024 ))MB"
+          else
+            echo "Warning: merod binary not found at $MEROD_BINARY"
+          fi
+
+      - name: Update version in tauri.conf.json
+        if: steps.build-mode.outputs.mode == 'release'
+        run: |
+          VERSION="${{ steps.build-mode.outputs.version }}"
+          cd apps/desktop/src-tauri
+          node -e "
+            const fs = require('fs');
+            const config = JSON.parse(fs.readFileSync('tauri.conf.json', 'utf8'));
+            config.package.version = '$VERSION';
+            fs.writeFileSync('tauri.conf.json', JSON.stringify(config, null, 2));
+          "
+
+      - name: Inject updater pubkey from secret
+        if: steps.build-mode.outputs.mode == 'release'
+        env:
+          TAURI_PUBLIC_KEY: ${{ secrets.TAURI_PUBLIC_KEY }}
+        run: |
+          if [ -n "$TAURI_PUBLIC_KEY" ]; then
+            cd apps/desktop/src-tauri
+            node -e "
+              const fs = require('fs');
+              const config = JSON.parse(fs.readFileSync('tauri.conf.json', 'utf8'));
+              config.tauri.updater.pubkey = process.env.TAURI_PUBLIC_KEY;
+              fs.writeFileSync('tauri.conf.json', JSON.stringify(config, null, 2));
+            "
+            echo "Injected TAURI_PUBLIC_KEY into tauri.conf.json"
+          else
+            echo "No TAURI_PUBLIC_KEY provided, using default pubkey"
+          fi
+
+      - name: Patch wry for webkit2gtk 0.18.2 compatibility
+        run: |
+          # wry 0.24.11 uses `use webkit2gtk::{traits::*, ...}` but on Linux with webkit2gtk 0.18.2
+          # the trait methods from SettingsExt are not resolved through the glob. Adding the
+          # explicit import is the fix the Rust compiler itself suggests.
+          cargo fetch --manifest-path apps/desktop/src-tauri/Cargo.toml
+          WRY_MOD=$(find ~/.cargo/registry/src -name "mod.rs" -path "*/wry-0.24.*/src/webview/webkitgtk/*" 2>/dev/null | head -1)
+          if [ -n "$WRY_MOD" ]; then
+            if ! grep -q "use webkit2gtk::SettingsExt" "$WRY_MOD"; then
+              sed -i 's/^use webkit2gtk::{/use webkit2gtk::SettingsExt;\nuse webkit2gtk::{/' "$WRY_MOD"
+              echo "Patched: $WRY_MOD"
+            else
+              echo "Already patched, skipping."
+            fi
+          else
+            echo "wry webkitgtk mod.rs not found in cargo cache"
+            exit 1
+          fi
+
+      - name: Build Tauri app for Chromebook (Linux ARM64)
+        working-directory: apps/desktop
+        env:
+          # beforeBuildCommand runs merod:prepare again; reuse binary from "Prepare merod binary" (no GITHUB_TOKEN here).
+          MEROD_SKIP_IF_EXISTS: "1"
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+        # .deb is the Crostini install path on ChromeOS; AppImage feeds the updater.
+        run: pnpm exec tauri build --bundles appimage,deb
+
+      - name: Verify build outputs
+        if: steps.build-mode.outputs.mode == 'validation'
+        run: |
+          echo "Checking for expected build outputs..."
+
+          DEB_FILE=$(find apps/desktop/src-tauri/target/release/bundle -name "*.deb" 2>/dev/null | head -1)
+          APPIMAGE_FILE=$(find apps/desktop/src-tauri/target/release/bundle -name "*.AppImage" 2>/dev/null | head -1)
+
+          # The .deb is the required Chromebook deliverable.
+          if [ -z "$DEB_FILE" ]; then
+            echo "Error: deb not found"
+            exit 1
+          fi
+          echo "DEB: $DEB_FILE ($(du -sh "$DEB_FILE" | cut -f1))"
+
+          [ -n "$APPIMAGE_FILE" ] && echo "AppImage: $APPIMAGE_FILE ($(du -sh "$APPIMAGE_FILE" | cut -f1))"
+
+          echo "Build validation passed"
+
+      - name: Collect and normalize assets
+        if: steps.build-mode.outputs.mode == 'release'
+        run: |
+          node scripts/release/collect-assets.cjs \
+            --version "${{ steps.build-mode.outputs.version }}" \
+            --platform chromebook \
+            --output release-assets/
+
+      - name: Upload artifacts
+        if: steps.build-mode.outputs.mode == 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: chromebook-build
+          path: release-assets/
+          retention-days: 7

--- a/.github/workflows/build-chromebook.yml
+++ b/.github/workflows/build-chromebook.yml
@@ -185,14 +185,17 @@ jobs:
           # wry 0.24.11 uses `use webkit2gtk::{traits::*, ...}` but on Linux with webkit2gtk 0.18.2
           # the trait methods from SettingsExt are not resolved through the glob. Adding the
           # explicit import is the fix the Rust compiler itself suggests.
+          # wry 0.24.12+ already imports SettingsExt explicitly, so the guard below must skip
+          # patching to avoid a duplicate import (E0252). Matching the bare `SettingsExt` token
+          # is correct for both: 0.24.11 never mentions it (glob), 0.24.12 lists it by name.
           cargo fetch --manifest-path apps/desktop/src-tauri/Cargo.toml
           WRY_MOD=$(find ~/.cargo/registry/src -name "mod.rs" -path "*/wry-0.24.*/src/webview/webkitgtk/*" 2>/dev/null | head -1)
           if [ -n "$WRY_MOD" ]; then
-            if ! grep -q "use webkit2gtk::SettingsExt" "$WRY_MOD"; then
+            if ! grep -q "SettingsExt" "$WRY_MOD"; then
               sed -i 's/^use webkit2gtk::{/use webkit2gtk::SettingsExt;\nuse webkit2gtk::{/' "$WRY_MOD"
               echo "Patched: $WRY_MOD"
             else
-              echo "Already patched, skipping."
+              echo "SettingsExt already imported (wry >= 0.24.12 or already patched); skipping."
             fi
           else
             echo "wry webkitgtk mod.rs not found in cargo cache"

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -176,14 +176,17 @@ jobs:
           # wry 0.24.11 uses `use webkit2gtk::{traits::*, ...}` but on Linux with webkit2gtk 0.18.2
           # the trait methods from SettingsExt are not resolved through the glob. Adding the
           # explicit import is the fix the Rust compiler itself suggests.
+          # wry 0.24.12+ already imports SettingsExt explicitly, so the guard below must skip
+          # patching to avoid a duplicate import (E0252). Matching the bare `SettingsExt` token
+          # is correct for both: 0.24.11 never mentions it (glob), 0.24.12 lists it by name.
           cargo fetch --manifest-path apps/desktop/src-tauri/Cargo.toml
           WRY_MOD=$(find ~/.cargo/registry/src -name "mod.rs" -path "*/wry-0.24.*/src/webview/webkitgtk/*" 2>/dev/null | head -1)
           if [ -n "$WRY_MOD" ]; then
-            if ! grep -q "use webkit2gtk::SettingsExt" "$WRY_MOD"; then
+            if ! grep -q "SettingsExt" "$WRY_MOD"; then
               sed -i 's/^use webkit2gtk::{/use webkit2gtk::SettingsExt;\nuse webkit2gtk::{/' "$WRY_MOD"
               echo "Patched: $WRY_MOD"
             else
-              echo "Already patched, skipping."
+              echo "SettingsExt already imported (wry >= 0.24.12 or already patched); skipping."
             fi
           else
             echo "wry webkitgtk mod.rs not found in cargo cache"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,12 +63,23 @@ jobs:
       TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
       TAURI_PUBLIC_KEY: ${{ secrets.TAURI_PUBLIC_KEY }}
 
+  build-chromebook:
+    name: Build Chromebook
+    needs: prepare
+    uses: ./.github/workflows/build-chromebook.yml
+    with:
+      version: ${{ needs.prepare.outputs.version }}
+    secrets:
+      TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+      TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+      TAURI_PUBLIC_KEY: ${{ secrets.TAURI_PUBLIC_KEY }}
+
   # Publish release with all platform artifacts
   publish:
     name: Publish Release
-    needs: [prepare, build-macos, build-linux]
+    needs: [prepare, build-macos, build-linux, build-chromebook]
     # Continue even if some platforms fail (partial release)
-    if: always() && needs.prepare.result == 'success' && (needs.build-macos.result == 'success' || needs.build-linux.result == 'success')
+    if: always() && needs.prepare.result == 'success' && (needs.build-macos.result == 'success' || needs.build-linux.result == 'success' || needs.build-chromebook.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -89,6 +100,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: linux-build
+          path: release-assets/
+
+      - name: Download Chromebook artifacts
+        if: needs.build-chromebook.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: chromebook-build
           path: release-assets/
 
       - name: List collected assets
@@ -136,6 +154,9 @@ jobs:
           fi
           if [ "${{ needs.build-linux.result }}" = "success" ]; then
             PLATFORMS="${PLATFORMS}"$'\n'"- **Linux** (64-bit): Download AppImage, deb, or rpm"
+          fi
+          if [ "${{ needs.build-chromebook.result }}" = "success" ]; then
+            PLATFORMS="${PLATFORMS}"$'\n'"- **Chromebook** (ARM64): Download the deb (install via the Files app) or AppImage"
           fi
 
           cat > release-notes.md << EOF

--- a/apps/download-site/src/App.tsx
+++ b/apps/download-site/src/App.tsx
@@ -34,7 +34,7 @@ import {
 import "./App.css";
 
 // Platform tab configuration
-const PLATFORM_ORDER: OS[] = ["macos", "windows", "linux"];
+const PLATFORM_ORDER: OS[] = ["macos", "windows", "linux", "chromebook"];
 
 interface PlatformTabProps {
   platform: OS;
@@ -588,6 +588,30 @@ function App() {
                         { id: 2, content: "x64 processor" },
                         { id: 3, content: "100 MB available disk space" },
                         { id: 4, content: "WebKit2GTK 4.0" },
+                      ]}
+                      variant="ghost"
+                      divider={true}
+                    />
+                  </Stack>
+
+                  <Stack spacing="lg">
+                    <Heading level={4} size="lg" weight="semibold">
+                      Chromebook
+                    </Heading>
+                    <List
+                      items={[
+                        {
+                          id: 1,
+                          content:
+                            "ChromeOS with the Linux (Crostini) environment enabled",
+                        },
+                        { id: 2, content: "ARM64 (aarch64) processor" },
+                        { id: 3, content: "100 MB available disk space" },
+                        {
+                          id: 4,
+                          content:
+                            "Install the .deb via the Files app, then launch from the launcher",
+                        },
                       ]}
                       variant="ghost"
                       divider={true}

--- a/apps/download-site/src/release/fetchRelease.ts
+++ b/apps/download-site/src/release/fetchRelease.ts
@@ -44,6 +44,8 @@ function inferAssetMetadata(
   filename: string
 ): { os: OS; format: string } | null {
   const lower = filename.toLowerCase();
+  // ARM64 Linux artifacts are Chromebook (Crostini) builds.
+  const isArm64 = lower.includes("arm64") || lower.includes("aarch64");
 
   if (lower.endsWith(".dmg")) {
     return { os: "macos", format: "dmg" };
@@ -55,10 +57,10 @@ function inferAssetMetadata(
     return { os: "windows", format: "msi" };
   }
   if (lower.endsWith(".appimage")) {
-    return { os: "linux", format: "appimage" };
+    return { os: isArm64 ? "chromebook" : "linux", format: "appimage" };
   }
   if (lower.endsWith(".deb")) {
-    return { os: "linux", format: "deb" };
+    return { os: isArm64 ? "chromebook" : "linux", format: "deb" };
   }
   if (lower.endsWith(".rpm")) {
     return { os: "linux", format: "rpm" };
@@ -115,7 +117,12 @@ async function fetchFromGitHubApi(): Promise<ReleaseManifest | null> {
 
       downloads.push({
         os: meta.os,
-        arch: meta.os === "macos" ? "universal" : "x64",
+        arch:
+          meta.os === "macos"
+            ? "universal"
+            : meta.os === "chromebook"
+              ? "arm64"
+              : "x64",
         format: meta.format as DownloadAsset["format"],
         label: getFormatLabel(meta.os, meta.format),
         url: asset.browser_download_url,
@@ -146,6 +153,9 @@ function getFormatLabel(os: OS, format: string): string {
   if (os === "linux" && format === "appimage") return "Linux (AppImage)";
   if (os === "linux" && format === "deb") return "Linux (Debian/Ubuntu)";
   if (os === "linux" && format === "rpm") return "Linux (Fedora/RHEL)";
+  if (os === "chromebook" && format === "deb") return "Chromebook (Debian/ARM64)";
+  if (os === "chromebook" && format === "appimage")
+    return "Chromebook (AppImage/ARM64)";
   return format.toUpperCase();
 }
 
@@ -153,6 +163,7 @@ function isPrimaryFormat(os: OS, format: string): boolean {
   if (os === "macos" && format === "dmg") return true;
   if (os === "windows" && format === "exe") return true;
   if (os === "linux" && format === "appimage") return true;
+  if (os === "chromebook" && format === "deb") return true;
   return false;
 }
 

--- a/apps/download-site/src/release/platform.ts
+++ b/apps/download-site/src/release/platform.ts
@@ -32,6 +32,12 @@ export function detectPlatform(): Platform {
     return "unknown";
   }
 
+  // Check for ChromeOS (Chromebook) before Linux — CrOS user agents report
+  // "X11; CrOS <arch>" and must not be mistaken for desktop Linux.
+  if (userAgent.includes("cros")) {
+    return "chromebook";
+  }
+
   // Check for macOS - Macintosh in user agent and no touch capability
   if (userAgent.includes("macintosh") && navigator.maxTouchPoints <= 1) {
     return "macos";
@@ -61,6 +67,8 @@ export function getPlatformLabel(platform: Platform): string {
       return "Windows";
     case "linux":
       return "Linux";
+    case "chromebook":
+      return "Chromebook";
     default:
       return "Unknown";
   }
@@ -70,5 +78,10 @@ export function getPlatformLabel(platform: Platform): string {
  * Check if a platform has available downloads.
  */
 export function isPlatformSupported(platform: Platform): boolean {
-  return platform === "macos" || platform === "windows" || platform === "linux";
+  return (
+    platform === "macos" ||
+    platform === "windows" ||
+    platform === "linux" ||
+    platform === "chromebook"
+  );
 }

--- a/apps/download-site/src/release/types.ts
+++ b/apps/download-site/src/release/types.ts
@@ -2,7 +2,7 @@
  * Types for release.json manifest consumed by the download site.
  */
 
-export type OS = "macos" | "windows" | "linux";
+export type OS = "macos" | "windows" | "linux" | "chromebook";
 export type Arch = "x64" | "arm64" | "universal";
 export type Format = "dmg" | "exe" | "msi" | "appimage" | "deb" | "rpm";
 

--- a/scripts/release/collect-assets.cjs
+++ b/scripts/release/collect-assets.cjs
@@ -76,6 +76,29 @@ const PLATFORM_CONFIG = {
       { pattern: /\.rpm$/, suffix: "_linux_x64.rpm", type: "installer" },
     ],
   },
+  // Chromebook = ARM64 Linux (Crostini). Built on a native aarch64 runner, so
+  // the bundle output lives in the same release/bundle path as x86_64 Linux.
+  chromebook: {
+    searchPaths: ["apps/desktop/src-tauri/target/release/bundle"],
+    artifacts: [
+      { pattern: /\.deb$/, suffix: "_linux_arm64.deb", type: "installer" },
+      {
+        pattern: /\.AppImage$/,
+        suffix: "_linux_arm64.AppImage",
+        type: "installer",
+      },
+      {
+        pattern: /\.AppImage\.tar\.gz$/,
+        suffix: "_linux_arm64.AppImage.tar.gz",
+        type: "updater",
+      },
+      {
+        pattern: /\.AppImage\.tar\.gz\.sig$/,
+        suffix: "_linux_arm64.AppImage.tar.gz.sig",
+        type: "signature",
+      },
+    ],
+  },
 };
 
 function findFiles(dir, pattern) {

--- a/scripts/release/generate-latest-json.cjs
+++ b/scripts/release/generate-latest-json.cjs
@@ -17,6 +17,7 @@ const TAURI_PLATFORMS = {
   macos: ["darwin-universal", "darwin-x86_64", "darwin-aarch64"],
   windows: ["windows-x86_64"],
   linux: ["linux-x86_64"],
+  chromebook: ["linux-aarch64"],
 };
 
 // Map our artifact types to Tauri updater expectations
@@ -24,6 +25,7 @@ const UPDATER_ASSET_SUFFIX = {
   macos: "_macos_universal.app.tar.gz",
   windows: "_windows_x64.nsis.zip",
   linux: "_linux_x64.AppImage.tar.gz",
+  chromebook: "_linux_arm64.AppImage.tar.gz",
 };
 
 function parseArgs() {
@@ -52,7 +54,7 @@ function parseArgs() {
 
 function loadPlatformManifests(assetsDir) {
   const manifests = {};
-  const platforms = ["macos", "windows", "linux"];
+  const platforms = ["macos", "windows", "linux", "chromebook"];
 
   for (const platform of platforms) {
     const manifestPath = path.join(assetsDir, `manifest-${platform}.json`);

--- a/scripts/release/generate-release-json.cjs
+++ b/scripts/release/generate-release-json.cjs
@@ -20,6 +20,9 @@ const DOWNLOAD_META = {
   "_linux_x64.AppImage": { os: "linux", arch: "x64", format: "appimage", label: "Linux (AppImage)" },
   "_linux_x64.deb": { os: "linux", arch: "x64", format: "deb", label: "Linux (Debian/Ubuntu)" },
   "_linux_x64.rpm": { os: "linux", arch: "x64", format: "rpm", label: "Linux (Fedora/RHEL)" },
+  // Chromebook (ARM64 Linux / Crostini). .deb is the canonical install path.
+  "_linux_arm64.deb": { os: "chromebook", arch: "arm64", format: "deb", label: "Chromebook (Debian/ARM64)" },
+  "_linux_arm64.AppImage": { os: "chromebook", arch: "arm64", format: "appimage", label: "Chromebook (AppImage/ARM64)" },
 };
 
 // Primary download format per OS
@@ -27,6 +30,7 @@ const PRIMARY_FORMAT = {
   macos: "dmg",
   windows: "exe",
   linux: "appimage",
+  chromebook: "deb",
 };
 
 function parseArgs() {
@@ -55,7 +59,7 @@ function parseArgs() {
 
 function loadPlatformManifests(assetsDir) {
   const manifests = {};
-  const platforms = ["macos", "windows", "linux"];
+  const platforms = ["macos", "windows", "linux", "chromebook"];
 
   for (const platform of platforms) {
     const manifestPath = path.join(assetsDir, `manifest-${platform}.json`);


### PR DESCRIPTION
## What

Adds a **Chromebook** build target alongside the existing macOS and Linux builds.

Chromebooks run Linux apps via the **Crostini** (Debian) container. Intel/AMD Chromebooks were already covered by the x86_64 Linux build; this adds the **ARM64 (aarch64)** artifacts that ARM Chromebooks (MediaTek/Qualcomm — most newer/budget models) need. The `.deb` is the primary deliverable (install via the ChromeOS Files app); the AppImage feeds the Tauri updater (`linux-aarch64`).

## How

- **`.github/workflows/build-chromebook.yml`** (new): `build-linux.yml` on a native `ubuntu-22.04-arm` runner, bundling `deb` + `appimage`. Runs on PRs (validation) and is called from `release.yml`. `prepare-merod.mjs` already maps `linux/arm64` → `aarch64-unknown-linux-gnu`, and core ships that asset.
- **`release.yml`**: wire in the `build-chromebook` job, artifact download, partial-release gate, and release-notes line.
- **Release scripts** (`collect-assets` / `generate-latest-json` / `generate-release-json`): teach them the `chromebook` platform with `_linux_arm64` suffixes and the `linux-aarch64` updater key.
- **download-site**: add `chromebook` OS (type, CrOS user-agent detection, GitHub-API fallback inference, labels, platform tab, system-requirements section).

## Testing done

- All JS scripts + both YAML files parse.
- End-to-end dry run of the release scripts with a mock ARM64 manifest → `latest.json` gets `linux-aarch64`, `release.json` lists chromebook downloads (deb primary), `validate-release` passes.
- download-site `tsc --noEmit` clean.

## Notes

- Uses GitHub's free `ubuntu-22.04-arm` hosted runner (public repo).
- No local-build changes needed: on an actual ARM Chromebook, `pnpm tauri build --bundles deb` already resolves the arm64 merod asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release publishing and Tauri updater manifests (`linux-aarch64`); mistakes could mislabel downloads or break ARM auto-updates, but changes are additive and mirror existing Linux/macOS patterns.
> 
> **Overview**
> Adds **ARM64 Chromebook (Crostini)** desktop builds and wires them through release and the download site.
> 
> A new **`build-chromebook.yml`** workflow builds on `ubuntu-22.04-arm`, producing **`.deb`** (primary install) and **AppImage** (Tauri updater `linux-aarch64`). **`release.yml`** runs that job, downloads `chromebook-build` artifacts, allows partial publish when Chromebook succeeds, and adds Chromebook to release notes.
> 
> Release tooling gains a **`chromebook`** platform with `_linux_arm64` naming in **`collect-assets`**, **`generate-latest-json`**, and **`generate-release-json`**. The **download site** adds a `chromebook` OS (CrOS detection before Linux, ARM64 inference in GitHub API fallback, tab, labels, system requirements).
> 
> **`build-linux.yml`** tightens the **wry / webkit2gtk** patch guard to grep for any `SettingsExt` so wry ≥0.24.12 is not double-patched. **`scripts/dev/build-arm64-local.sh`** mirrors CI for local ARM64 VM testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be82b1058b1daf085e874c1d3b69922913aaf26e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->