### PR TITLE
chore: bump bundled merod to 0.11.0-rc.7

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.50"
+    "version": "0.0.51"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.6"
+    "version": "0.11.0-rc.7"
 }


### PR DESCRIPTION
Bumps the bundled `merod` pin in `merod-config.json` `0.11.0-rc.6` → `0.11.0-rc.7`, picking up core PR #2855 (TEE fleet correctness; fixes #2848 / #2491 / #2771).

## Changes
- `merod-config.json`: `version` `0.11.0-rc.6` → `0.11.0-rc.7`

Bundling is fully data-driven from this file (prepare-merod.mjs, build.rs, Windows CI all read `config.version`) — no other merod-version pin exists, so this is the only change needed.

## Before merge
- The merod rc.7 **release asset must be published first** (core #2909 merge + tag) or the bundle download (`releases/tags/0.11.0-rc.7`) will 404 in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only bumps with no application logic changes; CI fails if the merod release is missing.
> 
> **Overview**
> Updates the **bundled `merod` pin** in `merod-config.json` from `0.11.0-rc.6` to **`0.11.0-rc.7`**, so `prepare-merod.mjs` and `build.rs` fetch and embed that core release (including TEE fleet fixes from core #2855).
> 
> Also bumps the **Calimero Desktop** package/Tauri version **`0.0.50` → `0.0.51`** in `apps/desktop/package.json` and `tauri.conf.json` to align the shipped app with the new node binary.
> 
> **Before merge:** the `0.11.0-rc.7` GitHub release asset must exist or CI/local `merod:prepare` will 404 on the tag download.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6706e52ab3ba792b658fd712776b56788a01e0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->