### PR TITLE
chore: bump app to 0.0.69, bundled merod to 0.11.0-rc.16

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.68"
+    "version": "0.0.69"
   },
   "tauri": {
     "allowlist": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.15"
+    "version": "0.11.0-rc.16"
 }


### PR DESCRIPTION
App **0.0.68 → 0.0.69**, bundled merod **rc.15 → rc.16** (merod-config.json + package.json + tauri.conf.json).

rc.16 ([core#3274](https://github.com/calimero-network/core/pull/3274)) exists to re-embed the fixed auth-frontend into merod — the setup-code field wired on the app-callback flow and the registry-trusted callback allowlist ([auth-frontend#40](https://github.com/calimero-network/auth-frontend/pull/40)). Desktop's own login already works on 0.0.68 (it injects the secret itself); this bump gets the **browser-served login pages** on desktop-managed nodes fixed too.

⚠️ Merge order: auth-frontend#40 → auth-frontend release → core#3274 merged + **Release Binaries published** → this PR. Then tag v0.0.69 on master head to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)