### PR TITLE
fix(desktop): cache-bust app-window URL so the webview stops serving stale code

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.58"
+    "version": "0.0.59"
   },
   "tauri": {
     "allowlist": {

--- a/apps/desktop/src/utils/appUtils.ts
+++ b/apps/desktop/src/utils/appUtils.ts
@@ -100,7 +100,17 @@ export async function openAppFrontend(
     // avoid leaking the user's dev-mode preference to every app frontend.
     if (settings.developerMode) hashParams.set('dev_mode', '1');
 
-    const urlToOpen = `${frontendUrl}#${hashParams.toString()}`;
+    // Cache-bust the document URL so the webview loads fresh HTML on open instead
+    // of a stale cached index.html pointing at an old bundle. Query param, not the
+    // SSO hash; auth is per-origin so SSO/localStorage are unaffected.
+    let urlToOpen: string;
+    try {
+      const u = new URL(frontendUrl);
+      u.searchParams.set('_cb', String(Date.now()));
+      urlToOpen = `${u.toString()}#${hashParams.toString()}`;
+    } catch {
+      urlToOpen = `${frontendUrl}#${hashParams.toString()}`;
+    }
 
     // Stable window label keyed by applicationId so every call site
     // (Home, Applications, Namespaces, shortcut) produces the same label


### PR DESCRIPTION
## Problem

Opening an app from the desktop points a WKWebView at the app's frontend URL. WKWebView caches the HTML document, so after an app **redeploys** the desktop keeps loading the **old `index.html`** — which references a stale, content-hashed JS bundle — until the cache evicts. The result: users see the previous version and think fixes "didn't ship" (this came up debugging Mero Meet, where pushed fixes appeared to have no effect).

## Fix

Append a per-open `_cb=<timestamp>` query param to the document URL in `openAppFrontend` so each open fetches a fresh `index.html`.

- Content-hashed assets keep their stable URLs → stay cached; only the tiny HTML re-downloads.
- `_cb` is a **query string**, not the `#…` hash the app parses for SSO — session/token parsing is untouched.
- `localStorage`/auth is keyed **per-origin**, not per-URL, so SSO and persisted state survive.
- Malformed `frontendUrl` falls back to the previous plain form (no regression).
- Only applies when a **new** window is created; the focus-existing-window path is unchanged.

This is a desktop-wide safety net. Apps that already send `no-cache` headers on their HTML (e.g. mero-meet now does) are unaffected — this covers the ones that don't, and the reopen path generally.

## Test plan

- `tsc --noEmit` passes clean in `apps/desktop`.
- Open an app, redeploy its frontend, reopen from the desktop → new version loads (previously required a cache clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)