### PR TITLE
feat(namespaces): collapsible structure tree + accurate context/subgroup counts

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.52"
+    "version": "0.0.53"
   },
   "tauri": {
     "allowlist": {

--- a/apps/desktop/src/pages/Namespaces.css
+++ b/apps/desktop/src/pages/Namespaces.css
@@ -1327,3 +1327,136 @@
   background: rgba(239, 68, 68, 0.08) !important;
   color: var(--error, #ef4444);
 }
+
+/* ─── Structure tree ─── */
+.ns-tree-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0 0 12px 0;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.ns-tree-header h2 {
+  border-bottom: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ns-tree-legend {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.ns-tree {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--surface-glass-soft);
+}
+
+.ns-tree-branch {
+  display: flex;
+  flex-direction: column;
+}
+
+.ns-tree-children {
+  display: flex;
+  flex-direction: column;
+}
+
+.ns-tree-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-right: 12px;
+  border-top: 1px solid var(--border-color);
+  min-height: 24px;
+}
+
+/* No divider above the very first row in the tree. */
+.ns-tree > .ns-tree-branch:first-child > .ns-tree-row {
+  border-top: none;
+}
+
+.ns-tree-row:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.ns-tree-namespace {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.ns-tree-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--text-tertiary);
+}
+
+.ns-tree-toggle:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.ns-tree-toggle-empty {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+}
+
+.ns-tree-chevron {
+  transition: transform 0.18s;
+}
+
+.ns-tree-chevron-open {
+  transform: rotate(90deg);
+}
+
+.ns-tree-icon {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.ns-tree-icon-root {
+  color: var(--accent-primary, #a5ff11);
+}
+
+/* Aligns context leaves under the subgroup's name (no chevron of their own). */
+.ns-tree-spacer {
+  display: inline-block;
+  width: 18px;
+  flex-shrink: 0;
+}
+
+.ns-tree-count {
+  flex: 0 0 auto;
+  font-size: 10px;
+  color: var(--text-tertiary);
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  padding: 1px 8px;
+  line-height: 1.6;
+}
+
+.ns-tree-empty {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-style: italic;
+  padding: 8px 12px;
+  border-top: 1px solid var(--border-color);
+}

--- a/apps/desktop/src/pages/Namespaces.css
+++ b/apps/desktop/src/pages/Namespaces.css
@@ -1488,3 +1488,13 @@
   color: var(--text-secondary);
   font-weight: 600;
 }
+
+.ns-tree-error {
+  margin: 0 0 10px;
+  padding: 7px 11px;
+  font-size: 12px;
+  color: var(--error, #ef4444);
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: var(--radius-md);
+}

--- a/apps/desktop/src/pages/Namespaces.css
+++ b/apps/desktop/src/pages/Namespaces.css
@@ -1460,3 +1460,31 @@
   padding: 8px 12px;
   border-top: 1px solid var(--border-color);
 }
+
+.ns-page-subtitle {
+  margin: 4px 0 0;
+  max-width: 640px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-tertiary);
+}
+
+.ns-tree-help {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 0 0 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-tertiary);
+}
+
+.ns-tree-help svg {
+  vertical-align: -2px;
+}
+
+.ns-tree-help strong {
+  color: var(--text-secondary);
+  font-weight: 600;
+}

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -272,6 +272,9 @@ export default function Namespaces() {
     ): Promise<TreeSubgroup> => {
       // Stop descending as soon as this run is superseded — avoids issuing a
       // burst of now-pointless requests for a tree that won't be committed.
+      // Note: requests already dispatched can't be aborted (the mero-js admin
+      // methods take no AbortSignal); their results are simply discarded by the
+      // `cancelled` guard in `.then`.
       if (cancelled) return { groupId, name, contexts: [], subgroups: [] };
       const [contexts, subs] = await Promise.all([
         admin.listGroupContexts(groupId).catch(onFetchErr("listGroupContexts", groupId)),

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -1132,6 +1132,9 @@ export default function Namespaces() {
           <div className="ns-page-top">
             <div className="ns-page-top-left">
               <h1>Namespaces</h1>
+              <p className="ns-page-subtitle">
+                A namespace is an app-bound workspace. It holds contexts (running app instances, e.g. a chat channel) and subgroups (nested groups that hold their own contexts).
+              </p>
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
               <button
@@ -1196,9 +1199,9 @@ export default function Namespaces() {
                     </button>
                   </div>
                   <div className="ns-card-stats">
-                    <span title="Subgroups"><Layers size={14} /> {(ns as any).subgroupCount ?? 0}</span>
-                    <span title="Members"><Users size={14} /> {(ns as any).memberCount ?? 0}</span>
-                    <span title="Contexts"><Box size={14} /> {(ns as any).contextCount ?? 0}</span>
+                    <span title="Subgroups — nested groups inside this namespace, each holding its own contexts"><Layers size={14} /> {(ns as any).subgroupCount ?? 0}</span>
+                    <span title="Members — identities with access to this namespace"><Users size={14} /> {(ns as any).memberCount ?? 0}</span>
+                    <span title="Contexts — running app instances (e.g. a chat channel) directly under the namespace"><Box size={14} /> {(ns as any).contextCount ?? 0}</span>
                   </div>
                   {ns.upgradePolicy && (
                     <div className="ns-card-policy">
@@ -1274,20 +1277,21 @@ export default function Namespaces() {
           <div className="ns-detail-stats">
             <button
               className="stat-card stat-card-clickable"
+              title="Members — identities with access to this namespace"
               onClick={() => document.getElementById('ns-members-section')?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
             >
               <div className="stat-value">{nsMembersLoading ? '…' : nsMembers.length}</div>
               <div className="stat-label">Members ↓</div>
             </button>
-            <div className="stat-card">
+            <div className="stat-card" title="Contexts — running app instances (e.g. a chat channel), counted across the namespace and all its subgroups">
               <div className="stat-value">{countsLoading ? '…' : nsContextCount}</div>
               <div className="stat-label">Contexts</div>
             </div>
-            <div className="stat-card">
+            <div className="stat-card" title="Subgroups — nested groups inside this namespace, each holding its own contexts (counted recursively)">
               <div className="stat-value">{countsLoading || nsLoadingGroups ? '…' : nsSubgroupCount}</div>
               <div className="stat-label">Subgroups</div>
             </div>
-            <div className="stat-card">
+            <div className="stat-card" title="Upgrade Policy — how this namespace adopts new application versions">
               <div className="stat-value" style={{ fontSize: "0.85rem" }}>{ns.upgradePolicy || "—"}</div>
               <div className="stat-label">Upgrade Policy</div>
             </div>
@@ -1318,6 +1322,10 @@ export default function Namespaces() {
               <h2><Layers size={16} /> Structure</h2>
               <span className="ns-tree-legend">{nsContextCount} contexts · {nsSubgroupCount} subgroups</span>
             </div>
+            <p className="ns-tree-help">
+              <Box size={12} /> <strong>Context</strong> = a running app instance (e.g. a chat channel).
+              <Layers size={12} /> <strong>Subgroup</strong> = a nested group holding its own contexts. Click a subgroup to expand it.
+            </p>
             {treeLoading && !tree ? (
               <div className="loading">Loading structure…</div>
             ) : !tree || (tree.rootContexts.length === 0 && tree.subgroups.length === 0) ? (

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -124,6 +124,54 @@ type GroupInfoExt = Omit<GroupInfo, "metadata"> & {
   groupStateHash?: string;
 };
 
+// ─── Namespace structure tree ───
+// A namespace owns root-level contexts and subgroups; each subgroup owns its
+// own contexts and (recursively) nested subgroups. We fetch this whole shape
+// imperatively (the mero-react hooks only resolve one level at a time) so the
+// page can render a collapsible folder tree and count contexts across the
+// entire tree — not just the root.
+interface TreeContext {
+  contextId: string;
+  name?: string;
+}
+interface TreeSubgroup {
+  groupId: string;
+  name?: string;
+  contexts: TreeContext[];
+  subgroups: TreeSubgroup[];
+}
+interface NamespaceTree {
+  rootContexts: TreeContext[];
+  subgroups: TreeSubgroup[];
+}
+
+// Guard against a pathological/cyclic group graph blowing the stack.
+const MAX_TREE_DEPTH = 12;
+
+// Total contexts in the whole tree: root contexts + every subgroup's contexts,
+// recursively. This is what the "Contexts" stat should reflect (the old count
+// only saw root contexts).
+function countTreeContexts(tree: NamespaceTree): number {
+  let n = tree.rootContexts.length;
+  const walk = (sg: TreeSubgroup) => {
+    n += sg.contexts.length;
+    sg.subgroups.forEach(walk);
+  };
+  tree.subgroups.forEach(walk);
+  return n;
+}
+
+// Total subgroups in the whole tree (direct + nested).
+function countTreeSubgroups(tree: NamespaceTree): number {
+  let n = 0;
+  const walk = (sg: TreeSubgroup) => {
+    n += 1;
+    sg.subgroups.forEach(walk);
+  };
+  tree.subgroups.forEach(walk);
+  return n;
+}
+
 export default function Namespaces() {
   const toast = useToast();
   const { mero } = useMero();
@@ -135,7 +183,7 @@ export default function Namespaces() {
   const activeNsRootId = (view.type === "namespace" || view.type === "group") ? view.ns.namespaceId : null;
 
   const { namespaces, loading, error, refetch: refetchNamespaces } = useNamespaces();
-  const { groups: nsGroups, loading: nsLoadingGroups, error: nsGroupsError, refetch: refetchNsGroups } = useNamespaceGroups(activeNsId) as any;
+  const { groups: nsGroups, loading: nsLoadingGroups, refetch: refetchNsGroups } = useNamespaceGroups(activeNsId) as any;
   const { groupInfo: groupInfoRaw, loading: groupInfoLoading } = useGroupInfo(activeGroupId);
   const { groupInfo: nsRootGroupInfoRaw } = useGroupInfo(activeNsRootId);
   // The SDK's `GroupInfo` is stale vs core's API (skew): it lacks
@@ -175,6 +223,78 @@ export default function Namespaces() {
     view.type === "namespace" ? view.ns.namespaceId : null,
   );
   const { subgroups: groupSubgroups = [], refetch: refetchSubgroups } = useSubgroups(activeGroupId) as any;
+
+  // Full structure tree for the namespace detail view (root contexts +
+  // subgroups recursively), fetched imperatively. `treeVersion` is bumped by
+  // create/delete handlers so the tree (and its counts) stay fresh.
+  const [tree, setTree] = useState<NamespaceTree | null>(null);
+  const [treeLoading, setTreeLoading] = useState(false);
+  const [treeVersion, setTreeVersion] = useState(0);
+  const [expandedNodes, setExpandedNodes] = useState<Set<string>>(new Set());
+  const refetchTree = useCallback(() => setTreeVersion((v) => v + 1), []);
+
+  useEffect(() => {
+    if (view.type !== "namespace" || !mero || !activeNsId) {
+      setTree(null);
+      return;
+    }
+    let cancelled = false;
+    const admin: any = mero.admin;
+
+    const buildSubgroup = async (
+      groupId: string,
+      name: string | undefined,
+      depth: number,
+    ): Promise<TreeSubgroup> => {
+      const [contexts, subs] = await Promise.all([
+        admin.listGroupContexts(groupId).catch(() => []),
+        depth < MAX_TREE_DEPTH
+          ? admin.listSubgroups(groupId).catch(() => [])
+          : Promise.resolve([]),
+      ]);
+      const subgroups = await Promise.all(
+        (subs as any[]).map((s) => buildSubgroup(s.groupId, s.name, depth + 1)),
+      );
+      return { groupId, name, contexts: (contexts as TreeContext[]) ?? [], subgroups };
+    };
+
+    setTreeLoading(true);
+    (async () => {
+      const [rootContexts, nsSubs] = await Promise.all([
+        admin.listGroupContexts(activeNsId).catch(() => []),
+        admin.listNamespaceGroups(activeNsId).catch(() => []),
+      ]);
+      const subgroups = await Promise.all(
+        (nsSubs as any[]).map((s) => buildSubgroup(s.groupId, s.name, 1)),
+      );
+      return { rootContexts: (rootContexts as TreeContext[]) ?? [], subgroups };
+    })()
+      .then((t) => {
+        if (cancelled) return;
+        setTree(t);
+        // Default: namespace root expanded, subgroups collapsed.
+        setExpandedNodes(new Set([`ns:${activeNsId}`]));
+      })
+      .catch(() => {
+        if (!cancelled) setTree(null);
+      })
+      .finally(() => {
+        if (!cancelled) setTreeLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [view.type, activeNsId, mero, treeVersion]);
+
+  const toggleNode = useCallback((id: string) => {
+    setExpandedNodes((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
 
   const { createNamespace, loading: creatingNamespace } = useCreateNamespace();
   const [creatingContext, setCreatingContext] = useState(false);
@@ -282,6 +402,7 @@ export default function Namespaces() {
       saveContextKey(result.contextId, result.memberPublicKey, applicationId);
       toast.success(`Context created: ${truncateId(result.contextId)}`);
       setCtxModalOpen(null);
+      refetchTree();
       await Promise.all([refetchGroupContexts?.(), refetchNsRootContexts?.()]);
     } catch (e: any) {
       toast.error(`Failed to create context: ${parseApiError(e)}`);
@@ -314,6 +435,7 @@ export default function Namespaces() {
       toast.success('Group deleted');
       setDeleteGroupTarget(null);
       if (view.type === 'group') setView({ type: 'namespace', ns: view.ns });
+      refetchTree();
       await Promise.all([
         refetchNsGroups?.(),
         refetchSubgroups?.(),
@@ -332,6 +454,7 @@ export default function Namespaces() {
       await mero.admin.deleteContext(contextId);
       toast.success('Context deleted');
       setDeleteContextTarget(null);
+      refetchTree();
       await Promise.all([
         refetch(),
         refetchNsRootContexts?.(),
@@ -813,6 +936,105 @@ export default function Namespaces() {
     );
   };
 
+  // ── Tree (folder structure) helpers ──
+  // A context leaf in the tree: copy + delete. `indent` is the nesting depth
+  // (0 = directly under the namespace root).
+  const renderTreeContext = (c: TreeContext, indent: number) => {
+    const hasName = !!c.name;
+    return (
+      <div
+        key={`ctx-${c.contextId}`}
+        className="ns-tree-row ns-tree-context"
+        style={{ paddingLeft: `${0.6 + indent * 1.25}rem` }}
+      >
+        <span className="ns-tree-spacer" />
+        <Box size={14} className="ns-tree-icon" />
+        <div className="ns-row-info">
+          {hasName ? (
+            <>
+              <span className="ns-row-name">{c.name}</span>
+              <span className="ns-row-id">{truncateId(c.contextId)}</span>
+            </>
+          ) : (
+            <span className="ns-row-name mono">{truncateId(c.contextId)}</span>
+          )}
+        </div>
+        <button className="copy-btn" onClick={() => copyToClipboard(c.contextId)} title="Copy ID">
+          <Copy size={12} />
+        </button>
+        <button
+          className="ns-danger-icon-btn"
+          title="Delete context"
+          onClick={() => setDeleteContextTarget({ contextId: c.contextId, name: c.name || truncateId(c.contextId), refetch: refetchTree })}
+        >
+          <Trash2 size={13} />
+        </button>
+      </div>
+    );
+  };
+
+  // A subgroup node: collapsible header (chevron toggles its children) whose
+  // name opens the group detail view; recurses into nested subgroups.
+  const renderTreeSubgroup = (sg: TreeSubgroup, ns: Namespace, indent: number) => {
+    const isOpen = expandedNodes.has(sg.groupId);
+    const childCount = sg.contexts.length + sg.subgroups.length;
+    const gName = sg.name;
+    return (
+      <div key={`sg-${sg.groupId}`} className="ns-tree-branch">
+        <div
+          className="ns-tree-row ns-tree-subgroup"
+          style={{ paddingLeft: `${0.6 + indent * 1.25}rem` }}
+        >
+          <button
+            className="ns-tree-toggle"
+            onClick={() => toggleNode(sg.groupId)}
+            title={isOpen ? "Collapse" : "Expand"}
+            disabled={childCount === 0}
+          >
+            {childCount === 0 ? (
+              <span className="ns-tree-toggle-empty" />
+            ) : (
+              <ChevronRight size={14} className={`ns-tree-chevron${isOpen ? " ns-tree-chevron-open" : ""}`} />
+            )}
+          </button>
+          <Layers size={15} className="ns-tree-icon" />
+          <div className="ns-row-info" onClick={() => openGroup(ns, sg.groupId)} style={{ cursor: "pointer" }}>
+            {gName ? (
+              <>
+                <span className="ns-row-name">{gName}</span>
+                <span className="ns-row-id">{truncateId(sg.groupId)}</span>
+              </>
+            ) : (
+              <span className="ns-row-name mono">{truncateId(sg.groupId)}</span>
+            )}
+          </div>
+          <span className="ns-tree-count">{childCount}</span>
+          <button
+            className="ns-danger-icon-btn"
+            title="Delete group"
+            onClick={(e) => { e.stopPropagation(); setDeleteGroupTarget(sg.groupId); }}
+          >
+            <Trash2 size={13} />
+          </button>
+        </div>
+        {isOpen && (
+          <div className="ns-tree-children">
+            {childCount === 0 ? (
+              <div className="ns-tree-empty" style={{ paddingLeft: `${0.6 + (indent + 1) * 1.25}rem` }}>
+                Empty subgroup
+              </div>
+            ) : (
+              <>
+                {sg.contexts.map((c) => renderTreeContext(c, indent + 1))}
+                {sg.subgroups.map((child) => renderTreeSubgroup(child, ns, indent + 1))}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
+
   // ── Modals ──
   const modalOverlay = (
     <>
@@ -974,7 +1196,7 @@ export default function Namespaces() {
                     </button>
                   </div>
                   <div className="ns-card-stats">
-                    <span title="Groups"><Layers size={14} /> {(ns as any).subgroupCount ?? 0}</span>
+                    <span title="Subgroups"><Layers size={14} /> {(ns as any).subgroupCount ?? 0}</span>
                     <span title="Members"><Users size={14} /> {(ns as any).memberCount ?? 0}</span>
                     <span title="Contexts"><Box size={14} /> {(ns as any).contextCount ?? 0}</span>
                   </div>
@@ -997,6 +1219,11 @@ export default function Namespaces() {
   // ─── Namespace Detail View ───
   if (view.type === "namespace") {
     const { ns } = view;
+    // Counts span the whole tree (root + nested subgroups). Fall back to the
+    // single-level hook data while the tree is still loading.
+    const nsContextCount = tree ? countTreeContexts(tree) : nsRootContexts.length;
+    const nsSubgroupCount = tree ? countTreeSubgroups(tree) : nsGroups.length;
+    const countsLoading = treeLoading && !tree;
     return (
       <>
       <div className="ns-page">
@@ -1030,7 +1257,7 @@ export default function Namespaces() {
                   <button className="ns-actions-menu-item" onClick={() => { setActionsMenuOpen(false); setCtxModalOpen({ namespaceId: ns.namespaceId, applicationId: ns.targetApplicationId }); }}>
                     <Plus size={13} /> Create Context
                   </button>
-                  <button className="ns-actions-menu-item" onClick={() => { setActionsMenuOpen(false); setJoinCtxModal({ groupId: ns.namespaceId, refetch: () => refetchNsRootContexts?.() }); }}>
+                  <button className="ns-actions-menu-item" onClick={() => { setActionsMenuOpen(false); setJoinCtxModal({ groupId: ns.namespaceId, refetch: () => { refetchTree(); refetchNsRootContexts?.(); } }); }}>
                     <LogIn size={13} /> Join Context
                   </button>
                   <button className="ns-actions-menu-item" onClick={() => { setActionsMenuOpen(false); setInviteModal({ groupId: ns.namespaceId, isNamespace: true }); }}>
@@ -1053,12 +1280,12 @@ export default function Namespaces() {
               <div className="stat-label">Members ↓</div>
             </button>
             <div className="stat-card">
-              <div className="stat-value">{nsRootContexts.length}</div>
+              <div className="stat-value">{countsLoading ? '…' : nsContextCount}</div>
               <div className="stat-label">Contexts</div>
             </div>
             <div className="stat-card">
-              <div className="stat-value">{nsLoadingGroups ? '…' : nsGroups.length}</div>
-              <div className="stat-label">Groups</div>
+              <div className="stat-value">{countsLoading || nsLoadingGroups ? '…' : nsSubgroupCount}</div>
+              <div className="stat-label">Subgroups</div>
             </div>
             <div className="stat-card">
               <div className="stat-value" style={{ fontSize: "0.85rem" }}>{ns.upgradePolicy || "—"}</div>
@@ -1087,12 +1314,38 @@ export default function Namespaces() {
           </div>
 
           <div className="ns-detail-section">
-            <h2><Box size={16} /> Contexts ({nsRootContexts.length})</h2>
-            {nsRootContexts.length === 0 ? (
-              <p className="empty-hint">No contexts yet. Click "Create Context" to add one.</p>
+            <div className="ns-tree-header">
+              <h2><Layers size={16} /> Structure</h2>
+              <span className="ns-tree-legend">{nsContextCount} contexts · {nsSubgroupCount} subgroups</span>
+            </div>
+            {treeLoading && !tree ? (
+              <div className="loading">Loading structure…</div>
+            ) : !tree || (tree.rootContexts.length === 0 && tree.subgroups.length === 0) ? (
+              <p className="empty-hint">Empty namespace. Create a context or subgroup to get started.</p>
             ) : (
-              <div className="ns-context-list">
-                {nsRootContexts.map((c: any) => renderContextItem(c, ns.targetApplicationId, () => refetchNsRootContexts?.()))}
+              <div className="ns-tree">
+                <div className="ns-tree-branch">
+                  <div className="ns-tree-row ns-tree-namespace" style={{ paddingLeft: "0.6rem" }}>
+                    <button
+                      className="ns-tree-toggle"
+                      onClick={() => toggleNode(`ns:${ns.namespaceId}`)}
+                      title={expandedNodes.has(`ns:${ns.namespaceId}`) ? "Collapse" : "Expand"}
+                    >
+                      <ChevronRight size={14} className={`ns-tree-chevron${expandedNodes.has(`ns:${ns.namespaceId}`) ? " ns-tree-chevron-open" : ""}`} />
+                    </button>
+                    <Box size={15} className="ns-tree-icon ns-tree-icon-root" />
+                    <div className="ns-row-info">
+                      <span className="ns-row-name">{nsDisplayName(ns)}</span>
+                    </div>
+                    <span className="ns-tree-count">{tree.rootContexts.length + tree.subgroups.length}</span>
+                  </div>
+                  {expandedNodes.has(`ns:${ns.namespaceId}`) && (
+                    <div className="ns-tree-children">
+                      {tree.rootContexts.map((c) => renderTreeContext(c, 1))}
+                      {tree.subgroups.map((sg) => renderTreeSubgroup(sg, ns, 1))}
+                    </div>
+                  )}
+                </div>
               </div>
             )}
           </div>
@@ -1210,49 +1463,6 @@ export default function Namespaces() {
             )}
           </div>
 
-          <div className="ns-detail-section">
-            <h2>Groups</h2>
-            {nsLoadingGroups ? (
-              <div className="loading">Loading groups...</div>
-            ) : nsGroupsError ? (
-              <div className="error-message">{nsGroupsError.message}</div>
-            ) : nsGroups.length === 0 ? (
-              <p className="empty-hint">No groups in this namespace</p>
-            ) : (
-              <div className="ns-group-list">
-                {nsGroups.map((g: any) => {
-                  const gName = (g as any).name || (g as any).metadata?.name;
-                  return (
-                    <div key={g.groupId} className="ns-group-item">
-                      <Layers size={16} />
-                      <div
-                        className="ns-row-info"
-                        onClick={() => openGroup(ns, g.groupId)}
-                        style={{ cursor: 'pointer' }}
-                      >
-                        {gName ? (
-                          <>
-                            <span className="ns-row-name">{gName}</span>
-                            <span className="ns-row-id">{truncateId(g.groupId)}</span>
-                          </>
-                        ) : (
-                          <span className="ns-row-name mono">{truncateId(g.groupId)}</span>
-                        )}
-                      </div>
-                      <button
-                        className="ns-danger-icon-btn"
-                        title="Delete group"
-                        onClick={(e) => { e.stopPropagation(); setDeleteGroupTarget(g.groupId); }}
-                      >
-                        <Trash2 size={13} />
-                      </button>
-                      <ChevronRight size={14} className="ns-card-chevron" onClick={() => openGroup(ns, g.groupId)} style={{ cursor: 'pointer' }} />
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
         </main>
       </div>
       {modalOverlay}

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -229,29 +229,54 @@ export default function Namespaces() {
   // create/delete handlers so the tree (and its counts) stay fresh.
   const [tree, setTree] = useState<NamespaceTree | null>(null);
   const [treeLoading, setTreeLoading] = useState(false);
+  const [treeError, setTreeError] = useState(false);
   const [treeVersion, setTreeVersion] = useState(0);
   const [expandedNodes, setExpandedNodes] = useState<Set<string>>(new Set());
+  // Tracks the namespace whose expansion state has been initialised, so that
+  // post-mutation refreshes (refetchTree) preserve the user's expanded
+  // subgroups and only the first load of a *new* namespace resets them.
+  const expandedInitRef = useRef<string | null>(null);
   const refetchTree = useCallback(() => setTreeVersion((v) => v + 1), []);
 
   useEffect(() => {
     if (view.type !== "namespace" || !mero || !activeNsId) {
       setTree(null);
+      setTreeError(false);
+      expandedInitRef.current = null;
       return;
     }
     let cancelled = false;
     const admin: any = mero.admin;
+    // When the namespace itself changes, drop the previous tree so we don't
+    // briefly show the wrong namespace's structure; a same-namespace refresh
+    // keeps the current tree on screen (no flicker, no collapse).
+    const namespaceChanged = expandedInitRef.current !== activeNsId;
+    if (namespaceChanged) setTree(null);
+
+    // Any sub-fetch failure flips this so the UI can warn that counts/branches
+    // may be incomplete instead of silently rendering an empty subtree.
+    let fetchFailed = false;
+    const onFetchErr = (label: string, id: string) => (e: unknown) => {
+      fetchFailed = true;
+      console.warn(`[ns-tree] ${label} failed for ${id}`, e);
+      return [] as any[];
+    };
 
     const buildSubgroup = async (
       groupId: string,
       name: string | undefined,
       depth: number,
     ): Promise<TreeSubgroup> => {
+      // Stop descending as soon as this run is superseded — avoids issuing a
+      // burst of now-pointless requests for a tree that won't be committed.
+      if (cancelled) return { groupId, name, contexts: [], subgroups: [] };
       const [contexts, subs] = await Promise.all([
-        admin.listGroupContexts(groupId).catch(() => []),
+        admin.listGroupContexts(groupId).catch(onFetchErr("listGroupContexts", groupId)),
         depth < MAX_TREE_DEPTH
-          ? admin.listSubgroups(groupId).catch(() => [])
+          ? admin.listSubgroups(groupId).catch(onFetchErr("listSubgroups", groupId))
           : Promise.resolve([]),
       ]);
+      if (cancelled) return { groupId, name, contexts: [], subgroups: [] };
       const subgroups = await Promise.all(
         (subs as any[]).map((s) => buildSubgroup(s.groupId, s.name, depth + 1)),
       );
@@ -261,8 +286,8 @@ export default function Namespaces() {
     setTreeLoading(true);
     (async () => {
       const [rootContexts, nsSubs] = await Promise.all([
-        admin.listGroupContexts(activeNsId).catch(() => []),
-        admin.listNamespaceGroups(activeNsId).catch(() => []),
+        admin.listGroupContexts(activeNsId).catch(onFetchErr("listGroupContexts", activeNsId)),
+        admin.listNamespaceGroups(activeNsId).catch(onFetchErr("listNamespaceGroups", activeNsId)),
       ]);
       const subgroups = await Promise.all(
         (nsSubs as any[]).map((s) => buildSubgroup(s.groupId, s.name, 1)),
@@ -272,11 +297,20 @@ export default function Namespaces() {
       .then((t) => {
         if (cancelled) return;
         setTree(t);
-        // Default: namespace root expanded, subgroups collapsed.
-        setExpandedNodes(new Set([`ns:${activeNsId}`]));
+        setTreeError(fetchFailed);
+        // Initialise expansion only on the first load of this namespace;
+        // refreshes preserve whatever the user has expanded.
+        if (namespaceChanged) {
+          expandedInitRef.current = activeNsId;
+          setExpandedNodes(new Set([`ns:${activeNsId}`]));
+        }
       })
-      .catch(() => {
-        if (!cancelled) setTree(null);
+      .catch((e) => {
+        if (cancelled) return;
+        // Total failure: keep any tree already on screen rather than blanking
+        // it to a misleading "Empty namespace"; just flag the error.
+        console.warn("[ns-tree] structure fetch failed", e);
+        setTreeError(true);
       })
       .finally(() => {
         if (!cancelled) setTreeLoading(false);
@@ -1326,8 +1360,13 @@ export default function Namespaces() {
               <Box size={12} /> <strong>Context</strong> = a running app instance (e.g. a chat channel).
               <Layers size={12} /> <strong>Subgroup</strong> = a nested group holding its own contexts. Click a subgroup to expand it.
             </p>
+            {treeError && tree && (
+              <p className="ns-tree-error">Some groups couldn't be loaded — the structure and counts may be incomplete.</p>
+            )}
             {treeLoading && !tree ? (
               <div className="loading">Loading structure…</div>
+            ) : treeError && !tree ? (
+              <p className="empty-hint">Couldn't load the namespace structure. Refresh to try again.</p>
             ) : !tree || (tree.rootContexts.length === 0 && tree.subgroups.length === 0) ? (
               <p className="empty-hint">Empty namespace. Create a context or subgroup to get started.</p>
             ) : (

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -252,6 +252,9 @@ export default function Namespaces() {
     // keeps the current tree on screen (no flicker, no collapse).
     const namespaceChanged = expandedInitRef.current !== activeNsId;
     if (namespaceChanged) setTree(null);
+    // Start each run with a clean error state so a stale banner from a prior
+    // failed fetch doesn't linger over a fresh (re)load.
+    setTreeError(false);
 
     // Any sub-fetch failure flips this so the UI can warn that counts/branches
     // may be incomplete instead of silently rendering an empty subtree.
@@ -292,15 +295,20 @@ export default function Namespaces() {
       const subgroups = await Promise.all(
         (nsSubs as any[]).map((s) => buildSubgroup(s.groupId, s.name, 1)),
       );
-      return { rootContexts: (rootContexts as TreeContext[]) ?? [], subgroups };
+      // `fetchFailed` is final here — the IIFE has awaited the entire tree —
+      // but we carry it in the resolved value so `.then` reads a snapshot
+      // rather than a closure variable.
+      return { rootContexts: (rootContexts as TreeContext[]) ?? [], subgroups, fetchFailed };
     })()
-      .then((t) => {
+      .then(({ fetchFailed: failed, ...treeData }) => {
         if (cancelled) return;
-        setTree(t);
-        setTreeError(fetchFailed);
+        setTree(treeData);
+        setTreeError(failed);
         // Initialise expansion only on the first load of this namespace;
-        // refreshes preserve whatever the user has expanded.
-        if (namespaceChanged) {
+        // refreshes preserve whatever the user has expanded. Re-check against
+        // the ref (not the start-of-run boolean) so a late-resolving fetch
+        // can't reset a namespace the user has since switched to.
+        if (expandedInitRef.current !== activeNsId) {
           expandedInitRef.current = activeNsId;
           setExpandedNodes(new Set([`ns:${activeNsId}`]));
         }
@@ -996,10 +1004,13 @@ export default function Namespaces() {
         <button className="copy-btn" onClick={() => copyToClipboard(c.contextId)} title="Copy ID">
           <Copy size={12} />
         </button>
+        {/* No-op refetch: handleDeleteContext already refreshes the tree
+            (refetchTree) plus the namespace/group context hooks, so a
+            per-target refetch would just bump treeVersion a second time. */}
         <button
           className="ns-danger-icon-btn"
           title="Delete context"
-          onClick={() => setDeleteContextTarget({ contextId: c.contextId, name: c.name || truncateId(c.contextId), refetch: refetchTree })}
+          onClick={() => setDeleteContextTarget({ contextId: c.contextId, name: c.name || truncateId(c.contextId), refetch: () => {} })}
         >
           <Trash2 size={13} />
         </button>
@@ -1356,10 +1367,12 @@ export default function Namespaces() {
               <h2><Layers size={16} /> Structure</h2>
               <span className="ns-tree-legend">{nsContextCount} contexts · {nsSubgroupCount} subgroups</span>
             </div>
-            <p className="ns-tree-help">
-              <Box size={12} /> <strong>Context</strong> = a running app instance (e.g. a chat channel).
-              <Layers size={12} /> <strong>Subgroup</strong> = a nested group holding its own contexts. Click a subgroup to expand it.
-            </p>
+            {tree && (
+              <p className="ns-tree-help">
+                <Box size={12} /> <strong>Context</strong> = a running app instance (e.g. a chat channel).
+                <Layers size={12} /> <strong>Subgroup</strong> = a nested group holding its own contexts. Click a subgroup to expand it.
+              </p>
+            )}
             {treeError && tree && (
               <p className="ns-tree-error">Some groups couldn't be loaded — the structure and counts may be incomplete.</p>
             )}


### PR DESCRIPTION
## What

Reworks the **Namespaces** page so a namespace's contents are shown as a **collapsible folder tree** instead of two flat, single-level lists, and fixes the top status-card counts.

### Tree (namespace detail view)

```
Namespace
├── <root context>
├── <root context>
└── Subgroup            (N)        ← click name to open, chevron to expand
    ├── <context>
    └── Nested subgroup  (N)
        └── <context>
```

- Replaces the separate **"Contexts"** and **"Groups"** sections with a single **"Structure"** tree.
- Each node collapses/expands; namespace root is expanded by default, subgroups collapsed.
- Contexts: copy ID + delete. Subgroups: click name → group detail, delete, child-count badge.
- The full tree is fetched recursively via `listGroupContexts` / `listNamespaceGroups` / `listSubgroups` (the mero-react hooks only resolve one level at a time, so this is done imperatively with a depth guard). It refreshes after create/delete of contexts and groups.

### Status cards

- **"Groups" → "Subgroups"** (namespace detail card + the list-view card tooltip).
- **Contexts count** now spans the **whole tree** (root contexts + every subgroup's contexts, recursively). Previously it only counted **root** contexts.
- Subgroups count likewise includes nested subgroups.

## Why

The old page only ever showed/counted one level deep: root contexts and direct subgroups, with no way to see what lived inside a subgroup without navigating into it, and the "Contexts" stat under-counted because it ignored subgroup contexts entirely.

## Testing

- `tsc --noEmit` clean (0 errors).
- `vite build` succeeds.
- Existing desktop test suite: **71/71 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)