### PR TITLE
chore: bump app to 0.0.63, bundled merod to 0.11.0-rc.11

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.62"
+    "version": "0.0.63"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.10"
+    "version": "0.11.0-rc.11"
 }


### PR DESCRIPTION
Desktop app **0.0.62 → 0.0.63** and bundled merod **0.11.0-rc.10 → 0.11.0-rc.11** (`merod-config.json`). rc.11 restores app-token access to namespaces/groups/blobs/aliases (calimero-network/core#3201).

⚠️ Builds fail until core's rc.11 **binaries** finish uploading (release exists at trigger time, assets take the build duration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)