### PR TITLE
fix(desktop): leave a namespace you cannot delete (0.0.61)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.60"
+    "version": "0.0.61"
   },
   "tauri": {
     "allowlist": {

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -231,9 +231,16 @@ export default function Namespaces() {
         | undefined)
     : undefined;
   const isNsAdmin = (myNsRole ?? '').toLowerCase() === 'admin';
-  // Only swap Delete → Leave when we POSITIVELY know we're not admin; while
-  // the role is unresolved keep the old Delete (the node still enforces).
-  const showNsLeave = myNsRole !== undefined && !isNsAdmin;
+  // Only swap Delete → Leave when we POSITIVELY know we're not admin: members
+  // finished loading AND our identity resolved AND our role was found. While
+  // either async source is pending the menu keeps the old Delete (the node
+  // still enforces admin-ship, so the worst case is the pre-existing error
+  // toast — never a wrong destructive action).
+  const showNsLeave =
+    !nsMembersLoading &&
+    myNsIdentity?.publicKey !== undefined &&
+    myNsRole !== undefined &&
+    !isNsAdmin;
 
   const { contexts: groupContexts, refetch: refetchGroupContexts } = useGroupContexts(activeGroupId);
   const { contexts: nsRootContexts, refetch: refetchNsRootContexts } = useGroupContexts(

--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -8,11 +8,12 @@ import {
   useGroupContexts,
   useSubgroups,
   useCreateNamespace,
+  useNamespaceIdentity,
   type Namespace,
 } from "@calimero-network/mero-react";
 import type { GroupInfo, MetadataRecord } from "@calimero-network/mero-js";
 import { useToast } from "../contexts/ToastContext";
-import { ChevronLeft, Users, Box, Layers, Copy, ChevronRight, Shield, Globe, Plus, X, Trash2, UserMinus, Link, ChevronDown, Check, MoreHorizontal, LogIn } from "lucide-react";
+import { ChevronLeft, Users, Box, Layers, Copy, ChevronRight, Shield, Globe, Plus, X, Trash2, UserMinus, Link, ChevronDown, Check, MoreHorizontal, LogIn, LogOut } from "lucide-react";
 import { apiClient } from "../lib/mero-client";
 import { saveContextKey } from "../utils/contextKeys";
 import { decodeMetadata } from "../utils/appUtils";
@@ -193,6 +194,9 @@ export default function Namespaces() {
   const groupInfo = groupInfoRaw as GroupInfoExt | null;
   const nsRootGroupInfo = nsRootGroupInfoRaw as GroupInfoExt | null;
   const { members: groupMembers, refetch: refetchGroupMembers } = useGroupMembers(activeGroupId) as any;
+  // My identity on the active namespace — used to find my ROLE in the member
+  // list (admin → may Delete; member → may only Leave) and to self-remove.
+  const { identity: myNsIdentity } = useNamespaceIdentity(activeNsRootId);
   const [nsMembers, setNsMembers] = useState<any[]>([]);
   const [nsMembersLoading, setNsMembersLoading] = useState(false);
   const [nsMembersVersion, setNsMembersVersion] = useState(0);
@@ -217,6 +221,19 @@ export default function Namespaces() {
       .finally(() => setNsMembersLoading(false));
     return () => controller.abort();
   }, [activeNsRootId, nsMembersVersion, view.type]);
+
+  // My role on the active namespace, resolved from the member list. Drives
+  // whether the actions menu offers Delete (admin) or Leave (plain member) —
+  // the node rejects a non-admin delete, so don't offer a dead-end action.
+  const myNsRole: string | undefined = myNsIdentity?.publicKey
+    ? (nsMembers.find((m: any) => m?.identity === myNsIdentity.publicKey)?.role as
+        | string
+        | undefined)
+    : undefined;
+  const isNsAdmin = (myNsRole ?? '').toLowerCase() === 'admin';
+  // Only swap Delete → Leave when we POSITIVELY know we're not admin; while
+  // the role is unresolved keep the old Delete (the node still enforces).
+  const showNsLeave = myNsRole !== undefined && !isNsAdmin;
 
   const { contexts: groupContexts, refetch: refetchGroupContexts } = useGroupContexts(activeGroupId);
   const { contexts: nsRootContexts, refetch: refetchNsRootContexts } = useGroupContexts(
@@ -347,6 +364,7 @@ export default function Namespaces() {
   // Action state
   const [actionLoading, setActionLoading] = useState(false);
   const [deleteNsTarget, setDeleteNsTarget] = useState<Namespace | null>(null);
+  const [leaveNsTarget, setLeaveNsTarget] = useState<Namespace | null>(null);
   const [deleteGroupTarget, setDeleteGroupTarget] = useState<string | null>(null);
   const [deleteContextTarget, setDeleteContextTarget] = useState<{ contextId: string; name: string; refetch: () => void } | null>(null);
   const [removeMemberTarget, setRemoveMemberTarget] = useState<{ groupId: string; identity: string; name: string; onSuccess: () => void } | null>(null);
@@ -467,6 +485,31 @@ export default function Namespaces() {
       await refetchNamespaces();
     } catch (e: any) {
       toast.error(`Failed to delete namespace: ${parseApiError(e)}`);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  // Leave = remove MY OWN identity from the namespace's member set. This is
+  // the cleanup path for non-admins: deleteNamespace is admin-gated on the
+  // node ("identity is not an admin on namespace/group …"), which previously
+  // left members with NO way to get rid of a namespace from their view.
+  const handleLeaveNamespace = async (ns: Namespace) => {
+    if (!mero || !myNsIdentity?.publicKey) {
+      toast.error('Could not resolve your identity on this namespace');
+      return;
+    }
+    setActionLoading(true);
+    try {
+      await mero.admin.removeGroupMembers(ns.namespaceId, {
+        members: [myNsIdentity.publicKey],
+      });
+      toast.success('Left namespace');
+      setLeaveNsTarget(null);
+      setView({ type: 'list' });
+      await refetchNamespaces();
+    } catch (e: any) {
+      toast.error(`Failed to leave namespace: ${parseApiError(e)}`);
     } finally {
       setActionLoading(false);
     }
@@ -1115,6 +1158,17 @@ export default function Namespaces() {
           onConfirm={() => handleDeleteNamespace(deleteNsTarget)}
         />
       )}
+      {leaveNsTarget && (
+        <DeleteConfirmModal
+          title="Leave Namespace"
+          warning="You will lose access to this namespace, its subgroups and contexts. Rejoining requires a new invitation."
+          name={nsDisplayName(leaveNsTarget)}
+          confirmLabel="Leave"
+          loading={actionLoading}
+          onClose={() => setLeaveNsTarget(null)}
+          onConfirm={() => handleLeaveNamespace(leaveNsTarget)}
+        />
+      )}
       {deleteGroupTarget && (
         <DeleteConfirmModal
           title="Delete Group"
@@ -1314,9 +1368,15 @@ export default function Namespaces() {
                   <button className="ns-actions-menu-item" onClick={() => { setActionsMenuOpen(false); setInviteModal({ groupId: ns.namespaceId, isNamespace: true }); }}>
                     <Link size={13} /> Invite
                   </button>
-                  <button className="ns-actions-menu-item ns-actions-menu-item-danger" onClick={() => { setActionsMenuOpen(false); setDeleteNsTarget(ns); }}>
-                    <Trash2 size={13} /> Delete
-                  </button>
+                  {showNsLeave ? (
+                    <button className="ns-actions-menu-item ns-actions-menu-item-danger" onClick={() => { setActionsMenuOpen(false); setLeaveNsTarget(ns); }}>
+                      <LogOut size={13} /> Leave
+                    </button>
+                  ) : (
+                    <button className="ns-actions-menu-item ns-actions-menu-item-danger" onClick={() => { setActionsMenuOpen(false); setDeleteNsTarget(ns); }}>
+                      <Trash2 size={13} /> Delete
+                    </button>
+                  )}
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Problem

Deleting an application works, but deleting a **namespace** you don't administer fails with:

> `identity is not an admin on namespace / group <contextGroupID>`

`deleteNamespace` is admin-gated on the node — correct — but the desktop offered no alternative, so plain members had **no way to clean a namespace out of their app**.

## Fix

Resolve the user's role **up front** and offer the action that will actually succeed:

- Fetch my identity on the namespace (`useNamespaceIdentity`) and match it against the already-loaded member list → my role.
- **Admin** → `Delete` (unchanged behavior).
- **Member** → `Leave` — removes *my own* identity via `admin.removeGroupMembers(nsId, { members: [me] })`, with a dedicated confirm modal ("You will lose access to this namespace, its subgroups and contexts. Rejoining requires a new invitation.").
- **Role unresolved** (identity/member fetch still loading or failed) → keep `Delete` as before; the node still enforces and the error surfaces exactly as it did.

Either path lands back on the namespaces list with a refetch → full cleanup from the user's perspective.

## Version

Bumps desktop **0.0.60 → 0.0.61**.

## Notes / test plan

- `tsc --noEmit` clean.
- Admin on own namespace → menu shows Delete; delete works as before.
- Member of someone else's namespace → menu shows **Leave**; after confirming, the namespace disappears from the list.
- Caveat worth a reviewer's eye: self-removal via `removeGroupMembers` assumes the node permits removing your own identity without admin rights. If core rejects that, the error toast surfaces it — and that becomes a core-side gap to open separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)