### PR TITLE
chore: bump app to 0.0.64, bundled merod to 0.11.0-rc.12

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.63"
+    "version": "0.0.64"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.11"
+    "version": "0.11.0-rc.12"
 }


### PR DESCRIPTION
Bumps the desktop app to **0.0.64** and the bundled merod pin to **0.11.0-rc.12**.

**Do not merge yet** — rc.12 is not released. Held open until:
1. calimero-network/core#3204 (rendezvous cookie poisoning fix — namespace-invite joins failing cross-internet with HTTP 0) merges, and
2. calimero-network/core#3205 (rc.12 cut) merges and the rc.12 binaries are published.

rc.12 carries the fix for the invite-join failures seen on the Spain↔Croatia mero-meet test setup; both peers need this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)