### PR TITLE
chore: bump app to 0.0.66, bundled merod to 0.11.0-rc.13

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.65"
+    "version": "0.0.66"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.12"
+    "version": "0.11.0-rc.13"
 }


### PR DESCRIPTION
- Calimero Desktop 0.0.65 → 0.0.66
- Bundled merod 0.11.0-rc.12 → 0.11.0-rc.13 (rendezvous re-registration fix core#3211, static-asset perf core#3184)

Same shape as #141/#143. Merge is gated on the core 0.11.0-rc.13 Release workflow finishing binary uploads (in progress); the v0.0.66 tag gets pushed after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes with no code or config behavior edits beyond release identifiers and the merod binary pin.
> 
> **Overview**
> **Release version bump** for Calimero Desktop and its bundled node binary, aligned with prior release PRs (#141/#143).
> 
> Desktop is bumped **0.0.65 → 0.0.66** in `apps/desktop/package.json` and `apps/desktop/src-tauri/tauri.conf.json` (Tauri package/updater version). The bundled **merod** pin in root `merod-config.json` moves **0.11.0-rc.12 → 0.11.0-rc.13**, which drives `merod:prepare` downloads and the compile-time `MEROD_CONFIG_VERSION` embedded in the Tauri build.
> 
> No application logic changes—only version metadata for the next desktop release and the core RC that includes rendezvous re-registration and static-asset performance fixes noted in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcad034a075c036c60f0671b6057e1014a30e147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->