### PR TITLE
fix: browser-style login from app windows dies on IPC scope rejection (v0.0.67)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -790,12 +790,33 @@ async fn create_app_window(
 
     // Configure IPC scope BEFORE showing window
     // This allows windows with unique labels (domain + timestamp) to access Tauri IPC
-    let remote_access = tauri::ipc::RemoteDomainAccessScope::new(domain)
-        .add_window(&window_label)
-        .enable_tauri_api();
-    app_handle.ipc_scope().configure_remote_access(remote_access);
+    //
+    // Tauri v1 matches IPC scopes by EXACT domain (no wildcards), and the
+    // browser-style login flow navigates this same window to the node's auth
+    // page (e.g. http://localhost:2528/auth/login). Without a scope for the
+    // node's host, every IPC call from that page fails with
+    // "Scope not defined for URL". Register the app domain, the node host and
+    // localhost. Note: Url::domain() returns None for IP hosts (127.0.0.1),
+    // so scopes can never match IP-hosted pages — the injected proxy script
+    // falls back to native fetch there (plain-HTTP pages don't need the proxy).
+    let mut scope_domains: Vec<String> = vec![domain.to_string(), "localhost".to_string()];
+    if let Some(node_host) = node_url_to_use
+        .parse::<url::Url>()
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_string))
+    {
+        scope_domains.push(node_host);
+    }
+    scope_domains.sort();
+    scope_domains.dedup();
+    for scope_domain in &scope_domains {
+        let remote_access = tauri::ipc::RemoteDomainAccessScope::new(scope_domain)
+            .add_window(&window_label)
+            .enable_tauri_api();
+        app_handle.ipc_scope().configure_remote_access(remote_access);
+    }
 
-    info!("[Tauri] Configured IPC scope for domain: {} on window: {}", domain, window_label);
+    info!("[Tauri] Configured IPC scope for domains: {:?} on window: {}", scope_domains, window_label);
 
     // Camera/microphone for WebRTC video calls (e.g. Mero Meet) needs no extra
     // work here: wry's own WKUIDelegate already grants

--- a/apps/desktop/src-tauri/src/proxy_script.js
+++ b/apps/desktop/src-tauri/src/proxy_script.js
@@ -20,6 +20,18 @@
         }
     }
 
+    // The proxy exists solely to bypass mixed-content blocking: HTTPS-hosted
+    // app pages cannot fetch http://localhost directly. When the page itself
+    // is served over plain HTTP (e.g. the node's auth frontend at
+    // http://localhost:2528/auth/login after a logout → browser-style login
+    // navigation), native fetch works fine — and Tauri v1 IPC scopes are
+    // exact-domain matches registered for the app's original domain, so
+    // invoking the proxy from a localhost-origin page fails with
+    // "Scope not defined for URL". Never proxy from non-HTTPS pages.
+    function pageNeedsProxy() {
+        return window.location.protocol === 'https:';
+    }
+
     // Normalize the first fetch() argument: string | URL | Request → string URL
     function normalizeUrl(urlArg) {
         if (typeof urlArg === 'string') return urlArg;
@@ -207,7 +219,7 @@
 
         // Proxy any HTTP localhost request (any port) to avoid mixed content blocking.
         // The Rust backend validates the URL before proxying.
-        const shouldProxy = isHttpLocalhost(urlStr);
+        const shouldProxy = pageNeedsProxy() && isHttpLocalhost(urlStr);
         console.log('[Tauri Proxy] Should proxy?', shouldProxy, 'for URL:', urlStr);
 
         if (shouldProxy) {
@@ -291,13 +303,15 @@
                     headers: new Headers(response.headers)
                 });
             } catch (error) {
-                console.error('[Tauri Proxy] Fetch proxy failed:', error, 'URL:', urlStr);
-                const isTauri = typeof window.__TAURI_INVOKE__ === 'function' ||
-                    (typeof window.__TAURI__ !== 'undefined' && typeof window.__TAURI__.invoke === 'function');
-                if (!isTauri) {
-                    return originalFetch.apply(this, arguments);
+                if (error instanceof DOMException && error.name === 'AbortError') {
+                    throw error;
                 }
-                throw error;
+                // Last resort: try the native fetch. If the proxy failed for an
+                // IPC scope error while the page can reach localhost natively,
+                // this recovers; if mixed content blocks it, it fails the same
+                // way the proxy just did.
+                console.error('[Tauri Proxy] Fetch proxy failed, falling back to native fetch:', error, 'URL:', urlStr);
+                return originalFetch.apply(this, arguments);
             }
         }
 
@@ -329,7 +343,7 @@
         };
 
         xhr.send = function(body) {
-            const shouldProxy = isHttpLocalhost(xhrUrl);
+            const shouldProxy = pageNeedsProxy() && isHttpLocalhost(xhrUrl);
 
             if (shouldProxy) {
                 console.log('[Tauri Proxy] XHR intercepted:', xhrMethod, xhrUrl);
@@ -365,12 +379,20 @@
                         xhr.dispatchEvent(new ProgressEvent('loadend'));
                     })
                     .catch(function(error) {
-                        console.error('[Tauri Proxy] XHR proxy failed:', error, 'URL:', xhrUrl);
-                        if (typeof xhr.onerror === 'function') {
-                            xhr.onerror(new ProgressEvent('error'));
+                        // Same last-resort fallback as fetch: open() already ran
+                        // on the real XHR, so a native send() can still succeed
+                        // (e.g. when only the IPC scope was the problem).
+                        console.error('[Tauri Proxy] XHR proxy failed, falling back to native XHR:', error, 'URL:', xhrUrl);
+                        try {
+                            originalSend(body);
+                        } catch (sendError) {
+                            console.error('[Tauri Proxy] Native XHR fallback failed:', sendError, 'URL:', xhrUrl);
+                            if (typeof xhr.onerror === 'function') {
+                                xhr.onerror(new ProgressEvent('error'));
+                            }
+                            xhr.dispatchEvent(new ProgressEvent('error'));
+                            xhr.dispatchEvent(new ProgressEvent('loadend'));
                         }
-                        xhr.dispatchEvent(new ProgressEvent('error'));
-                        xhr.dispatchEvent(new ProgressEvent('loadend'));
                     });
                 return;
             }

--- a/apps/desktop/src-tauri/src/proxy_script.js
+++ b/apps/desktop/src-tauri/src/proxy_script.js
@@ -29,7 +29,13 @@
     // invoking the proxy from a localhost-origin page fails with
     // "Scope not defined for URL". Never proxy from non-HTTPS pages.
     function pageNeedsProxy() {
-        return window.location.protocol === 'https:';
+        try {
+            return window.location.protocol === 'https:';
+        } catch (e) {
+            // No usable location (shouldn't happen in a real webview) —
+            // keep the historical always-proxy behavior.
+            return true;
+        }
     }
 
     // Normalize the first fetch() argument: string | URL | Request → string URL

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.66"
+    "version": "0.0.67"
   },
   "tauri": {
     "allowlist": {
@@ -89,14 +89,7 @@
     },
     "security": {
       "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:* http://127.0.0.1:* https://api.github.com; connect-src 'self' https://apps.calimero.network https://*.calimero.network http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* wss://* https: http: ws: wss: https://api.github.com https://github.com; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; font-src 'self' data:; frame-src 'self' https: http:;",
-      "dangerousRemoteDomainIpcAccess": [
-        {
-          "domain": "*",
-          "windows": ["*"],
-          "plugins": [],
-          "enableTauriAPI": true
-        }
-      ],
+      "dangerousRemoteDomainIpcAccess": [],
       "dangerousDisableAssetCspModification": true
     },
     "systemTray": {

--- a/apps/desktop/src/utils/proxyScript.test.ts
+++ b/apps/desktop/src/utils/proxyScript.test.ts
@@ -23,13 +23,16 @@ function injectProxy(mockWindow: any, nodeUrl = "http://localhost:2428") {
   new Function("window", src)(mockWindow);
 }
 
-function makeMockWindow() {
+function makeMockWindow(pageProtocol = "https:") {
   // Provide a minimal XMLHttpRequest stub so the script's XHR-wrapping code
   // doesn't throw on init (we don't exercise XHR in these tests).
   function FakeXHR() {}
   FakeXHR.prototype = {};
   return {
     __TAURI_FETCH_PROXY_INJECTED__: undefined as boolean | undefined,
+    // The proxy only runs on HTTPS-hosted pages (mixed-content bypass);
+    // default the mock to an HTTPS page so proxy-path tests exercise it.
+    location: { protocol: pageProtocol },
     // Stored by the script as `originalFetch` — returned for non-proxied URLs.
     fetch: vi.fn().mockResolvedValue(new Response("original", { status: 200 })),
     XMLHttpRequest: FakeXHR,
@@ -129,6 +132,27 @@ describe("proxy_script SSE routing", () => {
     // External HTTPS URL — must not go through the proxy.
     await mockWindow.fetch("https://api.example.com/data", {});
     expect(mockWindow.__TAURI_INVOKE__).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke Tauri IPC when the page itself is plain HTTP (e.g. the node's auth page)", async () => {
+    // Pages served over http:// (like http://localhost:2528/auth/login after
+    // a logout → browser-style login) have no mixed-content problem, and the
+    // window's IPC scope may not cover their origin — native fetch must be
+    // used instead of the proxy.
+    const mockWindow = makeMockWindow("http:");
+    mockWindow.__TAURI_INVOKE__ = vi.fn();
+    mockWindow.__TAURI__ = {
+      event: { listen: vi.fn(async () => vi.fn()) },
+    };
+
+    injectProxy(mockWindow);
+
+    const response = await mockWindow.fetch(
+      "http://localhost:2528/auth/providers",
+      { headers: { Accept: "application/json" } }
+    );
+    expect(mockWindow.__TAURI_INVOKE__).not.toHaveBeenCalled();
+    expect(await response.text()).toBe("original");
   });
 
   it("does not invoke Tauri IPC for non-SSE localhost requests", async () => {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.13"
+    "version": "0.11.0-rc.14"
 }


### PR DESCRIPTION
## Problem

Logging out of a remotely-hosted app (e.g. `mero-blocks.vercel.app`) and going through the browser-style login navigates the app window to the node's auth page (`http://localhost:2528/auth/login?...`). That page then dead-ends on **"No providers available / No authentication providers are configured on this node."** even though the node has providers configured.

Console shows:

```
Scope not defined for URL `http://localhost:2528/auth/login?...`
[Tauri Proxy] Fetch proxy failed: ...
Failed to load providers: HTTPError: HTTP 0 Network Error
```

## Root cause

Three stacked issues:

1. **Tauri v1 matches IPC scopes by exact string comparison** (`tauri-1.8.3/src/scope/ipc.rs`) on both domain and window label. The `{"domain": "*", "windows": ["*"]}` entry in `tauri.conf.json` `dangerousRemoteDomainIpcAccess` never matched anything — dead config.
2. `create_app_window` registers an IPC scope only for the app's own domain. After in-window navigation to the auth page, the page origin is `localhost`, which has no scope — every IPC call from it is rejected.
3. `proxy_script.js` routes **all** `http://localhost` fetches through Tauri IPC, even on the auth page itself, where native fetch would work fine (the page is plain-HTTP and same-origin with the node — no mixed content). On proxy failure it re-threw instead of falling back, so the providers request died with `HTTP 0`.

This only bites apps hosted on a domain other than the node — locally-served apps register `localhost` as their scope domain, which is why it looked intermittent.

## Fix

- **`proxy_script.js`**: only proxy fetch/XHR when the page is served over HTTPS — the proxy exists solely to bypass mixed-content blocking. On plain-HTTP pages (the auth frontend), requests now go through native fetch and just work. Fetch and XHR also fall back to the native path as a last resort if the proxy fails.
- **`create_app_window`**: register IPC scopes for the app domain **+** the configured node host **+** `localhost` (deduped), so IPC survives in-window navigation to the auth page. (`Url::domain()` returns `None` for IP hosts, so `127.0.0.1` pages can never match a scope in Tauri v1 — the JS fallback covers those.)
- **`tauri.conf.json`**: remove the inert wildcard `dangerousRemoteDomainIpcAccess` entry so it can't be mistaken for real coverage.
- Bump Calimero Desktop to **0.0.67**.

## Testing

- `cargo check` passes (via `TAURI_CONFIG` allowlist patch; plain `cargo check` fails on the pre-existing `http-all` feature/allowlist mismatch that the tauri CLI reconciles during `tauri build`)
- `node --check` on `proxy_script.js` passes
- All compiler warnings pre-exist this change

Companion PR in auth-frontend improves recovery UX on the providers page (distinguishes "unable to load" from "none configured" + retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)