### PR TITLE
chore: bump app to 0.0.65

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.64"
+    "version": "0.0.65"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
Version-only bump (merod pin stays 0.11.0-rc.12). Cut to exercise the rerun-safe release publish (#142) in action and produce fresh Linux x64 + Chromebook ARM64 builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)