### PR TITLE
fix(desktop): first login on core rc.14+ (auto-wire setup code); bump app 0.0.68, merod rc.15

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
  "futures-util",
  "keyring",
  "log",
+ "rand 0.8.6",
  "regex",
  "reqwest",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.5", features = [ "http-all", "system-tray", "updater", "process-relaunch", "shell-open", "window-all", "dialog-all", "icon-png"] }
+tauri = { version = "1.5", features = [ "system-tray", "updater", "process-relaunch", "shell-open", "window-all", "dialog-all", "icon-png"] }
 tauri-plugin-autostart = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -24,6 +24,7 @@ env_logger = "0.11"
 dirs = "5.0"
 toml = "0.8"
 regex = "1.10"
+rand = "0.8"
 thiserror = "1.0"
 keyring = "2"
 tauri-plugin-deep-link = "0.1"

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1294,12 +1294,20 @@ async fn start_merod(
                 }
             }
             
+            // Backfill the first-login setup code (core#3221) for nodes whose
+            // merod predates auto-generation (core#3270), so the first login
+            // on a fresh node can create the admin account instead of dying
+            // on an opaque 401.
+            if ensure_bootstrap_secret(&mut config) {
+                info!("[Merod] Generated a first-login setup code into config.toml");
+            }
+
             // Write updated config back
             let updated_config = toml::to_string_pretty(&config)
                 .map_err(|e| TauriError::with_details(TauriErrorCode::ConfigWriteError, "Failed to serialize config.toml", e.to_string()))?;
             std::fs::write(&config_path, updated_config)
                 .map_err(|e| TauriError::with_details(TauriErrorCode::ConfigWriteError, "Failed to write config.toml", e.to_string()))?;
-            
+
             info!("[Merod] Updated config.toml with server_port={} and swarm_port={}", server_port, swarm_port);
         }
     }
@@ -2349,6 +2357,101 @@ async fn get_merod_binary_version(app_handle: tauri::AppHandle) -> Result<String
     Ok(get_merod_version_at(&merod_binary).await.unwrap_or_else(|| "unknown".to_string()))
 }
 
+/// Ensure the node's first-login setup code (embedded-auth bootstrap secret,
+/// core#3221) exists in its parsed config.toml. Since core rc.14 a fresh node
+/// refuses to mint its first root key unless the login presents this secret;
+/// newer merod generates one at init (core#3270), but the rc.14 binary this
+/// app bundles does not — so the app backfills it before starting the node.
+/// A configured non-empty secret is left untouched; configs without an
+/// embedded_auth section (proxy-mode nodes) are skipped. Returns true when a
+/// secret was inserted.
+fn ensure_bootstrap_secret(config: &mut toml::Value) -> bool {
+    let Some(embedded_auth) = config
+        .get_mut("server")
+        .and_then(|s| s.get_mut("embedded_auth"))
+        .and_then(|a| a.as_table_mut())
+    else {
+        return false;
+    };
+
+    let user_password = embedded_auth
+        .entry("user_password")
+        .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+    let Some(user_password) = user_password.as_table_mut() else {
+        return false;
+    };
+
+    let missing = user_password
+        .get("bootstrap_secret")
+        .and_then(|v| v.as_str())
+        .map_or(true, str::is_empty);
+    if !missing {
+        return false;
+    }
+
+    let secret: String = {
+        use rand::Rng;
+        let bytes: [u8; 16] = rand::thread_rng().gen();
+        bytes.iter().map(|b| format!("{b:02x}")).collect()
+    };
+    let _ = user_password.insert(
+        "bootstrap_secret".to_string(),
+        toml::Value::String(secret),
+    );
+    true
+}
+
+/// Read the node's first-login setup code (embedded-auth bootstrap secret)
+/// from its config.toml, so the login flow can transparently present it when
+/// creating the first account on a fresh node (core#3221). Returns None when
+/// the node has no embedded-auth config or no secret; the caller then simply
+/// logs in without one, same as before rc.14.
+#[tauri::command]
+async fn get_bootstrap_secret(
+    node_name: String,
+    home_dir: Option<String>,
+) -> Result<Option<String>, TauriError> {
+    validate_node_name(&node_name).map_err(|e| TauriError::new(TauriErrorCode::InvalidInput, e))?;
+
+    let home_dir_path = if let Some(dir) = home_dir {
+        let expanded = if dir.starts_with("~") {
+            if let Some(home) = dirs::home_dir() {
+                dir.replacen("~", &home.to_string_lossy(), 1)
+            } else {
+                dir
+            }
+        } else {
+            dir
+        };
+        std::path::PathBuf::from(expanded)
+    } else {
+        dirs::home_dir()
+            .ok_or_else(|| TauriError::new(TauriErrorCode::HomeDirNotFound, "Failed to get home directory"))?
+            .join(".calimero")
+    };
+
+    let config_path = home_dir_path.join(&node_name).join("config.toml");
+    if !config_path.exists() {
+        return Ok(None);
+    }
+
+    let config_content = tokio::fs::read_to_string(&config_path)
+        .await
+        .map_err(|e| TauriError::with_details(TauriErrorCode::FileReadError, "Failed to read config.toml", e.to_string()))?;
+    let config: toml::Value = config_content
+        .parse::<toml::Value>()
+        .map_err(|e| TauriError::with_details(TauriErrorCode::ConfigParseError, "Failed to parse config.toml", e.to_string()))?;
+
+    Ok(config
+        .get("server")
+        .and_then(|s| s.get("embedded_auth"))
+        .and_then(|a| a.get("user_password"))
+        .and_then(|u| u.get("bootstrap_secret"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string))
+}
+
 /// Read merod logs for a node. Logs are only available for nodes started by the app.
 #[tauri::command]
 async fn get_merod_logs(
@@ -3008,6 +3111,7 @@ fn main() {
             init_merod_node,
             detect_running_merod_nodes,
             get_merod_logs,
+            get_bootstrap_secret,
             get_merod_binary_version,
             download_and_replace_merod,
             set_tray_icon_connected,
@@ -3031,7 +3135,80 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{validate_allowed_url, score_merod_asset, merod_target_triple};
+    use super::{
+        ensure_bootstrap_secret, merod_target_triple, score_merod_asset, validate_allowed_url,
+    };
+
+    #[test]
+    fn bootstrap_secret_backfilled_when_missing() {
+        let mut config: toml::Value = r#"
+[server.embedded_auth.user_password]
+min_password_length = 8
+"#
+        .parse()
+        .unwrap();
+        assert!(ensure_bootstrap_secret(&mut config));
+        let secret = config["server"]["embedded_auth"]["user_password"]["bootstrap_secret"]
+            .as_str()
+            .unwrap();
+        assert_eq!(secret.len(), 32);
+        assert!(secret.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn bootstrap_secret_backfilled_when_user_password_table_absent() {
+        let mut config: toml::Value = r#"
+[server.embedded_auth.jwt]
+issuer = "calimero-auth"
+"#
+        .parse()
+        .unwrap();
+        assert!(ensure_bootstrap_secret(&mut config));
+        assert!(config["server"]["embedded_auth"]["user_password"]["bootstrap_secret"]
+            .as_str()
+            .is_some());
+    }
+
+    #[test]
+    fn bootstrap_secret_kept_when_already_configured() {
+        let mut config: toml::Value = r#"
+[server.embedded_auth.user_password]
+bootstrap_secret = "operator-provisioned"
+"#
+        .parse()
+        .unwrap();
+        assert!(!ensure_bootstrap_secret(&mut config));
+        assert_eq!(
+            config["server"]["embedded_auth"]["user_password"]["bootstrap_secret"]
+                .as_str()
+                .unwrap(),
+            "operator-provisioned"
+        );
+    }
+
+    #[test]
+    fn bootstrap_secret_regenerated_when_blank() {
+        // An empty string disables the bootstrap gate server-side, so treat it
+        // as missing rather than leaving first login permanently broken.
+        let mut config: toml::Value = r#"
+[server.embedded_auth.user_password]
+bootstrap_secret = ""
+"#
+        .parse()
+        .unwrap();
+        assert!(ensure_bootstrap_secret(&mut config));
+    }
+
+    #[test]
+    fn bootstrap_secret_skipped_without_embedded_auth() {
+        let mut config: toml::Value = r#"
+[server]
+auth_mode = "proxy"
+"#
+        .parse()
+        .unwrap();
+        assert!(!ensure_bootstrap_secret(&mut config));
+    }
 
     #[test]
     fn test_allowed_localhost_urls() {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.67"
+    "version": "0.0.68"
   },
   "tauri": {
     "allowlist": {

--- a/apps/desktop/src/components/LoginView.tsx
+++ b/apps/desktop/src/components/LoginView.tsx
@@ -4,6 +4,8 @@ import { setAccessToken, setRefreshToken, setTokenExpiresAt } from '../lib/token
 import type { Provider } from '../lib/mero-client';
 import { ProviderSelector } from './ProviderSelector';
 import { UsernamePasswordForm } from './UsernamePasswordForm';
+import { getBootstrapSecret } from '../utils/merod';
+import { getSettings } from '../utils/settings';
 
 export interface LoginViewProps {
   onSuccess?: () => void;
@@ -57,13 +59,37 @@ export function LoginView({ onSuccess, onError, variant = 'light' }: LoginViewPr
       setUsernamePasswordLoading(true);
       setError(null);
 
+      // Since core rc.14 (core#3221) a fresh node only creates its first
+      // account when the login presents the node's bootstrap secret ("setup
+      // code"), which lives in the config.toml this app manages. Read it
+      // transparently so first-run stays a plain username/password login.
+      // Once an account exists the node ignores the value, and for remote
+      // or pre-rc.14 nodes it resolves to null and is simply omitted —
+      // matching the pre-rc.14 request shape exactly.
+      let bootstrapSecret: string | null = null;
+      const settings = getSettings();
+      if (settings.useEmbeddedNode && settings.embeddedNodeName) {
+        try {
+          bootstrapSecret = await getBootstrapSecret(
+            settings.embeddedNodeName,
+            settings.embeddedNodeDataDir,
+          );
+        } catch (err) {
+          console.warn('Could not read first-login setup code:', err);
+        }
+      }
+
       const tokenResponse = await apiClient.auth.requestToken({
         auth_method: 'user_password',
         public_key: username,
         client_name: 'calimero-desktop',
         timestamp: Date.now(),
         permissions: [],
-        provider_data: { username, password },
+        provider_data: {
+          username,
+          password,
+          ...(bootstrapSecret ? { bootstrap_secret: bootstrapSecret } : {}),
+        },
       });
 
       if (tokenResponse.error) {

--- a/apps/desktop/src/utils/merod.ts
+++ b/apps/desktop/src/utils/merod.ts
@@ -111,6 +111,20 @@ export async function getMerodLogs(
 }
 
 /**
+ * Read the node's first-login setup code (embedded-auth bootstrap secret,
+ * core#3221) from its config.toml. Fresh rc.14+ nodes only mint their first
+ * account when the login presents this code; the app reads it transparently
+ * so first-run stays a plain username/password login. Returns null when the
+ * node has no secret configured (pre-rc.14 nodes, proxy-mode nodes).
+ */
+export async function getBootstrapSecret(
+  nodeName: string,
+  homeDir?: string
+): Promise<string | null> {
+  return await invoke('get_bootstrap_secret', { nodeName, homeDir });
+}
+
+/**
  * Kill all merod processes on the system. Call before total nuke.
  */
 export async function killAllMerodProcesses(): Promise<string> {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.14"
+    "version": "0.11.0-rc.15"
 }


### PR DESCRIPTION
## Problem

core rc.14 ([core#3221](https://github.com/calimero-network/core/pull/3221)) gates a fresh node's first root key behind an out-of-band bootstrap secret. The desktop app neither provisions one nor sends one, so **first-run login on rc.14 dies with an opaque 401 `Invalid username or password`** — for every new user.

## Fix — first-run UX back to "type username/password, done"

- `start_merod` backfills a generated 128-bit hex setup code into `[server.embedded_auth.user_password] bootstrap_secret` during its existing config.toml rewrite — so this works with the **bundled rc.14 merod today**, no core release needed. Newer merod generates the code at init itself ([core#3270](https://github.com/calimero-network/core/pull/3270)) and is left untouched, as is any operator-provisioned value; blank strings are treated as missing because they disable the gate server-side.
- New `get_bootstrap_secret` command reads the code back from the node's config.toml; `LoginView` presents it transparently as `provider_data.bootstrap_secret` when signing in to the embedded node. Once the first account exists the node ignores the value; for remote or pre-rc.14 nodes it resolves to `null` and is omitted, making the request byte-identical to before.

Related client work: [auth-frontend#40](https://github.com/calimero-network/auth-frontend/pull/40) adds the setup-code field + `setup-code` URL param for browser flows.

## Verification

- 5 new Rust unit tests for the backfill (missing → generated 32-hex; absent `user_password` table → created; operator value → kept; blank → regenerated; proxy-mode config → untouched). `cargo test`: 23/23.
- `vitest`: 106/106; `pnpm build` + `tauri build --debug` clean (remaining warnings pre-existing).
- Wire shape verified against a live node: `POST /auth/token` with `provider_data.bootstrap_secret` mints the first root key and returns tokens; plain logins succeed afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)