### PR TITLE
fix(desktop): drop dead challenge + NEAR-wallet login paths

### DIFF
--- a/apps/desktop/src/components/LoginView.tsx
+++ b/apps/desktop/src/components/LoginView.tsx
@@ -47,8 +47,6 @@ export function LoginView({ onSuccess, onError, variant = 'light' }: LoginViewPr
     if (provider.name === 'user_password' || provider.name === 'username_password') {
       setShowProviders(false);
       setShowUsernamePasswordForm(true);
-    } else if (provider.name === 'near_wallet') {
-      setError('NEAR wallet authentication not yet implemented');
     } else {
       setError(`Provider ${provider.name} is not supported`);
     }

--- a/apps/desktop/src/components/ProviderSelector.tsx
+++ b/apps/desktop/src/components/ProviderSelector.tsx
@@ -20,7 +20,6 @@ export interface ProviderSelectorProps {
 }
 
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
-  near_wallet: 'NEAR Wallet',
   user_password: 'Username/Password',
   username_password: 'Username/Password',
 };

--- a/apps/desktop/src/lib/mero-client.ts
+++ b/apps/desktop/src/lib/mero-client.ts
@@ -165,15 +165,6 @@ class AuthApi {
     }
   }
 
-  async getChallenge(): Promise<ApiResponse<{ challenge: string; nonce: string }>> {
-    try {
-      const r = await this.meroJs.auth.getChallenge();
-      return { data: { challenge: r.challenge, nonce: r.expiresAt } };
-    } catch (e) {
-      return { error: { message: e instanceof Error ? e.message : 'Failed to get challenge' } };
-    }
-  }
-
   async generateClientKey(payload: {
     context_id: string;
     context_identity: string;


### PR DESCRIPTION
## Why

Core removes the `/auth/challenge` surface in calimero-network/core#3229 (security-review findings 8+16): the endpoint minted a nonce+jti that **nothing ever stored or verified** (`verify_challenge` had zero callers), and core ships no wallet provider, so the challenge flow was security theater. Team decision: no NEAR/wallet login this iteration — `user_password` only, which needs no proof-of-possession step.

## Before → after

| | Before | After |
|---|---|---|
| `mero-client.ts` | `getChallenge()` wrapper forwarding to `meroJs.auth.getChallenge()` → `GET /auth/challenge`. **Zero callers in the desktop.** | Removed. Leaving it would break the desktop build on the next mero-js bump, once `getChallenge()` is dropped from the SDK. |
| `LoginView.tsx` | `near_wallet` branch that only ever set *"NEAR wallet authentication not yet implemented"* — a dead end. | Removed; unsupported providers fall through to the existing generic `Provider X is not supported` message. |
| `ProviderSelector.tsx` | `near_wallet: 'NEAR Wallet'` display name. | Removed (core can never advertise the provider). |

No behavior change for users: the desktop only ever supported username/password login, and the removed paths were unreachable or unused.

## How to test

```
pnpm install && pnpm --filter desktop build   # tsc + vite, green
```

Manual: launch the desktop, log in with username/password → unchanged. The provider list only ever contains `user_password` (core ships no other provider).

## Depends on
- calimero-network/core#3229 (removes the server route)
- A follow-up mero-js release dropping `getChallenge()` — this PR makes the desktop safe to bump to it. It is safe to merge **before** that release: removing an unused wrapper cannot break anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)