### PR TITLE
fix(auth): stop sharing the refresh token with app webviews (single-use rotation)

### DIFF
--- a/apps/desktop/e2e/auth.spec.ts
+++ b/apps/desktop/e2e/auth.spec.ts
@@ -1,12 +1,19 @@
 import { test, expect } from "@playwright/test";
 import {
+  AUTH_ERROR_HEADERS,
   mockCoreAPIs,
+  mockSingleUseRefresh,
   setupAuthenticatedPage,
+  seedAuthenticatedState,
   seedSettings,
+  stubTauriIPC,
+  waitForAppShellReady,
 } from "./fixtures/helpers";
 import {
   AUTHENTICATED_SETTINGS,
+  MOCK_ACCESS_TOKEN,
   MOCK_PROVIDERS_RESPONSE,
+  MOCK_REFRESH_TOKEN,
   API_ROUTES,
   STORAGE_KEYS,
   listApplicationsWireBody,
@@ -43,6 +50,107 @@ test.describe("Authenticated user bypass", () => {
   test("skips login and shows main app", async ({ page }) => {
     await expect(page.getByTestId("login-screen")).not.toBeVisible();
     await expect(page.locator("aside.sidebar")).toBeVisible();
+  });
+});
+
+// ─── Single-use refresh tokens (calimero-network/core#3083) ─────────────────
+//
+// The node consumes the presented refresh token on every POST /auth/refresh and
+// mints a new one; re-presenting a consumed token is treated as theft and the
+// whole family is revoked. `mockSingleUseRefresh` enforces exactly that, so a
+// client that keeps a consumed token — or that shares one with a second holder,
+// which is what the desktop used to do by putting it in every app window's URL
+// hash — fails here instead of passing against a permissive mock.
+
+test.describe("single-use refresh token rotation", () => {
+  test("desktop keeps the rotated refresh token and never replays a consumed one", async ({
+    page,
+  }) => {
+    await stubTauriIPC(page);
+    await mockCoreAPIs(page);
+    const refresh = await mockSingleUseRefresh(page);
+
+    // Reject the seeded access token as expired, and accept anything else — i.e.
+    // behave like a node whose access token has aged out, until the client
+    // rotates. Keyed on the presented bearer rather than a call count because
+    // unauthenticated probes (onboarding, node detection) also hit this route.
+    //
+    // The `x-auth-error: token_expired` header is load-bearing: mero-js only
+    // auto-refreshes on that exact reason (web-client.js), and only when the
+    // node exposes the header cross-origin. Registered after mockCoreAPIs so
+    // this handler wins.
+    await page.route(API_ROUTES.adminHealth, (route) => {
+      const auth = route.request().headers()["authorization"] ?? "";
+      const presented = auth.replace(/^Bearer\s+/i, "");
+      if (presented === MOCK_ACCESS_TOKEN) {
+        return route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          headers: AUTH_ERROR_HEADERS("token_expired"),
+          body: JSON.stringify({ error: "Unauthorized" }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: { status: "ok" } }),
+      });
+    });
+
+    await page.goto("/");
+    await seedAuthenticatedState(page);
+    await page.reload();
+    await waitForAppShellReady(page);
+
+    // A rotation happened, and the replay path was never taken.
+    expect(refresh.callCount()).toBeGreaterThan(0);
+    expect(refresh.familyRevoked()).toBe(false);
+
+    // The consumed token must be gone from storage — keeping it is precisely
+    // what trips token_reuse on the next refresh.
+    const stored = await page.evaluate(
+      (key) => localStorage.getItem(key),
+      STORAGE_KEYS.refreshToken,
+    );
+    expect(refresh.consumedTokens()).toContain(MOCK_REFRESH_TOKEN);
+    expect(stored).not.toBe(MOCK_REFRESH_TOKEN);
+    expect(stored).toBe(refresh.liveRefreshToken());
+  });
+
+  test("node rejects a replayed refresh token with token_reuse and revokes the family", async ({
+    page,
+  }) => {
+    await stubTauriIPC(page);
+    await mockCoreAPIs(page);
+    const refresh = await mockSingleUseRefresh(page);
+    await page.goto("/");
+
+    // Two holders of the same refresh token, exactly as the old URL-hash handoff
+    // produced: the second one to refresh presents an already-consumed token.
+    const replay = await page.evaluate(async (token) => {
+      const post = async (refresh_token: string) => {
+        const res = await fetch("http://localhost:2528/auth/refresh", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ access_token: "stale", refresh_token }),
+        });
+        return {
+          status: res.status,
+          authError: res.headers.get("x-auth-error"),
+          body: await res.json().catch(() => null),
+        };
+      };
+      return { first: await post(token), second: await post(token) };
+    }, MOCK_REFRESH_TOKEN);
+
+    // First holder rotates fine and gets a brand-new pair.
+    expect(replay.first.status).toBe(200);
+    expect(replay.first.body.data.refresh_token).not.toBe(MOCK_REFRESH_TOKEN);
+
+    // Second holder replays the consumed token → theft → family revoked.
+    expect(replay.second.status).toBe(401);
+    expect(replay.second.authError).toBe("token_reuse");
+    expect(refresh.familyRevoked()).toBe(true);
   });
 });
 

--- a/apps/desktop/e2e/fixtures/helpers.ts
+++ b/apps/desktop/e2e/fixtures/helpers.ts
@@ -16,6 +16,7 @@ import {
   MOCK_INSTALLED_APPS,
   MOCK_REGISTRY_V2_BUNDLES,
   API_ROUTES,
+  rotatedTokenPair,
   listApplicationsWireBody,
   listContextsWireBody,
   type AppSettings,
@@ -157,6 +158,110 @@ export async function mockCoreAPIs(
     }
     return route.continue();
   });
+}
+
+// ─── Single-use refresh tokens (calimero-network/core#3083) ──────────────────
+
+/**
+ * The node signals *why* a 401 happened via `x-auth-error`, and clients key off
+ * it: mero-js only auto-refreshes on `token_expired` (web-client.js), and
+ * mero-js#67 treats `token_reuse` / `token_revoked` as terminal.
+ *
+ * The app is a different origin from the node (1420 → 2528), so the browser
+ * hides that header from JS unless the node also sends
+ * `Access-Control-Expose-Headers`. A mock that omits it silently disables every
+ * refresh path — the client can't see the header, so it never refreshes.
+ */
+export const AUTH_ERROR_HEADERS = (reason: string): Record<string, string> => ({
+  "x-auth-error": reason,
+  "access-control-expose-headers": "x-auth-error",
+});
+
+export interface SingleUseRefreshMock {
+  /** How many POST /auth/refresh calls the node received. */
+  callCount(): number;
+  /** True once a consumed refresh token was re-presented → family revoked. */
+  familyRevoked(): boolean;
+  /** The refresh token the node currently accepts. */
+  liveRefreshToken(): string;
+  /** Every refresh token the node has already consumed. */
+  consumedTokens(): readonly string[];
+}
+
+/**
+ * Model the node's single-use refresh-token rotation.
+ *
+ * Each POST /auth/refresh **consumes** the presented refresh token and returns a
+ * brand-new pair. Re-presenting a consumed token is treated as theft: the node
+ * revokes the whole token family and answers 401 `x-auth-error: token_reuse`,
+ * after which nothing in that family works again.
+ *
+ * That is the real server contract, so a client that hangs on to a consumed
+ * refresh token — or that hands the same one to a second holder, which is what
+ * the desktop used to do by putting it in every app window's URL hash — now
+ * fails loudly here instead of passing against a permissive mock.
+ */
+export async function mockSingleUseRefresh(
+  page: Page,
+): Promise<SingleUseRefreshMock> {
+  let generation = 0;
+  let live = MOCK_REFRESH_TOKEN;
+  let revoked = false;
+  let calls = 0;
+  const consumed = new Set<string>();
+
+  await page.route(API_ROUTES.refreshToken, async (route) => {
+    if (route.request().method() !== "POST") return route.continue();
+    calls += 1;
+
+    let presented = "";
+    try {
+      const body = route.request().postDataJSON() as
+        | { refresh_token?: string }
+        | null;
+      presented = body?.refresh_token ?? "";
+    } catch {
+      presented = "";
+    }
+
+    // Replay of a consumed token → theft. Revoke the family for good.
+    if (consumed.has(presented)) {
+      revoked = true;
+      return route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        headers: AUTH_ERROR_HEADERS("token_reuse"),
+        body: JSON.stringify({ error: "refresh token reuse detected" }),
+      });
+    }
+
+    if (revoked || presented !== live) {
+      return route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        headers: AUTH_ERROR_HEADERS("token_revoked"),
+        body: JSON.stringify({ error: "invalid refresh token" }),
+      });
+    }
+
+    consumed.add(presented);
+    generation += 1;
+    const next = rotatedTokenPair(generation);
+    live = next.refresh_token;
+
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ data: next }),
+    });
+  });
+
+  return {
+    callCount: () => calls,
+    familyRevoked: () => revoked,
+    liveRefreshToken: () => live,
+    consumedTokens: () => [...consumed],
+  };
 }
 
 /**

--- a/apps/desktop/e2e/fixtures/mock-data.ts
+++ b/apps/desktop/e2e/fixtures/mock-data.ts
@@ -61,6 +61,25 @@ export const MOCK_ACCESS_TOKEN = `${JWT_HEADER}.${JWT_PAYLOAD}.${JWT_SIGNATURE}`
 export const MOCK_REFRESH_TOKEN = `refresh-${JWT_HEADER}.${JWT_PAYLOAD}.${JWT_SIGNATURE}`;
 export const MOCK_TOKEN_EXPIRES_AT = Date.now() + 86400 * 1000;
 
+/**
+ * The token pair the node mints on the Nth rotation of a token family.
+ *
+ * Refresh tokens are single-use (calimero-network/core#3083): each
+ * POST /auth/refresh consumes the presented refresh token and returns a brand
+ * new pair, so no two generations share a token. Access tokens stay JWT-shaped
+ * because mero-js reads `exp` out of the payload to compute `expires_at`.
+ */
+export function rotatedTokenPair(generation: number): {
+  access_token: string;
+  refresh_token: string;
+} {
+  const signature = `${JWT_SIGNATURE}-r${generation}`;
+  return {
+    access_token: `${JWT_HEADER}.${JWT_PAYLOAD}.${signature}`,
+    refresh_token: `refresh-${JWT_HEADER}.${JWT_PAYLOAD}.${signature}`,
+  };
+}
+
 // ─── Auth providers ──────────────────────────────────────────────────────────
 
 export const MOCK_PROVIDERS = [
@@ -263,7 +282,10 @@ export const API_ROUTES = {
   adminHealth: "**/admin-api/health",
   providers: "**/auth/providers",
   requestToken: "**/auth/request-token",
-  refreshToken: "**/auth/refresh-token",
+  // The node's route is `/auth/refresh` (mero-js posts there). This used to read
+  // `**/auth/refresh-token`, which matched nothing — the refresh path was
+  // effectively untested and every refresh request escaped the mock.
+  refreshToken: "**/auth/refresh",
   listApplications: "**/admin-api/applications",
   installApplication: "**/admin-api/install-application",
   uninstallApplication: "**/admin-api/applications/*",

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -564,6 +564,115 @@ fn cancel_sse_stream(stream_id: String, cancel_registry: tauri::State<'_, SseCan
     }
 }
 
+// ─── Desktop token broker ───────────────────────────────────────────────────
+//
+// Refresh tokens are single-use (calimero-network/core#3083): every
+// POST /auth/refresh consumes the presented token, and re-presenting a consumed
+// one is treated as theft — the node revokes the whole token family and logs
+// out every holder. Each app webview is a separate origin with its own
+// localStorage and its own MeroJs, so they must not share a refresh token: the
+// first to rotate consumes it and the next one trips reuse detection.
+//
+// So app windows never get the real refresh token. The desktop window holds it
+// and is the sole rotator. The proxy script intercepts an app's
+// POST /auth/refresh and calls `broker_token_refresh`, which relays the request
+// to the desktop window and returns the access token it hands back.
+
+/// What the desktop window answers with: a fresh access token, or why not.
+type TokenBrokerReply = Result<String, String>;
+
+/// In-flight broker requests, keyed by request id, awaiting the desktop's reply.
+type TokenBrokerRegistry = std::sync::Arc<
+    std::sync::Mutex<std::collections::HashMap<String, tokio::sync::oneshot::Sender<TokenBrokerReply>>>,
+>;
+
+/// How long the desktop window gets to answer before the app's fetch fails.
+const TOKEN_BROKER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
+#[derive(Clone, Serialize)]
+struct TokenRequestPayload {
+    #[serde(rename = "requestId")]
+    request_id: String,
+}
+
+/// Broker an app window's `POST /auth/refresh` to the desktop window, which owns
+/// the refresh token. Returns a fresh access token — never a refresh token.
+#[tauri::command]
+async fn broker_token_refresh(
+    app_handle: tauri::AppHandle,
+    registry: tauri::State<'_, TokenBrokerRegistry>,
+) -> Result<String, TauriError> {
+    static NEXT_REQUEST_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let request_id = format!(
+        "tok-{}",
+        NEXT_REQUEST_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    );
+
+    let main_window = app_handle.get_window("main").ok_or_else(|| {
+        TauriError::new(
+            TauriErrorCode::WindowOperationFailed,
+            "Desktop window is unavailable; cannot refresh the access token",
+        )
+    })?;
+
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel::<TokenBrokerReply>();
+    registry
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .insert(request_id.clone(), reply_tx);
+
+    if let Err(e) = main_window.emit(
+        "calimero:token-request",
+        TokenRequestPayload { request_id: request_id.clone() },
+    ) {
+        registry.lock().unwrap_or_else(|p| p.into_inner()).remove(&request_id);
+        return Err(TauriError::with_details(
+            TauriErrorCode::WindowOperationFailed,
+            "Failed to reach the desktop window for a token refresh",
+            e.to_string(),
+        ));
+    }
+
+    match tokio::time::timeout(TOKEN_BROKER_TIMEOUT, reply_rx).await {
+        Ok(Ok(Ok(access_token))) => Ok(access_token),
+        Ok(Ok(Err(reason))) => Err(TauriError::new(TauriErrorCode::InternalError, reason)),
+        // Sender dropped without replying (desktop window closed mid-request).
+        Ok(Err(_)) => Err(TauriError::new(
+            TauriErrorCode::InternalError,
+            "Desktop window closed before the token refresh completed",
+        )),
+        Err(_) => {
+            registry.lock().unwrap_or_else(|p| p.into_inner()).remove(&request_id);
+            Err(TauriError::new(
+                TauriErrorCode::Timeout,
+                "Timed out waiting for the desktop to refresh the access token",
+            ))
+        }
+    }
+}
+
+/// Called by the desktop window to answer a `broker_token_refresh` request.
+#[tauri::command]
+fn resolve_token_request(
+    request_id: String,
+    access_token: Option<String>,
+    error: Option<String>,
+    registry: tauri::State<'_, TokenBrokerRegistry>,
+) {
+    if let Some(sender) = registry
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .remove(&request_id)
+    {
+        let reply = match access_token {
+            Some(token) => Ok(token),
+            None => Err(error.unwrap_or_else(|| "Token refresh failed".to_string())),
+        };
+        // Receiver gone means the request already timed out — nothing to do.
+        let _ = sender.send(reply);
+    }
+}
+
 #[tauri::command]
 fn get_pending_open_app(state: tauri::State<'_, PendingOpenApp>) -> Option<(String, String, Option<String>)> {
     state.0.lock().ok().and_then(|g| g.clone())
@@ -2854,6 +2963,7 @@ fn main() {
         })
         .manage(MerodState::default())
         .manage(SseCancelRegistry::new(std::sync::Mutex::new(std::collections::HashMap::new())))
+        .manage(TokenBrokerRegistry::new(std::sync::Mutex::new(std::collections::HashMap::new())))
         .invoke_handler(tauri::generate_handler![
             get_pending_open_app,
             clear_pending_open_app,
@@ -2865,6 +2975,8 @@ fn main() {
             proxy_http_request,
             proxy_sse_stream,
             cancel_sse_stream,
+            broker_token_refresh,
+            resolve_token_request,
             start_merod,
             stop_merod,
             stop_merod_by_pid_command,

--- a/apps/desktop/src-tauri/src/proxy_script.js
+++ b/apps/desktop/src-tauri/src/proxy_script.js
@@ -10,6 +10,10 @@
 
     console.log('[Tauri Proxy] Configured node URL for interception:', nodeUrl);
 
+    // Sentinel the desktop puts in the app's refresh-token slot instead of the
+    // real refresh token. MUST match BROKERED_REFRESH_TOKEN in src/lib/token-broker.ts.
+    const BROKERED_REFRESH_TOKEN = 'calimero-desktop-brokered-refresh-token';
+
     // Check if a URL is an HTTP localhost request that needs proxying
     function isHttpLocalhost(urlStr) {
         try {
@@ -17,6 +21,64 @@
             return u.protocol === 'http:' && (u.hostname === 'localhost' || u.hostname === '127.0.0.1');
         } catch (e) {
             return false;
+        }
+    }
+
+    // Is this the app's `POST /auth/refresh` call?
+    //
+    // Refresh tokens are single-use (calimero-network/core#3083): whoever calls
+    // /auth/refresh consumes the token and gets a new one, and re-presenting a
+    // consumed token revokes the entire family. App windows therefore never hold
+    // the real refresh token — the desktop does, and it is the only rotator. We
+    // intercept this request and let the desktop answer it.
+    //
+    // Matched on the node URL rather than on localhost specifically, so a
+    // remote-node setup is brokered too (and never leaks the sentinel to it).
+    function isAuthRefresh(urlStr, method) {
+        if ((method || 'GET').toUpperCase() !== 'POST') return false;
+        try {
+            return new URL(urlStr).pathname.replace(/\/+$/, '').endsWith('/auth/refresh');
+        } catch (e) {
+            return false;
+        }
+    }
+
+    // Ask the desktop window to rotate its refresh token and hand back a fresh
+    // access token. Returns a proxy-shaped response ({status, body, headers}) so
+    // both the fetch and XHR paths can consume it exactly like a proxied reply.
+    async function brokerTokenRefresh() {
+        const invokeFn = getTauriInvoke();
+        if (!invokeFn) {
+            // No Tauri IPC — we must NOT fall through to the network, because the
+            // app is holding the sentinel, not a real refresh token.
+            console.error('[Tauri Proxy] /auth/refresh needs Tauri IPC to be brokered by the desktop');
+            return {
+                status: 401,
+                body: JSON.stringify({ error: 'Token refresh unavailable: no Tauri IPC' }),
+                headers: { 'content-type': 'application/json' },
+            };
+        }
+
+        try {
+            const accessToken = await invokeFn('broker_token_refresh');
+            console.log('[Tauri Proxy] /auth/refresh brokered by desktop');
+            // Same wire shape the node returns, so unmodified mero-js/mero-react
+            // parse it as an ordinary refresh response. The refresh token stays
+            // the sentinel: the desktop keeps the real one.
+            return {
+                status: 200,
+                body: JSON.stringify({
+                    data: { access_token: accessToken, refresh_token: BROKERED_REFRESH_TOKEN },
+                }),
+                headers: { 'content-type': 'application/json' },
+            };
+        } catch (error) {
+            console.error('[Tauri Proxy] Desktop token broker failed:', error);
+            return {
+                status: 401,
+                body: JSON.stringify({ error: String((error && error.message) || error) }),
+                headers: { 'content-type': 'application/json' },
+            };
         }
     }
 
@@ -168,6 +230,13 @@
 
     // Helper function to proxy regular HTTP requests through Tauri
     async function proxyRequest(url, method, headers, body) {
+        // /auth/refresh is answered by the desktop, never forwarded to the node.
+        // Both the fetch and XHR interceptors funnel through here, so this single
+        // check covers both.
+        if (isAuthRefresh(url, method)) {
+            return brokerTokenRefresh();
+        }
+
         const invokeFn = getTauriInvoke();
         if (!invokeFn) {
             console.error('[Tauri Proxy] Tauri invoke API not available!');
@@ -202,12 +271,16 @@
             || (typeof Request !== 'undefined' && urlArg instanceof Request ? urlArg.headers : null);
         const effectiveSignal = (init && init.signal)
             || (typeof Request !== 'undefined' && urlArg instanceof Request ? urlArg.signal : null);
+        const effectiveMethod = (init && init.method)
+            || (typeof Request !== 'undefined' && urlArg instanceof Request ? urlArg.method : 'GET');
 
         console.log('[Tauri Proxy] Fetch called:', urlStr);
 
         // Proxy any HTTP localhost request (any port) to avoid mixed content blocking.
         // The Rust backend validates the URL before proxying.
-        const shouldProxy = isHttpLocalhost(urlStr);
+        // /auth/refresh is always routed through here — even for a non-localhost
+        // node — so the brokered sentinel can never reach the network.
+        const shouldProxy = isHttpLocalhost(urlStr) || isAuthRefresh(urlStr, effectiveMethod);
         console.log('[Tauri Proxy] Should proxy?', shouldProxy, 'for URL:', urlStr);
 
         if (shouldProxy) {
@@ -265,7 +338,7 @@
                 console.log('[Tauri Proxy] Headers being sent:', JSON.stringify(headers, null, 2));
                 console.log('[Tauri Proxy] Has Authorization header?', 'Authorization' in headers || 'authorization' in headers);
 
-                const requestPromise = proxyRequest(urlStr, (init && init.method) || 'GET', headers, bodyStr);
+                const requestPromise = proxyRequest(urlStr, effectiveMethod, headers, bodyStr);
 
                 let response;
                 if (effectiveSignal) {
@@ -329,7 +402,7 @@
         };
 
         xhr.send = function(body) {
-            const shouldProxy = isHttpLocalhost(xhrUrl);
+            const shouldProxy = isHttpLocalhost(xhrUrl) || isAuthRefresh(xhrUrl, xhrMethod);
 
             if (shouldProxy) {
                 console.log('[Tauri Proxy] XHR intercepted:', xhrMethod, xhrUrl);

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -4,6 +4,7 @@ import { createClientAsync, apiClient } from "./lib/mero-client";
 import { MeroContext, type MeroContextValue } from "@calimero-network/mero-react";
 import { LoginView } from "./components/LoginView";
 import { getAccessToken, clearAccessToken, clearRefreshToken } from "./lib/token-storage";
+import { startTokenBroker } from "./lib/token-broker";
 import { getSettings, getAuthUrl, saveSettings } from "./utils/settings";
 import { clearOnboardingProgress } from "./utils/onboardingProgress";
 import { startMerod, detectRunningMerodNodes, type RunningMerodNode } from "./utils/merod";
@@ -402,6 +403,15 @@ function App() {
   }, []);
 
 
+
+  // Serve token refreshes for app windows. Refresh tokens are single-use
+  // (calimero-network/core#3083), so the desktop keeps the only copy and is the
+  // only rotator; app windows ask us instead of refreshing themselves. Must run
+  // for the whole app lifetime — an app window can ask at any time.
+  useEffect(() => {
+    const unlisten = startTokenBroker();
+    return () => { unlisten.then((off) => off()).catch(() => {}); };
+  }, []);
 
   // Health-check interval — lightweight, just updates the connected indicator.
   // Skip on login/settings/onboarding screens.

--- a/apps/desktop/src/lib/token-broker.test.ts
+++ b/apps/desktop/src/lib/token-broker.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// The broker only runs inside the desktop window, where the Tauri API and a real
+// token store exist. Mock both so the module is testable under the `node` vitest
+// environment (no localStorage, no IPC).
+const listen = vi.fn();
+const invoke = vi.fn();
+vi.mock('@tauri-apps/api/event', () => ({ listen: (...a: unknown[]) => listen(...a) }));
+vi.mock('@tauri-apps/api/tauri', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
+
+vi.mock('../utils/settings', () => ({
+  getSettings: () => ({ nodeUrl: 'http://localhost:2528' }),
+}));
+
+let accessToken: string | null;
+let storedRefreshToken: string | null;
+let expiresAt: number | null;
+vi.mock('./token-storage', () => ({
+  getAccessToken: () => accessToken,
+  getRefreshToken: () => storedRefreshToken,
+  getTokenExpiresAt: () => expiresAt,
+  setAccessToken: (t: string) => { accessToken = t; },
+  setRefreshToken: (t: string) => { storedRefreshToken = t; },
+  setTokenExpiresAt: (e: number) => { expiresAt = e; },
+}));
+
+// Imported fresh for every test: the module keeps the in-flight rotation and the
+// captured original `fetch` in module scope, and a test must never inherit either.
+type Broker = typeof import('./token-broker');
+let broker: Broker;
+
+/** A promise plus its resolver, so a test can hold a rotation open. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+function refreshResponse(pair: { access_token: string; refresh_token: string }) {
+  return new Response(JSON.stringify({ data: pair }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const FRESH = () => Date.now() + 3600_000;
+const EXPIRED = () => Date.now() - 1_000;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  accessToken = 'access-1';
+  storedRefreshToken = 'refresh-1';
+  expiresAt = FRESH();
+  listen.mockResolvedValue(() => {});
+  invoke.mockResolvedValue(undefined); // real invoke() always returns a promise
+
+  // A fresh Response per call: a body can only be read once, and some tests
+  // rotate twice.
+  fetchMock = vi.fn().mockImplementation(async () =>
+    refreshResponse({ access_token: 'access-2', refresh_token: 'refresh-2' }),
+  );
+  vi.stubGlobal('window', { fetch: fetchMock, location: { href: 'http://localhost:1420/' } });
+  vi.stubGlobal('fetch', fetchMock);
+
+  vi.resetModules();
+  broker = await import('./token-broker');
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** The JSON body of the Nth POST /auth/refresh. */
+function refreshBody(n = 0) {
+  const [, init] = fetchMock.mock.calls[n] as [string, RequestInit];
+  return JSON.parse(init.body as string);
+}
+
+describe('rotateTokens', () => {
+  it('POSTs the stored token pair to the node and persists what comes back', async () => {
+    await expect(broker.rotateTokens()).resolves.toEqual({
+      access_token: 'access-2',
+      refresh_token: 'refresh-2',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe('http://localhost:2528/auth/refresh');
+    expect(refreshBody()).toEqual({ access_token: 'access-1', refresh_token: 'refresh-1' });
+
+    // The consumed token must be gone from storage — keeping it is exactly what
+    // trips token_reuse on the next rotation.
+    expect(storedRefreshToken).toBe('refresh-2');
+    expect(accessToken).toBe('access-2');
+  });
+
+  // The core#3083 guard. A second concurrent POST would present the token the
+  // first one just consumed; the node calls that theft and revokes the family.
+  it('collapses concurrent rotations into exactly one /auth/refresh', async () => {
+    const gate = deferred<Response>();
+    fetchMock.mockReturnValue(gate.promise);
+
+    const all = Promise.all([broker.rotateTokens(), broker.rotateTokens(), broker.rotateTokens()]);
+    gate.resolve(refreshResponse({ access_token: 'access-2', refresh_token: 'refresh-2' }));
+
+    const results = await all;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Every caller gets the same rotated pair.
+    expect(results).toEqual([
+      { access_token: 'access-2', refresh_token: 'refresh-2' },
+      { access_token: 'access-2', refresh_token: 'refresh-2' },
+      { access_token: 'access-2', refresh_token: 'refresh-2' },
+    ]);
+  });
+
+  it('re-reads the store, so a stale caller cannot replay a consumed token', async () => {
+    await broker.rotateTokens(); // consumes refresh-1, stores refresh-2
+    await broker.rotateTokens();
+
+    // The second rotation must present refresh-2 (from the store), never refresh-1.
+    expect(refreshBody(1).refresh_token).toBe('refresh-2');
+  });
+
+  it('rejects when the desktop is not authenticated', async () => {
+    accessToken = null;
+    storedRefreshToken = null;
+
+    await expect(broker.rotateTokens()).rejects.toThrow('Desktop is not authenticated');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the node`s auth error reason', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', { status: 401, headers: { 'x-auth-error': 'token_reuse' } }),
+    );
+
+    await expect(broker.rotateTokens()).rejects.toThrow('token_reuse');
+  });
+});
+
+describe('installRefreshSingleFlight', () => {
+  it('serves every MeroJs refresh from one rotation, in the node`s wire format', async () => {
+    broker.installRefreshSingleFlight();
+
+    // Three MeroJs instances each hitting a 401 at once — as the desktop really
+    // does (lazy apiClient + createClientAsync + StrictMode double-mount).
+    const responses = await Promise.all([
+      window.fetch('http://localhost:2528/auth/refresh', {
+        method: 'POST',
+        body: JSON.stringify({ access_token: 'access-1', refresh_token: 'refresh-1' }),
+      }),
+      window.fetch('http://localhost:2528/auth/refresh', {
+        method: 'POST',
+        body: JSON.stringify({ access_token: 'access-1', refresh_token: 'refresh-1' }),
+      }),
+      window.fetch('http://localhost:2528/auth/refresh', {
+        method: 'POST',
+        body: JSON.stringify({ access_token: 'access-1', refresh_token: 'refresh-1' }),
+      }),
+    ]);
+
+    // One real POST for three callers — the whole point.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    for (const response of responses) {
+      expect(response.status).toBe(200);
+      // Shaped exactly like the node's reply, so each MeroJs updates its own
+      // cache and token store as it normally would.
+      expect(await response.json()).toEqual({
+        data: { access_token: 'access-2', refresh_token: 'refresh-2' },
+      });
+    }
+  });
+
+  it('leaves every other request alone', async () => {
+    broker.installRefreshSingleFlight();
+
+    await window.fetch('http://localhost:2528/admin-api/health');
+    await window.fetch('http://localhost:2528/auth/refresh', { method: 'GET' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:2528/admin-api/health');
+  });
+
+  it('answers a failed rotation with a 401 rather than hanging the caller', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', { status: 401, headers: { 'x-auth-error': 'token_reuse' } }),
+    );
+    broker.installRefreshSingleFlight();
+
+    const response = await window.fetch('http://localhost:2528/auth/refresh', {
+      method: 'POST',
+      body: '{}',
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.text()).toContain('token_reuse');
+  });
+});
+
+describe('brokerAccessToken', () => {
+  it('hands back the stored access token without rotating when it is still fresh', async () => {
+    await expect(broker.brokerAccessToken()).resolves.toBe('access-1');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('treats a token expiring inside the skew window as expired', async () => {
+    expiresAt = Date.now() + 5_000; // < 30s skew
+    await expect(broker.brokerAccessToken()).resolves.toBe('access-2');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rotates when the stored access token has expired', async () => {
+    expiresAt = EXPIRED();
+    await expect(broker.brokerAccessToken()).resolves.toBe('access-2');
+  });
+});
+
+describe('startTokenBroker', () => {
+  /** Run the handler registered for `calimero:token-request`. */
+  async function fireRequest(requestId: string | undefined) {
+    await broker.startTokenBroker();
+    const [eventName, handler] = listen.mock.calls[0] as [string, (e: unknown) => Promise<void>];
+    expect(eventName).toBe('calimero:token-request');
+    await handler({ payload: requestId === undefined ? {} : { requestId } });
+  }
+
+  it('answers an app window with an access token — and never a refresh token', async () => {
+    await fireRequest('tok-1');
+
+    expect(invoke).toHaveBeenCalledWith('resolve_token_request', {
+      requestId: 'tok-1',
+      accessToken: 'access-1',
+    });
+
+    // The refresh token must never leave the desktop.
+    const [, payload] = invoke.mock.calls[0] as [string, Record<string, unknown>];
+    expect(Object.keys(payload)).not.toContain('refreshToken');
+    expect(JSON.stringify(payload)).not.toContain('refresh-1');
+  });
+
+  it('answers with an error instead of leaving the app window hanging', async () => {
+    accessToken = null;
+    storedRefreshToken = null;
+    expiresAt = null;
+
+    await fireRequest('tok-2');
+
+    expect(invoke).toHaveBeenCalledWith('resolve_token_request', {
+      requestId: 'tok-2',
+      error: 'Desktop is not authenticated',
+    });
+  });
+
+  it('ignores a malformed request with no id', async () => {
+    await fireRequest(undefined);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});
+
+describe('BROKERED_REFRESH_TOKEN', () => {
+  it('is non-empty — an empty slot would stop mero-js from ever calling /auth/refresh', () => {
+    // mero-js's performTokenRefresh() throws "No refresh token available" and
+    // never hits the network when the refresh-token slot is empty, so the app
+    // could not refresh at all rather than being brokered.
+    expect(broker.BROKERED_REFRESH_TOKEN).toBeTruthy();
+  });
+
+  it('matches the sentinel hard-coded in proxy_script.js', async () => {
+    const { readFileSync } = await import('fs');
+    const { fileURLToPath } = await import('url');
+    const path = await import('path');
+    const dir = path.dirname(fileURLToPath(import.meta.url));
+    const script = readFileSync(path.resolve(dir, '../../src-tauri/src/proxy_script.js'), 'utf-8');
+    expect(script).toContain(
+      `const BROKERED_REFRESH_TOKEN = '${broker.BROKERED_REFRESH_TOKEN}'`,
+    );
+  });
+});

--- a/apps/desktop/src/lib/token-broker.ts
+++ b/apps/desktop/src/lib/token-broker.ts
@@ -1,0 +1,241 @@
+/**
+ * Desktop token broker — the desktop is the SINGLE holder and SINGLE rotator
+ * of the refresh token.
+ *
+ * Why this exists (calimero-network/core#3083):
+ * refresh tokens are single-use. Every `POST /auth/refresh` consumes the
+ * presented refresh token and mints a new one; re-presenting a consumed token
+ * is treated as theft — the server revokes the whole token family and replies
+ * 401 `x-auth-error: token_reuse`, logging out every holder.
+ *
+ * Two independent things used to break that rule, and this module fixes both by
+ * funnelling every rotation — the desktop's own and every app window's —
+ * through one single-flight `rotateTokens()`:
+ *
+ * 1. **Across webviews.** Each app webview is a separate origin with its own
+ *    localStorage and its own MeroJs. The desktop used to hand its real refresh
+ *    token to every app window in the SSO URL hash, so each one would rotate it
+ *    independently: the first consumes it, the next presents a consumed token,
+ *    family revoked, everything logged out. Now app windows never receive the
+ *    real refresh token — they get `BROKERED_REFRESH_TOKEN`, and the proxy
+ *    script (src-tauri/src/proxy_script.js) routes their `/auth/refresh` calls
+ *    to the `broker_token_refresh` Tauri command, which lands in
+ *    `startTokenBroker()` below.
+ *
+ * 2. **Within the desktop itself.** The desktop holds more than one MeroJs
+ *    instance (the lazily-created `apiClient` default, the one built by
+ *    `createClientAsync`, plus React StrictMode double-mounting in dev). Each
+ *    has its own token cache and its own refresh dedupe, so a burst of 401s
+ *    produced several concurrent `POST /auth/refresh` calls all presenting the
+ *    same token — one succeeded and the rest tripped `token_reuse`.
+ *    `installRefreshSingleFlight()` patches `fetch` so every one of those calls
+ *    collapses into a single rotation whose result they all share.
+ *
+ * mero-js's own single-flight and `navigator.locks` serialization (mero-js#67)
+ * only coordinate holders *within one origin* and *one instance tree*, so they
+ * cannot solve either case for us; the desktop pins mero-js 2.x regardless.
+ *
+ * Apps need no changes: an unmodified mero-js/mero-react app still just calls
+ * `/auth/refresh` and gets a well-formed reply.
+ */
+import { listen } from '@tauri-apps/api/event';
+import { invoke } from '@tauri-apps/api/tauri';
+import { getSettings } from '../utils/settings';
+import {
+  getAccessToken,
+  getRefreshToken,
+  getTokenExpiresAt,
+  setAccessToken,
+  setRefreshToken,
+  setTokenExpiresAt,
+} from './token-storage';
+
+/**
+ * Sentinel handed to app windows in place of the real refresh token.
+ *
+ * It only has to be non-empty: mero-js's `performTokenRefresh()` throws
+ * "No refresh token available" and never calls `/auth/refresh` when the slot is
+ * empty, so an app given no refresh token at all could not refresh — it would
+ * simply hard-fail on the first 401. The sentinel keeps the app on its normal
+ * refresh code path, which the proxy script then brokers.
+ *
+ * It is not a credential: the proxy script always intercepts `/auth/refresh`
+ * before it reaches the network, so this value is never sent to the node. Even
+ * if it leaked it is not a valid token — and, not being a real `jti`, it cannot
+ * trip reuse detection or revoke anyone's token family.
+ *
+ * MUST be kept in sync with BROKERED_REFRESH_TOKEN in proxy_script.js.
+ */
+export const BROKERED_REFRESH_TOKEN = 'calimero-desktop-brokered-refresh-token';
+
+/** Treat an access token expiring within this window as already expired. */
+const EXPIRY_SKEW_MS = 30_000;
+
+export interface TokenPair {
+  access_token: string;
+  refresh_token: string;
+}
+
+/** The one in-flight rotation. Every caller — desktop or app — shares it. */
+let inflight: Promise<TokenPair> | null = null;
+
+/** `fetch` as it was before we patched it; the rotation must not re-enter us. */
+let originalFetch: typeof fetch | null = null;
+
+/** `true` when the stored access token is still usable as-is. */
+function accessTokenIsFresh(): boolean {
+  const expiresAt = getTokenExpiresAt();
+  if (expiresAt === null) return false;
+  return expiresAt - Date.now() > EXPIRY_SKEW_MS;
+}
+
+function expiresAtFromJwt(accessToken: string): number {
+  try {
+    const payload = JSON.parse(atob(accessToken.split('.')[1]));
+    if (typeof payload.exp === 'number') return payload.exp * 1000;
+  } catch {
+    // not a JWT / unparseable — fall through
+  }
+  return Date.now() + 3600_000;
+}
+
+/** True for a `POST` to the node's `/auth/refresh`. */
+function isRefreshRequest(url: string, method: string): boolean {
+  if (method.toUpperCase() !== 'POST') return false;
+  try {
+    return new URL(url, window.location.href).pathname.replace(/\/+$/, '').endsWith('/auth/refresh');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Rotate the refresh token exactly once, however many callers are asking.
+ *
+ * The refresh token is re-read from storage inside the single-flight rather than
+ * taken from the caller: a MeroJs instance that cached its tokens before an
+ * earlier rotation would otherwise present an already-consumed token and revoke
+ * the family. Storage is the source of truth after the first rotation.
+ */
+export function rotateTokens(): Promise<TokenPair> {
+  if (inflight) return inflight;
+
+  const run = async (): Promise<TokenPair> => {
+    const accessToken = getAccessToken();
+    const refreshToken = getRefreshToken();
+    if (!accessToken || !refreshToken) {
+      throw new Error('Desktop is not authenticated');
+    }
+
+    const doFetch = originalFetch ?? fetch;
+    const baseUrl = (getSettings().nodeUrl ?? '').replace(/\/$/, '');
+    const response = await doFetch(`${baseUrl}/auth/refresh`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ access_token: accessToken, refresh_token: refreshToken }),
+    });
+
+    if (!response.ok) {
+      const reason = response.headers.get('x-auth-error') ?? String(response.status);
+      throw new Error(`Token refresh failed: ${reason}`);
+    }
+
+    const body = await response.json();
+    const rotated: TokenPair | undefined = body?.data;
+    if (!rotated?.access_token || !rotated?.refresh_token) {
+      throw new Error('Token refresh returned no tokens');
+    }
+
+    // Persist before any caller can read the store again, so the consumed token
+    // is never handed back out.
+    setAccessToken(rotated.access_token);
+    setRefreshToken(rotated.refresh_token);
+    setTokenExpiresAt(expiresAtFromJwt(rotated.access_token));
+
+    return rotated;
+  };
+
+  inflight = run().finally(() => {
+    inflight = null;
+  });
+  return inflight;
+}
+
+/**
+ * Collapse every `POST /auth/refresh` made from this window into one rotation.
+ *
+ * The desktop runs several MeroJs instances that each cache their own tokens and
+ * dedupe refreshes only among their own requests, so a burst of 401s used to
+ * produce several concurrent refresh POSTs carrying the same single-use token.
+ * Patching `fetch` is the only join point we have over instances we do not own —
+ * and it is what the app windows already do, via the injected proxy script.
+ *
+ * Every caller gets the same rotated pair back in the node's own wire format, so
+ * each MeroJs updates its cache and its token store exactly as it would have.
+ */
+export function installRefreshSingleFlight(): void {
+  if (originalFetch) return; // already installed
+  originalFetch = window.fetch.bind(window);
+  const passthrough = originalFetch;
+
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    const method =
+      init?.method ?? (typeof input === 'object' && 'method' in input ? input.method : 'GET');
+
+    if (!isRefreshRequest(url, method) || !getRefreshToken()) {
+      return passthrough(input as RequestInfo, init);
+    }
+
+    try {
+      const rotated = await rotateTokens();
+      return new Response(JSON.stringify({ data: rotated }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    } catch (error) {
+      return new Response(
+        JSON.stringify({ error: error instanceof Error ? error.message : 'refresh failed' }),
+        { status: 401, headers: { 'content-type': 'application/json' } },
+      );
+    }
+  };
+}
+
+/**
+ * Return an access token an app window can use, rotating only when needed.
+ *
+ * The common case is cheap: an app's access token expired but the desktop (or
+ * another app window, brokered through here) already rotated, so the stored one
+ * is fresh and we just hand it over — no `/auth/refresh` at all.
+ */
+export async function brokerAccessToken(): Promise<string> {
+  const accessToken = getAccessToken();
+  if (accessToken && accessTokenIsFresh()) return accessToken;
+  const rotated = await rotateTokens();
+  return rotated.access_token;
+}
+
+/**
+ * Serve `broker_token_refresh` requests relayed from app windows by Rust.
+ * Returns an unlisten function.
+ */
+export async function startTokenBroker(): Promise<() => void> {
+  return listen<{ requestId: string }>('calimero:token-request', async (event) => {
+    const requestId = event.payload?.requestId;
+    if (!requestId) return;
+
+    try {
+      const accessToken = await brokerAccessToken();
+      await invoke('resolve_token_request', { requestId, accessToken });
+    } catch (error) {
+      // Always answer: a dropped reply would leave the app window's fetch
+      // hanging until the Rust-side timeout.
+      await invoke('resolve_token_request', {
+        requestId,
+        error: error instanceof Error ? error.message : 'Token refresh failed',
+      }).catch(() => {});
+    }
+  });
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -4,7 +4,16 @@ import App from "./App";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { ToastProvider } from "./contexts/ToastContext";
 import ErrorBoundary from "./components/ErrorBoundary";
+import { installRefreshSingleFlight } from "./lib/token-broker";
 import "./index.css";
+
+// Before anything can construct a MeroJs and start talking to the node: refresh
+// tokens are single-use (calimero-network/core#3083), and the desktop runs
+// several MeroJs instances that each dedupe refreshes only among their own
+// requests. Without this, a burst of 401s fires several concurrent
+// POST /auth/refresh calls carrying the same token — the node consumes it once
+// and treats the rest as theft, revoking the family and logging everyone out.
+installRefreshSingleFlight();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/apps/desktop/src/utils/appUtils.test.ts
+++ b/apps/desktop/src/utils/appUtils.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const invoke = vi.fn();
+vi.mock('@tauri-apps/api/tauri', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
+
+const getByLabel = vi.fn();
+vi.mock('@tauri-apps/api/window', () => ({
+  WebviewWindow: { getByLabel: (...a: unknown[]) => getByLabel(...a) },
+}));
+
+// Keep the broker's own imports (Tauri event API, mero-client) inert — this
+// suite only needs the sentinel constant it exports.
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+vi.mock('../lib/mero-client', () => ({ apiClient: {} }));
+
+let developerMode = false;
+vi.mock('./settings', () => ({
+  getSettings: () => ({ nodeUrl: 'http://localhost:2528', developerMode }),
+}));
+
+const REAL_REFRESH_TOKEN = 'the-real-single-use-refresh-token';
+let accessToken: string | null;
+let refreshToken: string | null;
+vi.mock('../lib/token-storage', () => ({
+  getAccessToken: () => accessToken,
+  getRefreshToken: () => refreshToken,
+  getTokenExpiresAt: () => 1_700_000_000_000,
+}));
+
+import { openAppFrontend } from './appUtils';
+import { BROKERED_REFRESH_TOKEN } from '../lib/token-broker';
+
+/** The hash params of the URL `create_app_window` was invoked with. */
+function openedHash(): URLSearchParams {
+  expect(invoke).toHaveBeenCalledWith('create_app_window', expect.anything());
+  const [, args] = invoke.mock.calls[0] as [string, { url: string }];
+  return new URLSearchParams(new URL(args.url).hash.slice(1));
+}
+
+function openedUrl(): string {
+  const [, args] = invoke.mock.calls[0] as [string, { url: string }];
+  return args.url;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  developerMode = false;
+  accessToken = 'the-access-token';
+  refreshToken = REAL_REFRESH_TOKEN;
+  getByLabel.mockReturnValue(null);
+  invoke.mockResolvedValue(undefined);
+});
+
+describe('openAppFrontend token handoff', () => {
+  // The regression this whole change exists to prevent.
+  //
+  // Refresh tokens are single-use (calimero-network/core#3083). Every app
+  // webview is its own origin with its own localStorage and its own MeroJs, so
+  // shipping the real refresh token in the URL hash gave N independent holders
+  // one single-use token: the first to rotate consumes it, the next one presents
+  // a consumed token, and the node revokes the family — logging out the desktop
+  // and every app at once.
+  it('never puts the real refresh token in the app window URL', async () => {
+    await openAppFrontend('https://app.example.com/', 'Example');
+
+    expect(openedUrl()).not.toContain(REAL_REFRESH_TOKEN);
+    expect(openedHash().get('refresh_token')).not.toBe(REAL_REFRESH_TOKEN);
+  });
+
+  it('hands the app the access token plus the brokered sentinel', async () => {
+    await openAppFrontend('https://app.example.com/', 'Example');
+
+    const hash = openedHash();
+    expect(hash.get('access_token')).toBe('the-access-token');
+    expect(hash.get('refresh_token')).toBe(BROKERED_REFRESH_TOKEN);
+    expect(hash.get('node_url')).toBe('http://localhost:2528');
+  });
+
+  // Why a sentinel and not simply omitting `refresh_token`.
+  //
+  // Two independent things in the app-side stack turn an absent/empty refresh
+  // slot into a worse bug than the one this change fixes:
+  //
+  //   * mero-js `parseAuthCallback()` does `refresh_token: params.get('refresh_token') ?? ''`,
+  //     and mero-react's token store writes `token.refresh_token` UNCONDITIONALLY.
+  //     An access-token-only hash therefore makes an app overwrite its stored
+  //     refresh token with an empty string (until mero-react#45 ships).
+  //   * mero-js `performTokenRefresh()` throws "No refresh token available" and
+  //     never calls /auth/refresh at all when the slot is empty — so the app
+  //     could not be brokered either; it would just hard-fail on the first 401.
+  //
+  // Keeping the slot populated with an inert sentinel sidesteps both, and means
+  // this change needs no coordinated app/mero-react release.
+  it('keeps the refresh_token slot populated, so an app can never blank its own', async () => {
+    await openAppFrontend('https://app.example.com/', 'Example');
+
+    const slot = openedHash().get('refresh_token');
+    expect(slot).toBeTruthy();
+    expect(slot).not.toBe('');
+    expect(slot).toBe(BROKERED_REFRESH_TOKEN);
+  });
+
+  it('sends no tokens at all when the desktop is not logged in', async () => {
+    accessToken = null;
+    refreshToken = null;
+
+    await openAppFrontend('https://app.example.com/', 'Example');
+
+    const hash = openedHash();
+    expect(hash.has('access_token')).toBe(false);
+    expect(hash.has('refresh_token')).toBe(false);
+  });
+
+  it('forwards app context and dev mode without touching the refresh token', async () => {
+    developerMode = true;
+    await openAppFrontend('https://app.example.com/', 'Example', undefined, {
+      applicationId: 'app-1',
+      contextId: 'ctx-1',
+      executorPublicKey: 'pk-1',
+    });
+
+    const hash = openedHash();
+    expect(hash.get('app-id')).toBe('app-1');
+    expect(hash.get('context_id')).toBe('ctx-1');
+    expect(hash.get('executor_public_key')).toBe('pk-1');
+    expect(hash.get('dev_mode')).toBe('1');
+    expect(openedUrl()).not.toContain(REAL_REFRESH_TOKEN);
+  });
+});
+
+describe('openAppFrontend re-opening an existing window', () => {
+  it('focuses it and signals a re-read, carrying no credentials', async () => {
+    const emit = vi.fn().mockResolvedValue(undefined);
+    const existing = {
+      isMinimized: vi.fn().mockResolvedValue(true),
+      unminimize: vi.fn().mockResolvedValue(undefined),
+      show: vi.fn().mockResolvedValue(undefined),
+      setFocus: vi.fn().mockResolvedValue(undefined),
+      emit,
+    };
+    getByLabel.mockReturnValue(existing);
+
+    await openAppFrontend('https://app.example.com/', 'Example', undefined, {
+      applicationId: 'app-1',
+    });
+
+    expect(existing.unminimize).toHaveBeenCalled();
+    expect(existing.setFocus).toHaveBeenCalled();
+    // No new window, and no token re-injection over the app's live state.
+    expect(invoke).not.toHaveBeenCalledWith('create_app_window', expect.anything());
+
+    const [eventName, payload] = emit.mock.calls[0] as [string, Record<string, unknown>];
+    expect(eventName).toBe('calimero:auth-refresh');
+    expect(JSON.stringify(payload)).not.toContain(REAL_REFRESH_TOKEN);
+    expect(JSON.stringify(payload)).not.toContain('the-access-token');
+  });
+});

--- a/apps/desktop/src/utils/appUtils.ts
+++ b/apps/desktop/src/utils/appUtils.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/tauri";
 import { WebviewWindow } from "@tauri-apps/api/window";
 import { getSettings } from "./settings";
 import { getAccessToken, getRefreshToken, getTokenExpiresAt } from "../lib/token-storage";
+import { BROKERED_REFRESH_TOKEN } from "../lib/token-broker";
 
 /**
  * Extract a human-readable message from a Tauri command error.
@@ -80,14 +81,26 @@ export async function openAppFrontend(
     const settings = getSettings();
     const nodeUrl = (settings.nodeUrl ?? '').replace(/\/$/, '');
 
-    // Build URL hash with node_url and tokens so the app can skip the auth flow
+    // Build URL hash with node_url and the access token so the app can skip the
+    // auth flow.
+    //
+    // The REAL refresh token is deliberately not shared. Refresh tokens are
+    // single-use (calimero-network/core#3083): each POST /auth/refresh consumes
+    // the presented token, and re-presenting a consumed one is treated as theft
+    // — the node revokes the whole token family and every holder is logged out.
+    // Each app webview is its own origin with its own localStorage and its own
+    // MeroJs, so handing them all the same refresh token guarantees exactly that
+    // collision. Instead the desktop keeps the refresh token and stays the sole
+    // rotator: apps get BROKERED_REFRESH_TOKEN, and their /auth/refresh calls are
+    // intercepted by the injected proxy script and served by the desktop.
+    // See src/lib/token-broker.ts.
     const hashParams = new URLSearchParams();
     hashParams.set('node_url', nodeUrl);
     const accessToken = getAccessToken();
     const refreshToken = getRefreshToken();
     if (accessToken && refreshToken) {
       hashParams.set('access_token', accessToken);
-      hashParams.set('refresh_token', refreshToken);
+      hashParams.set('refresh_token', BROKERED_REFRESH_TOKEN);
       hashParams.set('expires_at', String(getTokenExpiresAt() ?? Date.now() + 3600_000));
     }
     if (context?.applicationId) hashParams.set('app-id', context.applicationId);

--- a/apps/desktop/src/utils/proxyScript.test.ts
+++ b/apps/desktop/src/utils/proxyScript.test.ts
@@ -12,6 +12,13 @@ const RAW_PROXY_SCRIPT = readFileSync(
   "utf-8"
 );
 
+// The script runs in a webview, where ProgressEvent is a browser global. The
+// vitest environment is `node`, which has Event but not ProgressEvent — so the
+// XHR path would ReferenceError here for reasons that never occur in the app.
+if (typeof (globalThis as any).ProgressEvent === "undefined") {
+  (globalThis as any).ProgressEvent = class ProgressEvent extends Event {};
+}
+
 /**
  * Execute the proxy IIFE with a fake `window` object.
  * Using `new Function('window', src)` means all `window.*` accesses inside
@@ -24,10 +31,20 @@ function injectProxy(mockWindow: any, nodeUrl = "http://localhost:2428") {
 }
 
 function makeMockWindow() {
-  // Provide a minimal XMLHttpRequest stub so the script's XHR-wrapping code
-  // doesn't throw on init (we don't exercise XHR in these tests).
-  function FakeXHR() {}
-  FakeXHR.prototype = {};
+  // Minimal XMLHttpRequest stub. The script wraps open/send/setRequestHeader and
+  // dispatches events on the instance, so those must exist for it to wrap them.
+  function FakeXHR(this: any) {
+    this.onload = null;
+    this.onerror = null;
+    this.onreadystatechange = null;
+  }
+  FakeXHR.prototype = {
+    open() {},
+    send() {},
+    setRequestHeader() {},
+    dispatchEvent() {},
+    addEventListener() {},
+  };
   return {
     __TAURI_FETCH_PROXY_INJECTED__: undefined as boolean | undefined,
     // Stored by the script as `originalFetch` — returned for non-proxied URLs.
@@ -156,5 +173,131 @@ describe("proxy_script SSE routing", () => {
       (call) => call[0] === "proxy_sse_stream"
     );
     expect(sseCalls.length).toBe(0);
+  });
+});
+
+// ─── Brokered /auth/refresh (calimero-network/core#3083) ────────────────────
+//
+// Refresh tokens are single-use: whoever POSTs /auth/refresh consumes the token
+// and gets a new one, and re-presenting a consumed one revokes the entire
+// family. App windows therefore hold a sentinel, not a real refresh token —
+// their /auth/refresh calls must be answered by the desktop, and must never
+// reach the node.
+describe("proxy_script /auth/refresh brokering", () => {
+  const BROKERED_REFRESH_TOKEN = "calimero-desktop-brokered-refresh-token";
+
+  function tauriWindow(invokeImpl: (cmd: string, args: any) => Promise<unknown>) {
+    const mockWindow = makeMockWindow();
+    mockWindow.__TAURI_INVOKE__ = vi.fn(invokeImpl);
+    mockWindow.__TAURI__ = { event: { listen: vi.fn(async () => vi.fn()) } };
+    // `originalFetch` is captured by the script at injection time; hold on to it
+    // so a test can prove the sentinel never went out over the network.
+    mockWindow.__originalFetch = mockWindow.fetch;
+    return mockWindow;
+  }
+
+  it("routes an app's POST /auth/refresh to the desktop instead of the node", async () => {
+    const mockWindow = tauriWindow(async (cmd) =>
+      cmd === "broker_token_refresh" ? "fresh-access-token" : { status: 200, headers: {}, body: "{}" }
+    );
+    injectProxy(mockWindow);
+
+    const response = await mockWindow.fetch("http://localhost:2428/auth/refresh", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ access_token: "stale", refresh_token: BROKERED_REFRESH_TOKEN }),
+    });
+
+    const commands = mockWindow.__TAURI_INVOKE__.mock.calls.map((c: any[]) => c[0]);
+    expect(commands).toContain("broker_token_refresh");
+    // The sentinel must never be forwarded to the node.
+    expect(commands).not.toContain("proxy_http_request");
+
+    // Shaped like a real /auth/refresh reply so unmodified mero-js parses it.
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      data: {
+        access_token: "fresh-access-token",
+        refresh_token: BROKERED_REFRESH_TOKEN,
+      },
+    });
+  });
+
+  it("brokers /auth/refresh even when the node is not on localhost", async () => {
+    const mockWindow = tauriWindow(async () => "fresh-access-token");
+    injectProxy(mockWindow, "https://node.example.com");
+
+    const response = await mockWindow.fetch("https://node.example.com/auth/refresh", {
+      method: "POST",
+      body: "{}",
+    });
+
+    expect(mockWindow.__TAURI_INVOKE__).toHaveBeenCalledWith("broker_token_refresh");
+    expect(response.status).toBe(200);
+    // A remote node is not "localhost", so without the explicit auth-refresh
+    // route this would have gone straight out over the network with the sentinel.
+    expect(mockWindow.__originalFetch).not.toHaveBeenCalled();
+  });
+
+  it("does not broker a GET to /auth/refresh, nor other auth routes", async () => {
+    const mockWindow = tauriWindow(async () => ({ status: 200, headers: {}, body: "{}" }));
+    injectProxy(mockWindow);
+
+    await mockWindow.fetch("http://localhost:2428/auth/refresh", { method: "GET" }).catch(() => {});
+    await mockWindow
+      .fetch("http://localhost:2428/auth/login", { method: "POST", body: "{}" })
+      .catch(() => {});
+
+    const commands = mockWindow.__TAURI_INVOKE__.mock.calls.map((c: any[]) => c[0]);
+    expect(commands).not.toContain("broker_token_refresh");
+  });
+
+  it("fails closed with a 401 rather than leaking the sentinel when IPC is unavailable", async () => {
+    const mockWindow = makeMockWindow(); // no __TAURI_INVOKE__ at all
+    const originalFetch = mockWindow.fetch;
+    injectProxy(mockWindow);
+
+    const response = await mockWindow.fetch("http://localhost:2428/auth/refresh", {
+      method: "POST",
+      body: JSON.stringify({ refresh_token: BROKERED_REFRESH_TOKEN }),
+    });
+
+    expect(response.status).toBe(401);
+    // Must NOT fall back to the network: the app holds the sentinel, not a real
+    // refresh token, so there is nothing useful to send and nothing to leak.
+    expect(originalFetch).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a desktop-side refresh failure as a 401", async () => {
+    const mockWindow = tauriWindow(async (cmd) => {
+      if (cmd === "broker_token_refresh") throw new Error("Desktop is not authenticated");
+      return { status: 200, headers: {}, body: "{}" };
+    });
+    injectProxy(mockWindow);
+
+    const response = await mockWindow.fetch("http://localhost:2428/auth/refresh", {
+      method: "POST",
+      body: "{}",
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.text()).toContain("Desktop is not authenticated");
+  });
+
+  it("brokers an XHR POST to /auth/refresh too", async () => {
+    const mockWindow = tauriWindow(async () => "fresh-access-token");
+    injectProxy(mockWindow);
+
+    const xhr = new mockWindow.XMLHttpRequest();
+    xhr.open("POST", "http://localhost:2428/auth/refresh");
+    const done = new Promise<void>((resolve) => { xhr.onload = () => resolve(); });
+    xhr.send(JSON.stringify({ refresh_token: BROKERED_REFRESH_TOKEN }));
+    await done;
+
+    const commands = mockWindow.__TAURI_INVOKE__.mock.calls.map((c: any[]) => c[0]);
+    expect(commands).toContain("broker_token_refresh");
+    expect(commands).not.toContain("proxy_http_request");
+    expect(xhr.status).toBe(200);
+    expect(JSON.parse(xhr.responseText).data.access_token).toBe("fresh-access-token");
   });
 });


### PR DESCRIPTION
## Why

[calimero-network/core#3083](https://github.com/calimero-network/core/pull/3083) makes refresh tokens **single-use**: every `POST /auth/refresh` consumes the presented refresh token and mints a new one. Re-presenting a consumed token is treated as theft — the node revokes the **entire token family** and replies `401` with `x-auth-error: token_reuse`, so *every* holder is logged out.

The desktop broke that rule in two independent ways.

### 1. Across webviews (the reported bug)

`openAppFrontend` put the **real refresh token** in every app window's SSO URL hash:

```ts
hashParams.set('access_token', accessToken);
hashParams.set('refresh_token', refreshToken);   // ← the real, single-use token
```

Every app webview is a separate origin with its own `localStorage` and its own `MeroJs`. So the desktop *and every open app* each held the same single-use refresh token and each would independently rotate it. First one to refresh consumes it; the next presents a consumed token → `token_reuse` → family revoked → desktop and all apps hard-logged-out. Re-opening an app also re-injected the desktop's (possibly stale) token over the app's live one.

mero-js's own single-flight + `navigator.locks` fix ([mero-js#67](https://github.com/calimero-network/mero-js/pull/67)) cannot help here — those coordinate holders **within one origin**, and each webview is a different one.

### 2. Within the desktop itself (found while fixing the e2e mock)

The desktop runs **several** `MeroJs` instances — the lazily-created `apiClient` default, the one from `createClientAsync`, plus React StrictMode double-mounting — and each dedupes refreshes only among *its own* requests. Once the e2e mock actually modelled single-use rotation, it caught this immediately: a burst of 401s fired **six concurrent `POST /auth/refresh` calls all carrying the same token**. One succeeded; the other five were reuse → family revoked. The desktop could not have stayed logged in against a core#3083 node even with zero apps open.

## Before → After

| | Before | After |
|---|---|---|
| Refresh token in the app-window URL hash | The real, single-use token | Opaque `BROKERED_REFRESH_TOKEN` sentinel — never a credential |
| Who can rotate | Desktop **and** every app webview, independently | **Only** the desktop |
| App's `POST /auth/refresh` | Went to the node with a shared token → `token_reuse` | Intercepted by the injected proxy script → `broker_token_refresh` Tauri command → answered by the desktop |
| Concurrent refreshes inside the desktop | 6 concurrent POSTs with the same token → family revoked | One single-flight rotation; all callers share its result |
| Stale cached token replayed | Possible (each MeroJs cached its own) | Impossible — the store is re-read **inside** the single-flight |
| Re-opening an app | Re-injected the desktop's stale refresh token over the app's live one | Re-injects only the sentinel, which is inert |
| e2e refresh mock | Routed `**/auth/refresh-token` — **matches nothing**; refresh was never exercised | Routes the real `**/auth/refresh`, models single-use rotation + `token_reuse` |

## Design trade-off

The brief offered two options. I implemented the **preferred one: the desktop is the sole rotator**, and did *not* take the per-window `client-key` alternative.

**Why not per-window client keys.** It would still leave N independent rotators (one family per window). That is safe against `token_reuse`, but it multiplies the token families the node must track, adds a `/admin/client-key` round-trip to every app open, and leaves each window able to log itself out independently. It also would not have fixed bug 2 — the desktop's *own* concurrent refreshes — which is the more urgent of the two. Worth noting: `generateClientKey` returns `{ keyId, permissions }`, **not** a token pair, so minting a usable per-window family is not the one-call operation the brief assumed.

**How the chosen design avoids an app-side change.** The obvious objection to "send only the access token" is that mero-js's `performTokenRefresh()` **throws `No refresh token available` and never calls `/auth/refresh` when the slot is empty** — an app with no refresh token could not refresh *at all*, it would just hard-fail on the first 401. That is what the sentinel is for: it keeps the app on its normal refresh code path, and the proxy script — which already intercepts *every* app→node request — brokers that call to the desktop. The reply is returned in the node's exact wire format, so **unmodified** mero-js/mero-react apps work with no changes and no version bump. The sentinel never reaches the network, and even if it leaked it is not a valid token and (not being a real `jti`) cannot trip reuse detection.

The same single-flight then also serves the desktop's own refreshes, via a `fetch` patch in the desktop renderer — the only join point available across `MeroJs` instances we don't own, and exactly what the app windows already do via the injected proxy script.

## Changes

- **`src/lib/token-broker.ts`** (new) — `rotateTokens()` single-flight (re-reads the token store before POSTing, so a stale caller cannot replay a consumed token); `installRefreshSingleFlight()` patches `fetch` so every desktop `MeroJs` shares one rotation; `brokerAccessToken()` serves app windows, rotating only when needed; `startTokenBroker()` answers relayed requests. Exports `BROKERED_REFRESH_TOKEN`.
- **`src/utils/appUtils.ts:88-103`** — hash carries the access token + the sentinel; the real refresh token never leaves the desktop.
- **`src/main.tsx:11`** — install the single-flight before any `MeroJs` can be constructed.
- **`src/App.tsx:407-415`** — run the broker for the app's lifetime.
- **`src-tauri/src/proxy_script.js`** — `isAuthRefresh()` + `brokerTokenRefresh()`; `POST /auth/refresh` is answered by the desktop and **never** forwarded to the node (fails closed with a 401 if IPC is unavailable, rather than leaking the sentinel). Hooked in at `proxyRequest()`, which both the `fetch` and XHR interceptors funnel through, and routed even for a non-localhost node.
- **`src-tauri/src/main.rs`** — `broker_token_refresh` (relays to the desktop window, 20s timeout) and `resolve_token_request`, plus a `TokenBrokerRegistry` mirroring the existing `SseCancelRegistry` pattern. Returns an access token only — never a refresh token.

### Tests

- **`e2e/fixtures/mock-data.ts:266`** — `**/auth/refresh-token` → `**/auth/refresh`. The old glob matched nothing, so the refresh path was untested and the 401 test was passing for the wrong reason.
- **`e2e/fixtures/helpers.ts`** — `mockSingleUseRefresh()` models core#3083 faithfully: a new pair per call, `token_reuse` + permanent family revocation on replay. Also `AUTH_ERROR_HEADERS`, because `x-auth-error` is load-bearing — mero-js only auto-refreshes on `token_expired`, and the browser hides the header cross-origin unless the node sends `Access-Control-Expose-Headers`. A mock that omits it silently disables every refresh path.
- New: `src/lib/token-broker.test.ts` (17), `src/utils/appUtils.test.ts` (5, incl. "never puts the real refresh token in the app window URL"), `proxyScript.test.ts` +6, `auth.spec.ts` +2.

No existing test was weakened.

## How to test

```bash
pnpm install
pnpm --filter desktop build        # tsc + vite
pnpm --filter desktop test:unit    # 104 passed (was 77)
pnpm --filter desktop test:e2e     # 118 passed (was 116)
cd apps/desktop/src-tauri && cargo check
```

> `cargo check` standalone fails on `master` too (the Tauri v1 CLI auto-syncs allowlist features; bare cargo trips the `http-all` check). Verified with `TAURI_CONFIG='{"tauri":{"allowlist":{"http":{"all":true,"request":true}}}}' cargo check` — compiles clean, only pre-existing warnings.

Manual, against a core#3083 node: log in, open two apps, leave them until the access token expires. Before: the first refresh wins and everything else is logged out. After: exactly one `POST /auth/refresh` in the node log per rotation, and both apps keep working.

The regression test that matters: `auth.spec.ts` › *"desktop keeps the rotated refresh token and never replays a consumed one"* fails on `master` (`familyRevoked: true`, six refresh POSTs) and passes here.

## Not blocked on mero-react#45 — and why the sentinel is load-bearing

There is a real hazard nearby, and it is worth being explicit that this PR does **not** step in it.

`parseAuthCallback()` in mero-js does `refresh_token: params.get('refresh_token') ?? ''` ([`dist/auth/index.js:17`]), and until [calimero-network/mero-react#45](https://github.com/calimero-network/mero-react/pull/45) lands, mero-react's SSO handler writes `token.refresh_token` to its store **unconditionally** ([`dist/index.js:103`]). So a desktop that simply **dropped** `refresh_token` from the app-window hash would make every app on today's mero-react overwrite its stored refresh token with an **empty string** — destroying the session's ability to refresh at all. That is strictly worse than the bug being fixed here, and it would be a hard release-ordering dependency.

**This PR does not drop the parameter.** It keeps `refresh_token` present and **non-empty**, holding the inert `BROKERED_REFRESH_TOKEN` sentinel:

```ts
hashParams.set('refresh_token', BROKERED_REFRESH_TOKEN);   // never '' , never the real token
```

so `?? ''` never fires, and mero-react persists the sentinel rather than blanking the slot. Nothing downstream has to change and nothing has to ship first.

The sentinel is doing double duty, defending the two mirror-image failure modes of an empty slot:

| Empty/absent `refresh_token` would… | …because |
|---|---|
| make the app **blank its stored refresh token** | mero-react writes `refresh_token` unconditionally; mero-js yields `''` for a missing param |
| make the app **never call `/auth/refresh` at all** | mero-js `performTokenRefresh()` throws `No refresh token available` on an empty slot — so it could not even be brokered; it would hard-fail on the first 401 |

Locked down by a regression test — *"keeps the refresh_token slot populated, so an app can never blank its own"* (`appUtils.test.ts`) — so a later "simplification" to an access-token-only hash cannot silently reintroduce either failure.

**mero-react#45 is complementary, not a prerequisite:** it makes the SSO callback merge rather than replace, which is the right hardening regardless. This PR is safe to merge and release before or after it, in either order.

## Depends on

- calimero-network/core#3083 — single-use refresh tokens (the behaviour this adapts to)
- calimero-network/mero-js#67 — single-flight refresh + `token_reuse` handling. **Not required to merge this** (the desktop pins mero-js 2.x and the fix here is independent), but it is what makes *in-origin* refreshes safe once the desktop moves to mero-js 7.x.
- calimero-network/mero-react#45 — SSO callback merges instead of replacing. **Not a blocker** (see above: the sentinel keeps the hash slot non-empty, so no app can blank its stored refresh token), but it removes the sharp edge for good.

## Note for core

For a browser/webview client to react to `token_reuse` at all, the node must send `Access-Control-Expose-Headers: x-auth-error` — otherwise the browser hides the header from JS and mero-js#67's terminal-revocation path can never fire cross-origin. Worth confirming core#3083 does this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
