### PR TITLE
feat(ha): re-assert TEE admission policy on load for owned HA namespaces

### DIFF
--- a/apps/desktop/src/pages/Namespaces.tsx
+++ b/apps/desktop/src/pages/Namespaces.tsx
@@ -21,6 +21,7 @@ import {
   enableHaForNamespace,
   disableHaNamespace,
   getCloudNamespaces,
+  ensureTeeAdmissionPolicy,
   CloudSessionExpiredError,
 } from "../utils/cloudApi";
 import { getCloudIdToken } from "../utils/cloudAuth";
@@ -819,6 +820,62 @@ export default function Namespaces() {
     },
     [clearReconcileRetryTimer],
   );
+
+  // ── Reconcile: ensure the TEE admission policy exists for HA-ENABLED
+  // namespaces we own. `enableHaForNamespace` authors the policy once, at
+  // toggle time — so a namespace enabled on an OLDER build (before that PUT
+  // existed) has NO policy, and its fleet TEE node loops forever on merod's
+  // "no TeeAdmissionPolicy set for group"; a namespace whose fleet MRTD
+  // later rotated has a STALE one. This self-heals both on load: for each
+  // enabled namespace where we are the root Admin, `ensureTeeAdmissionPolicy`
+  // re-asserts the policy from the current fleet measurements. It is
+  // idempotent (a correct policy is a read-only no-op) and owner-gated (a
+  // namespace we merely joined is skipped), so the steady state is cheap and
+  // a member node never tries to author a policy it can't sign. Distinct
+  // from the disable-side eviction reconcile above; deliberately kept
+  // separate from its retry/semaphore machinery.
+  useEffect(() => {
+    const settings = getSettings();
+    if (!settings.nodeUrl) return;
+    const idToken = getCloudIdToken();
+    if (!idToken) return;
+    const enabledIds = Object.entries(haEnabled)
+      .filter(([, v]) => v === true)
+      .map(([id]) => id);
+    if (enabledIds.length === 0) return;
+
+    let cancelled = false;
+    void (async () => {
+      let reasserted = 0;
+      for (const nsId of enabledIds) {
+        if (cancelled) return;
+        try {
+          const outcome = await ensureTeeAdmissionPolicy(
+            settings.nodeUrl,
+            idToken,
+            nsId,
+          );
+          if (outcome === "reasserted") reasserted += 1;
+        } catch (e) {
+          // Best-effort: one namespace failing (transient merod/cloud error)
+          // must not abort the rest. The fleet node keeps retrying admission,
+          // so a missed re-assert self-heals on the next load — log, no toast.
+          console.warn(
+            `ensure-policy: ${nsId} skipped (${(e as Error)?.name ?? "error"})`,
+          );
+        }
+      }
+      if (!cancelled && reasserted > 0) {
+        toast.success(
+          `Re-authored TEE admission policy for ${reasserted} HA namespace(s)`,
+        );
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [haEnabled]);
 
   const toggleHa = useCallback(async (ns: Namespace) => {
     const token = getCloudIdToken();

--- a/apps/desktop/src/utils/cloudApi.test.ts
+++ b/apps/desktop/src/utils/cloudApi.test.ts
@@ -18,6 +18,7 @@ import {
   requestOwnershipProof,
   enableHaForNamespace,
   getCloudNamespaces,
+  ensureTeeAdmissionPolicy,
   CLOUD_BASE_URL,
 } from './cloudApi';
 
@@ -454,5 +455,129 @@ describe('enableHaForNamespace', () => {
     await expect(
       enableHaForNamespace(makeJwt({ iss: 'mdma', email: 'u@e' }), 'http://node', 'ns-root', []),
     ).rejects.toThrow(/Unexpected response from local node members endpoint/);
+  });
+});
+
+describe('ensureTeeAdmissionPolicy', () => {
+  let restore: () => void;
+  afterEach(() => restore?.());
+
+  const membersAdmin = () =>
+    jsonResponse({ members: [{ identity: 'me', role: 'Admin' }], selfIdentity: 'me' });
+  const membersMember = () =>
+    jsonResponse({ members: [{ identity: 'me', role: 'Member' }], selfIdentity: 'me' });
+  const measurements = (mrtd: string[]) =>
+    jsonResponse({
+      release_tag: 'v1',
+      allowed_mrtd: mrtd,
+      allowed_rtmr0: [],
+      allowed_rtmr1: [],
+      allowed_rtmr2: [],
+      allowed_rtmr3: [],
+    });
+  const idToken = () => makeJwt({ iss: 'mdma', email: 'u@e' });
+
+  it('skips (no measurements, no PUT) when the node is not the namespace admin', async () => {
+    const calls: string[] = [];
+    const { restore: r } = installFetch((url, init) => {
+      calls.push(`${init?.method ?? 'GET'} ${url}`);
+      if (url.includes('/members')) return membersMember();
+      return jsonResponse({});
+    });
+    restore = r;
+    await expect(
+      ensureTeeAdmissionPolicy('http://node', idToken(), 'ns-root'),
+    ).resolves.toBe('skipped');
+    // A member must never fetch measurements or PUT a policy it cannot sign.
+    expect(calls.some((c) => c.includes('/fleet/measurements'))).toBe(false);
+    expect(calls.some((c) => c.includes('/tee-admission-policy'))).toBe(false);
+  });
+
+  it('skips when the node is not a member of the namespace root (role lookup throws)', async () => {
+    const { restore: r } = installFetch((url) => {
+      if (url.includes('/members')) return new Response('not a member', { status: 404 });
+      return jsonResponse({});
+    });
+    restore = r;
+    await expect(
+      ensureTeeAdmissionPolicy('http://node', idToken(), 'ns-root'),
+    ).resolves.toBe('skipped');
+  });
+
+  it('skips when there are no fleet MRTD measurements', async () => {
+    const { restore: r } = installFetch((url) => {
+      if (url.includes('/members')) return membersAdmin();
+      if (url.includes('/fleet/measurements')) return measurements([]);
+      return jsonResponse({});
+    });
+    restore = r;
+    await expect(
+      ensureTeeAdmissionPolicy('http://node', idToken(), 'ns-root'),
+    ).resolves.toBe('skipped');
+  });
+
+  it("is a no-op ('ok', no PUT) when the on-node policy already covers the desired MRTDs", async () => {
+    const calls: { method: string; url: string }[] = [];
+    const { restore: r } = installFetch((url, init) => {
+      const method = init?.method ?? 'GET';
+      calls.push({ method, url });
+      if (url.includes('/members')) return membersAdmin();
+      if (url.includes('/fleet/measurements')) return measurements(['mrtd-1']);
+      if (url.includes('/tee-admission-policy'))
+        return jsonResponse({ enabled: true, allowedMrtd: ['mrtd-1'] });
+      return jsonResponse({});
+    });
+    restore = r;
+    await expect(
+      ensureTeeAdmissionPolicy('http://node', idToken(), 'ns-root'),
+    ).resolves.toBe('ok');
+    expect(
+      calls.some((c) => c.method === 'PUT' && c.url.includes('/tee-admission-policy')),
+    ).toBe(false);
+  });
+
+  it("re-authors ('reasserted') when no policy is set (enabled:false) — the stuck-node case", async () => {
+    let putBody: { allowedMrtd?: unknown } | undefined;
+    const { restore: r } = installFetch((url, init) => {
+      const method = init?.method ?? 'GET';
+      if (url.includes('/members')) return membersAdmin();
+      if (url.includes('/fleet/measurements')) return measurements(['mrtd-1']);
+      if (url.includes('/tee-admission-policy')) {
+        if (method === 'PUT') {
+          putBody = JSON.parse(String(init?.body));
+          return new Response('{}', { status: 200 });
+        }
+        return jsonResponse({ enabled: false, allowedMrtd: [] });
+      }
+      return jsonResponse({});
+    });
+    restore = r;
+    await expect(
+      ensureTeeAdmissionPolicy('http://node', idToken(), 'ns-root'),
+    ).resolves.toBe('reasserted');
+    // PUT uses the load-bearing camelCase key with the current MRTD set.
+    expect(putBody?.allowedMrtd).toEqual(['mrtd-1']);
+  });
+
+  it('re-authors when the policy is stale (MRTD rotated — different set)', async () => {
+    let putBody: { allowedMrtd?: unknown } | undefined;
+    const { restore: r } = installFetch((url, init) => {
+      const method = init?.method ?? 'GET';
+      if (url.includes('/members')) return membersAdmin();
+      if (url.includes('/fleet/measurements')) return measurements(['mrtd-NEW']);
+      if (url.includes('/tee-admission-policy')) {
+        if (method === 'PUT') {
+          putBody = JSON.parse(String(init?.body));
+          return new Response('{}', { status: 200 });
+        }
+        return jsonResponse({ enabled: true, allowedMrtd: ['mrtd-OLD'] });
+      }
+      return jsonResponse({});
+    });
+    restore = r;
+    await expect(
+      ensureTeeAdmissionPolicy('http://node', idToken(), 'ns-root'),
+    ).resolves.toBe('reasserted');
+    expect(putBody?.allowedMrtd).toEqual(['mrtd-NEW']);
   });
 });

--- a/apps/desktop/src/utils/cloudApi.ts
+++ b/apps/desktop/src/utils/cloudApi.ts
@@ -281,6 +281,100 @@ export async function setTeeAdmissionPolicy(
   }
 }
 
+/** The subset of the merod GET tee-admission-policy response we act on. */
+export interface TeeAdmissionPolicyState {
+  enabled: boolean;
+  allowedMrtd: string[];
+}
+
+/**
+ * Read the current TEE admission policy for a group from the local merod.
+ *
+ * merod's GET returns 200 with the `disabled()` shape (`enabled:false`,
+ * empty lists) when no policy is set — NOT a 404 — so an absent policy is
+ * `{ enabled:false, allowedMrtd:[] }`, distinguishable from a set one.
+ * Response keys are camelCase (GetTeeAdmissionPolicyApiResponse has
+ * `#[serde(rename_all="camelCase")]`) and, like the members endpoint, the
+ * payload is returned directly with no `{ data }` envelope.
+ */
+export async function getTeeAdmissionPolicy(
+  nodeUrl: string,
+  groupId: string,
+): Promise<TeeAdmissionPolicyState> {
+  const accessToken = getAccessToken();
+  if (!accessToken) {
+    throw new Error('Not authenticated to local node — sign in first');
+  }
+  const res = await fetch(
+    `${nodeUrl}/admin-api/groups/${encodeURIComponent(groupId)}/settings/tee-admission-policy`,
+    { method: 'GET', headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Failed to read TEE admission policy: ${text || res.statusText}`);
+  }
+  const data = (await res.json().catch(() => null)) as {
+    enabled?: unknown;
+    allowedMrtd?: unknown;
+  } | null;
+  return {
+    enabled: data?.enabled === true,
+    allowedMrtd: Array.isArray(data?.allowedMrtd)
+      ? (data!.allowedMrtd as unknown[]).filter((m): m is string => typeof m === 'string')
+      : [],
+  };
+}
+
+/**
+ * Idempotently re-assert a namespace's TEE admission policy on the local
+ * merod so a fleet TEE node can be admitted.
+ *
+ * The enable-HA flow (`enableHaForNamespace`) authors this policy exactly
+ * once, at toggle time. A namespace whose HA was enabled on an OLDER build
+ * (before that PUT existed) has no policy at all — its fleet node loops
+ * forever on merod's `no TeeAdmissionPolicy set for group`. A namespace
+ * whose fleet MRTD later ROTATED has a stale policy. This heals both.
+ *
+ * Owner-gated: only the namespace-root Admin may author the policy, so a
+ * node that merely joined the namespace is a no-op (`'skipped'`).
+ * `getSelfRoleInGroup` throws when this node isn't a member of the root —
+ * that, and any non-Admin role, is a clean skip, not an error.
+ *
+ * Idempotent: re-authors only when the on-node policy is absent/disabled or
+ * its MRTD set differs from the current fleet measurements — a correct
+ * policy is a read-only no-op (`'ok'`). Mirrors enable-HA's exact-set
+ * semantics (re-author to the desired set), so a rotated-out MRTD is
+ * dropped, not merely supplemented.
+ */
+export async function ensureTeeAdmissionPolicy(
+  nodeUrl: string,
+  idToken: string,
+  namespaceId: string,
+): Promise<'ok' | 'reasserted' | 'skipped'> {
+  let role: string | null;
+  try {
+    role = await getSelfRoleInGroup(nodeUrl, namespaceId);
+  } catch {
+    // Not a member of the namespace root (actor bails) — not ours to author.
+    return 'skipped';
+  }
+  if (role !== 'Admin') return 'skipped';
+
+  const desired = (await getFleetMeasurements(idToken)).allowed_mrtd;
+  if (!desired.length) return 'skipped';
+
+  const current = await getTeeAdmissionPolicy(nodeUrl, namespaceId);
+  const currentSet = current.enabled ? new Set(current.allowedMrtd) : null;
+  const matches =
+    currentSet !== null &&
+    currentSet.size === new Set(desired).size &&
+    desired.every((m) => currentSet.has(m));
+  if (matches) return 'ok';
+
+  await setTeeAdmissionPolicy(nodeUrl, namespaceId, desired);
+  return 'reasserted';
+}
+
 // ── Ownership proofs (namespace HA gate) ──
 
 /**


### PR DESCRIPTION
## Problem

`enableHaForNamespace` authors the namespace's `TeeAdmissionPolicy` exactly once, at enable time. So:
- A namespace whose HA was **enabled on an older build** (before that PUT was added to the flow) has **no policy at all** — its fleet TEE node loops forever on merod's `no TeeAdmissionPolicy set for group`, attestation-valid but never admitted.
- A namespace whose fleet **MRTD later rotated** has a **stale** policy.

Neither self-heals today.

## Fix

An idempotent, owner-gated re-assert that runs on load, reusing existing endpoints (no core/mdma changes — the core `PUT .../settings/tee-admission-policy` endpoint already exists):

- **`getTeeAdmissionPolicy`** — read the current on-node policy (GET; merod returns `enabled:false`, not 404, when unset).
- **`ensureTeeAdmissionPolicy`** — for a namespace where this node is the root **Admin**, re-author from the current fleet measurements when the policy is absent/disabled or its MRTD set differs from the desired one. A correct policy is a read-only no-op; a non-admin (member) node skips (only the owner can sign).
- **`Namespaces`** — a small effect over the HA-enabled namespaces, deliberately kept **separate** from the disable-side eviction reconcile machinery.

## Tests

6 new unit tests (skip-when-member, skip-when-not-joined, skip-no-measurements, ok-when-covered, reassert-when-missing = the stuck-node case, reassert-on-rotation). `tsc --noEmit` clean; 77 unit tests pass.