### PR TITLE
fix(marketplace): style app-install version dropdown to match design + bump to 0.0.52

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.51"
+    "version": "0.0.52"
   },
   "tauri": {
     "allowlist": {

--- a/apps/desktop/src/pages/Marketplace.css
+++ b/apps/desktop/src/pages/Marketplace.css
@@ -672,6 +672,54 @@
   font-size: 12px;
 }
 
+.modal-version-select {
+  flex: 1;
+  min-width: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  padding: 7px 32px 7px 12px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--text-primary);
+  background-color: var(--surface-glass-soft);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238b949e' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.modal-version-select:hover:not(:disabled) {
+  border-color: var(--accent-dim);
+  background-color: var(--surface-glass);
+}
+
+.modal-version-select:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px var(--accent-light);
+  background-color: var(--surface-glass);
+}
+
+.modal-version-select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.modal-version-select option {
+  background: var(--bg-primary, #111);
+  color: var(--text-primary);
+}
+
+.modal-versions-loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-tertiary);
+}
+
 .modal-meta-link {
   color: var(--accent-primary);
   text-decoration: none;


### PR DESCRIPTION
## Summary
The version picker `<select>` in the app-install detail modal (Marketplace) was an unstyled native `<select>` — it rendered with default browser chrome (light background, native OS arrow), which looked out of place against the dark glass design used for the rest of the modal (Package ID / Author / Downloads / Registry rows, Install/Close buttons).

This adds a `.modal-version-select` style that matches the existing design language and bumps the desktop app version `0.0.51` → `0.0.52`.

## Changes
- `apps/desktop/src/pages/Marketplace.css`
  - New `.modal-version-select` rule: glass surface (`--surface-glass-soft`), themed `--border-color`, `--radius-sm`, custom chevron, and `:hover`/`:focus` states mirroring `.search-input` (accent border + `--accent-light` focus ring).
  - Themed `<option>` list and a `.modal-versions-loading` helper for the "Loading…" state.
- `apps/desktop/package.json` + `apps/desktop/src-tauri/tauri.conf.json`: version `0.0.51` → `0.0.52`.

No markup or behavior changes — the dropdown is the same `data-testid="version-picker"` element, now visually in sync.

## Testing
- `pnpm --filter desktop build` ✅ (tsc + vite build pass; only pre-existing chunk-size warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only marketplace styling plus a routine version bump; no logic or security-sensitive changes.
> 
> **Overview**
> Styles the Marketplace app-install modal **version** `<select>` so it matches the dark glass modal UI instead of default browser chrome.
> 
> Adds **`.modal-version-select`** (and related **`:hover`/`focus`/disabled**, themed **`option`**, and **`.modal-versions-loading`**) in `Marketplace.css`, aligned with patterns like **`.search-input`**. No markup or install behavior changes—the existing `data-testid="version-picker"` control is unchanged.
> 
> Bumps Calimero Desktop from **0.0.51** to **0.0.52** in `package.json` and `tauri.conf.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a57356111661c5fb6312f450f93f83540467836b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->