### PR TITLE
chore: bump bundled merod to 0.11.0-rc.8

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.53"
+    "version": "0.0.54"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.7"
+    "version": "0.11.0-rc.8"
 }


### PR DESCRIPTION
Bumps the bundled `merod` version in `merod-config.json` from `0.11.0-rc.7` to `0.11.0-rc.8` to consume the new core release.

The `merod` binary is fetched from the corresponding core GitHub release asset at build time, so this PR depends on **calimero-network/core#2952** publishing the `0.11.0-rc.8` release (and its `merod-*` asset).

**Merge only after that core release is live** — until the release publishes, the binary download URL will 404 at build time.

This mirrors the prior rc.7 bump (#127): it changes the bundled merod version only and does not touch the desktop app version.