### PR TITLE
fix(desktop): restore dock-minimized app window on Open (0.0.60)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.59"
+    "version": "0.0.60"
   },
   "tauri": {
     "allowlist": {

--- a/apps/desktop/src/utils/appUtils.ts
+++ b/apps/desktop/src/utils/appUtils.ts
@@ -125,12 +125,17 @@ export async function openAppFrontend(
       : domain;
     const windowLabel = `app-${appKey}`.slice(0, 64);
 
-    // If the window is already open, focus it and signal a token refresh.
-    // setFocus first: if it throws (window closed), we skip the emit entirely
+    // If the window is already open, restore + focus it and signal a token refresh.
+    // A window minimized to the macOS dock does NOT come back on setFocus alone —
+    // it must be unminimized first (and shown, in case it was hidden), otherwise
+    // clicking "Open" on an already-open-but-minimized app appears to do nothing.
+    // These run before the emit: if any throw (window closed), we skip the emit
     // so no credentials reach a window that may have navigated to a different origin.
     const existing = WebviewWindow.getByLabel(windowLabel);
     if (existing) {
       try {
+        if (await existing.isMinimized()) await existing.unminimize();
+        await existing.show();
         await existing.setFocus();
         // Signal apps to re-read their auth state. No token payload here to avoid
         // sending credentials to a window whose current origin we cannot verify.
@@ -142,8 +147,8 @@ export async function openAppFrontend(
           .catch(() => {});
         return windowLabel;
       } catch (e) {
-        // window was closed between getByLabel and setFocus; fall through to create a new one
-        console.warn('setFocus failed, opening new window:', e);
+        // window was closed between getByLabel and restore/focus; fall through to create a new one
+        console.warn('focus existing window failed, opening new one:', e);
       }
     }
 


### PR DESCRIPTION
## Problem

When an app window is **minimized to the macOS dock**, clicking **Open** for that app did nothing — the window stayed in the dock instead of coming to the foreground. (It worked fine when the window was merely in the background / behind others.)

Root cause: `openAppFrontend` focuses an already-open window with `existing.setFocus()`, but on macOS `setFocus()` alone does **not** un-minimize a window that's been minimized to the dock.

## Fix

Before `setFocus()`, unminimize the window (when minimized) and `show()` it:

```ts
if (await existing.isMinimized()) await existing.unminimize();
await existing.show();
await existing.setFocus();
```

If any of these throw (window was closed in the meantime), we fall through to creating a fresh window, exactly as before — and the credential `emit` still only runs after a successful focus.

## Version

Bumps desktop **0.0.59 → 0.0.60** (`package.json` + `tauri.conf.json`).

## Test plan

- `tsc --noEmit` passes clean in `apps/desktop`.
- Open an app → minimize it to the dock → click Open again → window restores and focuses (previously nothing happened).
- Background (non-minimized) focus still works; closed-window path still recreates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)