### PR TITLE
feat(webrtc): bake Cloudflare TURN endpoint into release builds (v0.0.57)

### DIFF
--- a/.github/workflows/build-chromebook.yml
+++ b/.github/workflows/build-chromebook.yml
@@ -21,6 +21,9 @@ on:
         required: false
       TAURI_PUBLIC_KEY:
         required: true
+      # Mero Meet WebRTC: bearer key for the ICE/TURN credential endpoint
+      CALIMERO_ICE_ENDPOINT_KEY:
+        required: false
     outputs:
       artifact-name:
         description: "Name of the uploaded artifact"
@@ -209,6 +212,9 @@ jobs:
           MEROD_SKIP_IF_EXISTS: "1"
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          # Baked into the binary via option_env! so installed apps reach the TURN relay
+          CALIMERO_ICE_ENDPOINT: ${{ vars.CALIMERO_ICE_ENDPOINT }}
+          CALIMERO_ICE_ENDPOINT_KEY: ${{ secrets.CALIMERO_ICE_ENDPOINT_KEY }}
         # .deb is the Crostini install path on ChromeOS; AppImage feeds the updater.
         run: pnpm exec tauri build --bundles appimage,deb
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -15,6 +15,9 @@ on:
         required: false
       TAURI_PUBLIC_KEY:
         required: true
+      # Mero Meet WebRTC: bearer key for the ICE/TURN credential endpoint
+      CALIMERO_ICE_ENDPOINT_KEY:
+        required: false
     outputs:
       artifact-name:
         description: "Name of the uploaded artifact"
@@ -200,6 +203,9 @@ jobs:
           MEROD_SKIP_IF_EXISTS: "1"
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          # Baked into the binary via option_env! so installed apps reach the TURN relay
+          CALIMERO_ICE_ENDPOINT: ${{ vars.CALIMERO_ICE_ENDPOINT }}
+          CALIMERO_ICE_ENDPOINT_KEY: ${{ secrets.CALIMERO_ICE_ENDPOINT_KEY }}
         run: pnpm exec tauri build --bundles appimage,deb,rpm
 
       - name: Verify build outputs

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -29,6 +29,9 @@ on:
         required: false
       TAURI_PUBLIC_KEY:
         required: true
+      # Mero Meet WebRTC: bearer key for the ICE/TURN credential endpoint
+      CALIMERO_ICE_ENDPOINT_KEY:
+        required: false
     outputs:
       artifact-name:
         description: "Name of the uploaded artifact"
@@ -256,6 +259,9 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          # Baked into the binary via option_env! so installed apps reach the TURN relay
+          CALIMERO_ICE_ENDPOINT: ${{ vars.CALIMERO_ICE_ENDPOINT }}
+          CALIMERO_ICE_ENDPOINT_KEY: ${{ secrets.CALIMERO_ICE_ENDPOINT_KEY }}
         id: build-app-release
         run: |
           if [ -n "$APPLE_SIGNING_IDENTITY" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
       TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
       TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
       TAURI_PUBLIC_KEY: ${{ secrets.TAURI_PUBLIC_KEY }}
+      CALIMERO_ICE_ENDPOINT_KEY: ${{ secrets.CALIMERO_ICE_ENDPOINT_KEY }}
 
   build-linux:
     name: Build Linux
@@ -62,6 +63,7 @@ jobs:
       TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
       TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
       TAURI_PUBLIC_KEY: ${{ secrets.TAURI_PUBLIC_KEY }}
+      CALIMERO_ICE_ENDPOINT_KEY: ${{ secrets.CALIMERO_ICE_ENDPOINT_KEY }}
 
   build-chromebook:
     name: Build Chromebook
@@ -73,6 +75,7 @@ jobs:
       TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
       TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
       TAURI_PUBLIC_KEY: ${{ secrets.TAURI_PUBLIC_KEY }}
+      CALIMERO_ICE_ENDPOINT_KEY: ${{ secrets.CALIMERO_ICE_ENDPOINT_KEY }}
 
   # Publish release with all platform artifacts
   publish:

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -2400,15 +2400,37 @@ struct IceServer {
     credential: Option<String>,
 }
 
-/// Read and sanitize an optional TURN credential env var: trims whitespace and
-/// rejects empty, over-long (>256 chars), or control-character-bearing values so
-/// a malformed or hostile env value can't be forwarded verbatim into the
-/// frontend's `RTCPeerConnection` config.
+/// Validate a credential/secret value: trims whitespace and rejects empty,
+/// over-long (>256 chars), or control-character-bearing values so a malformed or
+/// hostile value can't be forwarded verbatim into the frontend's
+/// `RTCPeerConnection` config.
+fn sanitize_secret(value: &str) -> Option<String> {
+    let v = value.trim();
+    (!v.is_empty() && v.len() <= 256 && !v.chars().any(char::is_control)).then(|| v.to_string())
+}
+
+/// Read and sanitize an optional TURN credential env var.
 fn sanitized_turn_secret(var: &str) -> Option<String> {
-    std::env::var(var)
+    std::env::var(var).ok().as_deref().and_then(sanitize_secret)
+}
+
+/// The ICE credential endpoint URL. Runtime `CALIMERO_ICE_ENDPOINT` wins; otherwise
+/// the value baked in at build time via `option_env!` (so release builds ship a
+/// working default the installed app uses with zero user configuration). Returns
+/// `None` unless the resolved value is an http(s) URL.
+fn ice_endpoint() -> Option<String> {
+    let raw = std::env::var("CALIMERO_ICE_ENDPOINT")
         .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty() && s.len() <= 256 && !s.chars().any(char::is_control))
+        .or_else(|| option_env!("CALIMERO_ICE_ENDPOINT").map(str::to_string))?;
+    let raw = raw.trim();
+    (raw.starts_with("http://") || raw.starts_with("https://")).then(|| raw.to_string())
+}
+
+/// The bearer key sent to the ICE endpoint. Runtime env wins; otherwise the
+/// build-time baked value (paired with the baked `ice_endpoint`).
+fn ice_endpoint_key() -> Option<String> {
+    sanitized_turn_secret("CALIMERO_ICE_ENDPOINT_KEY")
+        .or_else(|| option_env!("CALIMERO_ICE_ENDPOINT_KEY").and_then(sanitize_secret))
 }
 
 /// JSON returned by a self-hosted ICE credential endpoint (`CALIMERO_ICE_ENDPOINT`).
@@ -2443,7 +2465,7 @@ async fn fetch_ice_servers_from_endpoint(endpoint: &str) -> Option<Vec<IceServer
         .build()
         .ok()?;
     let mut req = client.get(endpoint);
-    if let Some(key) = sanitized_turn_secret("CALIMERO_ICE_ENDPOINT_KEY") {
+    if let Some(key) = ice_endpoint_key() {
         req = req.bearer_auth(key);
     }
     let resp = req.send().await.ok()?;
@@ -2477,8 +2499,10 @@ async fn fetch_ice_servers_from_endpoint(endpoint: &str) -> Option<Vec<IceServer
 
 /// ICE servers for WebRTC apps (Mero Meet). Resolution order:
 ///
-/// 1. `CALIMERO_ICE_ENDPOINT` — a self-hosted endpoint that mints short-lived
-///    TURN credentials (authenticated with `CALIMERO_ICE_ENDPOINT_KEY` if set).
+/// 1. `CALIMERO_ICE_ENDPOINT` — an endpoint that mints short-lived TURN
+///    credentials (authenticated with `CALIMERO_ICE_ENDPOINT_KEY` if set).
+///    Resolved from the runtime env var, or from a value baked in at build time
+///    (`option_env!`) so release builds use it with zero user configuration.
 ///    This is the preferred production path: no long-lived TURN secret ships in
 ///    the app binary, and the endpoint owns the full STUN+TURN list. If it's
 ///    configured and reachable, its response is authoritative.
@@ -2490,19 +2514,14 @@ async fn fetch_ice_servers_from_endpoint(endpoint: &str) -> Option<Vec<IceServer
 ///    behind symmetric NAT/CGNAT, where a relay is mandatory.
 #[tauri::command]
 async fn get_ice_servers() -> Vec<IceServer> {
-    // (1) Preferred: self-hosted ephemeral-credential endpoint.
-    if let Ok(endpoint) = std::env::var("CALIMERO_ICE_ENDPOINT") {
-        let endpoint = endpoint.trim();
-        if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
-            if let Some(servers) = fetch_ice_servers_from_endpoint(endpoint).await {
-                return servers;
-            }
-            log::warn!(
-                "[webrtc] CALIMERO_ICE_ENDPOINT unreachable/invalid; falling back to static config"
-            );
-        } else if !endpoint.is_empty() {
-            log::warn!("[webrtc] ignoring CALIMERO_ICE_ENDPOINT: must be an http(s) URL");
+    // (1) Preferred: ephemeral-credential endpoint (runtime env, else baked at build).
+    if let Some(endpoint) = ice_endpoint() {
+        if let Some(servers) = fetch_ice_servers_from_endpoint(&endpoint).await {
+            return servers;
         }
+        log::warn!(
+            "[webrtc] CALIMERO_ICE_ENDPOINT unreachable/invalid; falling back to static config"
+        );
     }
 
     // (2)/(3) Static STUN (+ optional static TURN from env).

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.56"
+    "version": "0.0.57"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
## Why
v0.0.56 added `CALIMERO_ICE_ENDPOINT` support but read it only from the **runtime** environment — and a GUI desktop app launched from Finder/Start menu doesn't inherit shell env vars, so installed apps never saw it and still fell back to Google STUN (calls behind symmetric NAT keep failing).

## What
- **Code:** `get_ice_servers` now resolves `CALIMERO_ICE_ENDPOINT` / `CALIMERO_ICE_ENDPOINT_KEY` from the runtime env **or** a value baked in at build time via `option_env!`. Runtime still wins (handy for testing).
- **CI:** the macOS/Linux/Chromebook **release** build steps inject the endpoint (repo **variable** `CALIMERO_ICE_ENDPOINT`) and key (repo **secret** `CALIMERO_ICE_ENDPOINT_KEY`); `release.yml` passes the secret through to the reusable build workflows. Both are declared `required: false`, so missing values just fall back to STUN.
- **Version:** bump to 0.0.57.

Net effect: installed builds reach the Cloudflare TURN credential Worker (`mero-meet-turn.calimero-p2p.workers.dev/ice`, already live + verified) with **zero user configuration**.

## Safety
No existing secret touched — only one new optional secret + one variable added. All `TAURI_*`/`APPLE_*` references unchanged; all four workflows validated.

## Test
- `cargo check` passes.
- Cloudflare Worker verified live (200 with key → full STUN+TURN ICE list; 401 without).

🤖 Generated with [Claude Code](https://claude.com/claude-code)