### PR TITLE
chore: release 0.0.58 + bundled merod 0.11.0-rc.9

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.57"
+    "version": "0.0.58"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.8"
+    "version": "0.11.0-rc.9"
 }


### PR DESCRIPTION
## What
- Bump the desktop app version **0.0.57 → 0.0.58** (`apps/desktop/package.json` + `apps/desktop/src-tauri/tauri.conf.json`).
- Bump the bundled **merod** version **0.11.0-rc.8 → 0.11.0-rc.9** (`merod-config.json`), which `prepare-merod.mjs` / the build workflows read to fetch the node binary.

## Why
Track the latest core release (rc.9) in the desktop app's bundled node, alongside the frontend apps' mero-react 4.1.0 + contract rc.9 bumps.

## Notes
- No source changes; the release build (signed installers) is produced by the platform build workflows in CI.
- Assumes core's `0.11.0-rc.9` release publishes the `merod_*` macOS/Linux archives (as rc.8 did); Windows archives aren't published upstream, per the existing build-windows workflow note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)