### PR TITLE
chore: bump desktop app version to 0.0.50

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.49"
+    "version": "0.0.50"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
## Summary
- Bump desktop app version `0.0.49` → `0.0.50` (`apps/desktop/package.json` + `apps/desktop/src-tauri/tauri.conf.json`)

Prepares for the `v0.0.50` release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no runtime, security, or behavioral impact.
> 
> **Overview**
> Bumps the Calimero Desktop release version from **0.0.49** to **0.0.50** in `apps/desktop/package.json` and `apps/desktop/src-tauri/tauri.conf.json` (`package.version`) so npm metadata and Tauri bundle versioning stay aligned ahead of a **v0.0.50** release tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc3e5aa6226a7fd985971d5c97fb343c15e6cf24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->