### PR TITLE
chore: bump app to 0.0.62, bundled merod to 0.11.0-rc.10

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.61"
+    "version": "0.0.62"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.9"
+    "version": "0.11.0-rc.10"
 }


### PR DESCRIPTION
Desktop app **0.0.61 → 0.0.62** (`apps/desktop/package.json` + `src-tauri/tauri.conf.json`) and bundled merod **0.11.0-rc.9 → 0.11.0-rc.10** (`merod-config.json`) for the upcoming core rc.10 node release.

⚠️ Installer builds will fail to fetch merod until core publishes the `0.11.0-rc.10` release artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)