### PR TITLE
fix(desktop): redesign onboarding + login, stop progress-bar flicker (v0.0.71)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/plan-logs.md
+++ b/apps/desktop/plan-logs.md
@@ -1,0 +1,216 @@
+# Plan: Node log rotation, size cap, cleanup & viewer performance
+
+**Scope:** the Calimero Desktop app (`apps/desktop`) and how it captures, stores, reads
+and displays a merod node's logs.
+
+**Goal (from the request):** _"Cleanup and cap the logs — logs should be rotated and
+also cleaned up."_ Concretely:
+
+1. Hard-cap on-disk logs at **~100 MB per node** (configurable).
+2. **Rotate** the active log into numbered segments instead of one unbounded file.
+3. **Delete** old segments (and stale per-node log dirs) automatically.
+4. Make the **Nodes-tab log viewer** fast even when a node has logged a lot.
+
+This is a design/implementation plan only — no behaviour is changed by this document.
+
+---
+
+## 1. Current state (why it's a problem)
+
+### 1a. Write path — one unbounded append file
+- `start_merod` (`src-tauri/src/main.rs` ~L1143) creates
+  `~/.calimero/<node>/logs/merod.log` with
+  `OpenOptions::new().create(true).append(true)` (~L1310–1330) and hands the **raw
+  file descriptor** to the child: `cmd.stdout(Stdio::from(log_file_stdout))` /
+  `cmd.stderr(... try_clone())` (~L1355–1362), then `cmd.spawn()` (~L1365).
+- Verbosity is set by the `debugLogs` setting → `RUST_LOG=debug|info` (~L1339–1344).
+  Debug mode fills the file **much** faster.
+- **There is no rotation, size check, or cleanup anywhere** (confirmed: no
+  `set_len`/`metadata(size)`/`rotate` logic touches `merod.log`). The file only ever
+  disappears when the whole data dir is nuked (`delete_calimero_data_dir`, ~L2533).
+
+> **Key constraint:** merod owns the FD and writes to it directly. The app never sees
+> the byte stream. Any rotation strategy has to account for a live writer holding the
+> file open (see §2).
+
+### 1b. Read path — reads the entire file to return 500 lines
+- `get_merod_logs(node_name, home_dir, lines)` (`main.rs` ~L2376–2421):
+  ```rust
+  let lines = lines.unwrap_or(500).min(10_000);
+  let content = tokio::fs::read_to_string(&log_path).await?;   // WHOLE file into RAM
+  let all_lines: Vec<&str> = content.lines().collect();         // Vec of every line
+  let start = all_lines.len().saturating_sub(lines as usize);
+  Ok(all_lines[start..].join("\n"))
+  ```
+  At 100 MB this reads 100 MB into memory and allocates a vector of every line just to
+  keep the last 500. This is the main backend scaling pain.
+
+### 1c. Frontend viewer — full blob, not virtualized, manual refresh
+- `src/pages/NodeManagement.tsx`: `handleViewLogs` / `handleRefreshLogs` (~L265–297)
+  call `getMerodLogs(node, homeDir, 500)` and store the whole string in `logsContent`;
+  rendered by `<LogsViewer content={logsContent} />` (~L585). **No polling.**
+- `src/components/LogsViewer.tsx`:
+  - `content.split("\n")` + `.filter()` on **every render / keystroke** (~L40–55).
+  - Converts the entire joined text to one HTML string via `ansi-to-html` (~L57–71)
+    and dumps it with `dangerouslySetInnerHTML` into a single scroll div (~L169–177) —
+    **every line lives in the DOM, no virtualization**.
+  - Counts lines with a third `split("\n")` in the footer (~L180).
+- Util layer: `src/utils/merod.ts` — `startMerod(...)` (~L31) and
+  `getMerodLogs(nodeName, homeDir?, lines?)` (~L116). No clear/download/rotate helpers.
+
+---
+
+## 2. Backend: rotation + 100 MB cap + cleanup
+
+Two viable strategies. **Recommended: Strategy B** (pipe interposition) because it gives
+true rotation without racing a live writer; **Strategy A** (copytruncate) is a smaller
+change if we want a first cut.
+
+### Strategy A — copytruncate (smallest change)
+Keep giving merod the FD, and run a periodic capper.
+
+- Add a Tauri-side background task (per running node) that every ~30 s checks
+  `fs::metadata(merod.log).len()`. When it exceeds the segment size (e.g. 10 MB):
+  1. copy the current tail to `merod.log.1` (shift existing `.1→.2 … .N-1→.N`, drop `.N`),
+  2. `File::options().write(true).open(merod.log)?.set_len(0)` to truncate in place.
+- Because merod holds an `O_APPEND` fd, after `set_len(0)` the next write lands at
+  offset 0 — **no node restart needed**.
+- Retention = keep `merod.log` + up to 9 rotated segments × 10 MB ≈ **100 MB**.
+- **Downside:** a tiny race — log lines written between "copy" and "truncate" can be
+  lost. Acceptable for diagnostics; keep the window small (truncate immediately after
+  copy). Document it.
+
+### Strategy B — interpose a rotating writer (recommended)
+Stop handing merod the file FD; drain its streams and write through a size-capped
+rotating sink.
+
+- Spawn with `Stdio::piped()` for stdout+stderr instead of `Stdio::from(file)`
+  (`main.rs` ~L1355–1362).
+- Spawn one async drain task per stream (`tokio::io::BufReader::lines()`), forwarding
+  into a shared `LogRotator` (behind a `Mutex`/`mpsc`):
+  ```rust
+  struct LogRotator { dir: PathBuf, active: File, active_len: u64,
+                      segment_bytes: u64 /*10MB*/, max_segments: u8 /*10*/ }
+  impl LogRotator {
+      fn write_line(&mut self, line: &str) -> io::Result<()> {
+          let buf = /* line + '\n' */;
+          if self.active_len + buf.len() as u64 > self.segment_bytes { self.roll()?; }
+          self.active.write_all(buf)?; self.active_len += buf.len() as u64; Ok(())
+      }
+      fn roll(&mut self) -> io::Result<()> {
+          // merod.log.(N-1) -> merod.log.N (drop oldest), merod.log -> merod.log.1,
+          // reopen a fresh merod.log; enforce max_segments (= 100MB / segment_bytes).
+      }
+  }
+  ```
+- Total cap = `segment_bytes * max_segments` = **100 MB** (10 × 10 MB).
+- **Trade-off:** the app must keep draining or a full pipe can block merod. Mitigate:
+  bounded channel + drop-oldest on overflow, and ensure the drain task lives as long as
+  the child. This is the same pattern `tracing-appender`'s rolling file appender uses;
+  we can also just depend on `tracing-appender` (`RollingFileAppender` + a size guard)
+  rather than hand-rolling `roll()`.
+
+### Cleanup (both strategies)
+- **On `start_merod`:** before spawning, scan `~/.calimero/<node>/logs/`:
+  - delete rotated segments beyond `max_segments`,
+  - delete any `merod.log*` older than a retention window (e.g. 14 days),
+  - enforce the 100 MB total (delete oldest segments until under cap).
+- **New Tauri command `clear_merod_logs(node_name, home_dir)`** — truncate the active
+  file and remove rotated segments (wired to a "Clear logs" button, §4).
+- Optional: a global sweep on app startup across all `~/.calimero/*/logs` dirs.
+
+### Config
+- Extend `Settings` (`src/utils/settings.ts`, defaults ~L12/L89) with optional
+  `logMaxMb` (default 100) and `logRetentionDays` (default 14); thread into `start_merod`
+  args and the cleanup routine. Ship sensible defaults so no UI is strictly required.
+
+---
+
+## 3. Backend read path: tail without reading the whole file
+
+Replace the `read_to_string`-everything in `get_merod_logs` (`main.rs` ~L2403–2418) with
+a **bounded reverse tail**:
+
+- `open` the active file, `seek(SeekFrom::End(0))` to get length, then read backwards in
+  chunks (e.g. 64 KB) counting `\n` until we have `lines` newlines **or** hit a byte cap
+  (e.g. 2 MB). Decode only that slice. This makes cost O(tail) not O(file).
+- If the active file has fewer than `lines`, optionally continue into `merod.log.1`, `.2`
+  … to fill the request (walk segments newest→oldest).
+- Add an **incremental API** for live-tail: `get_merod_logs_since(node, home_dir, offset)`
+  returning `{ bytes, next_offset }` (only data written since `offset`). This is what the
+  viewer polls (§4) instead of re-pulling the whole tail. Handle truncation/rotation by
+  detecting `current_len < offset` → reset to a fresh tail.
+
+---
+
+## 4. Frontend viewer optimization (`LogsViewer.tsx` + `NodeManagement.tsx`)
+
+- **Virtualize** the line list (e.g. render only visible rows) or hard-cap the DOM to the
+  last N lines (e.g. 5 000). Keep an in-memory ring buffer capped at N so live-tail can't
+  grow unbounded.
+- **Split once, memoize:** derive `lines` from `content` a single time; drop the triple
+  `split("\n")` (filter body ~L40–55 and footer count ~L180 should reuse it).
+- **Debounce** the text filter input (~150 ms) so filtering doesn't run per keystroke.
+- **ANSI conversion per line, memoized** (convert only the visible/less-than-N lines),
+  not the whole blob each render (~L57–71).
+- **Live tail via polling** the incremental API (§3): when the modal is open and
+  "auto-scroll/live" is on, `setInterval` (~1–2 s) calls `get_merod_logs_since` and
+  appends only new bytes (currently there is **no** polling — refresh is manual).
+  Pause polling when the modal is closed or the tab is hidden.
+- **Auto-scroll only when pinned to bottom** (don't yank the view if the user scrolled up).
+- Add **"Clear logs"** (calls `clear_merod_logs`) and optionally **"Download full log"**
+  (stream file to a user-picked path) buttons.
+- Mirror new commands in `src/utils/merod.ts` (`getMerodLogsSince`, `clearMerodLogs`).
+
+---
+
+## 5. File-by-file change list
+
+| Area | File | Change |
+|------|------|--------|
+| Spawn / rotation | `src-tauri/src/main.rs` (`start_merod` ~L1143–1365) | Strategy A capper task or Strategy B piped drain + `LogRotator`; startup cleanup |
+| Read/tail | `src-tauri/src/main.rs` (`get_merod_logs` ~L2376–2421) | Bounded reverse tail; add `get_merod_logs_since`; add `clear_merod_logs`; register in `invoke_handler` (~L2034) |
+| Utils | `src/utils/merod.ts` (~L116) | Add `getMerodLogsSince`, `clearMerodLogs`; pass log-cap args to `startMerod` |
+| Viewer | `src/components/LogsViewer.tsx` | Virtualize, single split, debounce, per-line memo, live-tail, pin-to-bottom, Clear/Download |
+| Page | `src/pages/NodeManagement.tsx` (~L265–297, L585) | Wire live-tail polling + Clear/Download; stop refetching full tail |
+| Settings | `src/utils/settings.ts` (~L12/L89), `src/pages/Settings.tsx` | Optional `logMaxMb` / `logRetentionDays` + note that debug logs fill faster |
+
+---
+
+## 6. Risks & decisions
+
+- **Live writer vs rotation** (§2): Strategy A can lose a few lines at truncation;
+  Strategy B is clean but the drain task must never stall merod (bounded channel,
+  drop-oldest). **Recommendation: Strategy B** for correctness; fall back to A if the
+  drain plumbing proves fiddly.
+- **Cross-platform:** `set_len`/rename semantics differ on Windows (can't rename a file
+  with an open handle). Strategy B avoids this entirely because the app owns the file
+  handles, not merod — another reason to prefer B.
+- **Existing giant `merod.log`:** the startup cleanup + first rotation will bring legacy
+  100 MB+ files under cap; make sure the first `get_merod_logs` after upgrade uses the
+  bounded tail so it doesn't choke on a pre-existing huge file.
+- **debugLogs** stays a spawn-time `RUST_LOG` switch; the cap protects disk regardless.
+
+---
+
+## 7. Testing
+
+- **Rust unit tests:** `LogRotator` rolls at the boundary, enforces `max_segments`,
+  never exceeds 100 MB; reverse-tail returns the correct last-N across a segment
+  boundary; `get_merod_logs_since` returns only new bytes and resets after rotation.
+- **Manual/integration:** run a node in debug mode, generate >100 MB, confirm disk stays
+  capped, segments rotate, oldest are deleted; open the viewer and confirm it stays
+  responsive and live-tails.
+- **Frontend:** LogsViewer renders a 50k-line fixture without freezing; filter debounces;
+  auto-scroll only when pinned; Clear/Download work.
+- **Regression:** existing `e2e/` suite (nodes / node-lifecycle / navigation) stays green.
+
+---
+
+## 8. Suggested rollout order
+
+1. Backend bounded reverse tail for `get_merod_logs` (immediate viewer speed-up, low risk).
+2. Rotation + 100 MB cap + startup cleanup (Strategy B) with defaults.
+3. `clear_merod_logs` + `get_merod_logs_since` commands.
+4. Frontend viewer: virtualize + single split + debounce.
+5. Frontend live-tail polling + Clear/Download; optional Settings knobs.

--- a/apps/desktop/plan-logs.md
+++ b/apps/desktop/plan-logs.md
@@ -149,7 +149,7 @@ rotating sink.
 Replace the `read_to_string`-everything in `get_merod_logs` (`main.rs` ~L2403–2418) with
 a **bounded reverse tail**:
 
-- ✅ Implemented as `log_rotation::read_tail`: reads at most `TAIL_READ_CAP_BYTES` (4 MB)
+- ✅ Implemented as `log_rotation::read_tail`: reads at most `TAIL_READ_CAP_BYTES` (10 MB = one full segment)
   from the **end** of each file, walking segments newest→oldest until it has `lines`
   lines. Cost is O(tail), and it's safe against a legacy huge `merod.log`.
 - ⏭️ **Deferred** — incremental API for live-tail: `get_merod_logs_since(node, home_dir, offset)`

--- a/apps/desktop/plan-logs.md
+++ b/apps/desktop/plan-logs.md
@@ -11,7 +11,22 @@ also cleaned up."_ Concretely:
 3. **Delete** old segments (and stale per-node log dirs) automatically.
 4. Make the **Nodes-tab log viewer** fast even when a node has logged a lot.
 
-This is a design/implementation plan only — no behaviour is changed by this document.
+> **Status (this PR):** the core of the plan is now **implemented** — 100 MB cap,
+> rotation, startup cleanup, a bounded tail read, a `clear_merod_logs` command, and a
+> faster viewer. What's implemented vs. deferred is called out inline with
+> **✅ Implemented** / **⏭️ Deferred** tags. The deferred items (incremental
+> `get_merod_logs_since` live-tail, DOM virtualization library, Settings knobs,
+> Download-full-log) are follow-ups, not required for the cap/cleanup goal.
+
+### Implemented in this PR
+- `src-tauri/src/log_rotation.rs` — `RollingLogWriter` (10 MB segments × up to 10 files
+  ≈ 100 MB), `cleanup_logs`, `clear_logs`, bounded `read_tail`; 6 unit tests.
+- `start_merod` now pipes merod stdout/stderr and drains them into the rotating writer,
+  and runs `cleanup_logs` before starting.
+- `get_merod_logs` uses the bounded reverse tail (no more whole-file read).
+- New `clear_merod_logs` Tauri command (+ `clearMerodLogs` in `utils/merod.ts`).
+- `LogsViewer.tsx`: single split, debounced filter, DOM capped to the last 3 000 lines,
+  ANSI conversion of only the rendered slice, pin-to-bottom auto-scroll, **Clear** button.
 
 ---
 
@@ -80,7 +95,9 @@ Keep giving merod the FD, and run a periodic capper.
   lost. Acceptable for diagnostics; keep the window small (truncate immediately after
   copy). Document it.
 
-### Strategy B — interpose a rotating writer (recommended)
+### Strategy B — interpose a rotating writer (recommended) — ✅ Implemented
+_This is the strategy that shipped (`log_rotation::RollingLogWriter` + `spawn_log_drain`)._
+
 Stop handing merod the file FD; drain its streams and write through a size-capped
 rotating sink.
 
@@ -119,24 +136,23 @@ rotating sink.
   file and remove rotated segments (wired to a "Clear logs" button, §4).
 - Optional: a global sweep on app startup across all `~/.calimero/*/logs` dirs.
 
-### Config
-- Extend `Settings` (`src/utils/settings.ts`, defaults ~L12/L89) with optional
-  `logMaxMb` (default 100) and `logRetentionDays` (default 14); thread into `start_merod`
-  args and the cleanup routine. Ship sensible defaults so no UI is strictly required.
+### Config — ⏭️ Deferred
+- Currently the cap/retention are constants in `log_rotation.rs` (`SEGMENT_BYTES` 10 MB,
+  `MAX_SEGMENTS` 9 ⇒ ~100 MB, `RETENTION_DAYS` 14). Optional follow-up: surface
+  `logMaxMb` / `logRetentionDays` in `Settings` (`src/utils/settings.ts`) and thread them
+  into `start_merod`. Not required for the cap/cleanup goal.
 
 ---
 
-## 3. Backend read path: tail without reading the whole file
+## 3. Backend read path: tail without reading the whole file — ✅ tail / ⏭️ since-API
 
 Replace the `read_to_string`-everything in `get_merod_logs` (`main.rs` ~L2403–2418) with
 a **bounded reverse tail**:
 
-- `open` the active file, `seek(SeekFrom::End(0))` to get length, then read backwards in
-  chunks (e.g. 64 KB) counting `\n` until we have `lines` newlines **or** hit a byte cap
-  (e.g. 2 MB). Decode only that slice. This makes cost O(tail) not O(file).
-- If the active file has fewer than `lines`, optionally continue into `merod.log.1`, `.2`
-  … to fill the request (walk segments newest→oldest).
-- Add an **incremental API** for live-tail: `get_merod_logs_since(node, home_dir, offset)`
+- ✅ Implemented as `log_rotation::read_tail`: reads at most `TAIL_READ_CAP_BYTES` (4 MB)
+  from the **end** of each file, walking segments newest→oldest until it has `lines`
+  lines. Cost is O(tail), and it's safe against a legacy huge `merod.log`.
+- ⏭️ **Deferred** — incremental API for live-tail: `get_merod_logs_since(node, home_dir, offset)`
   returning `{ bytes, next_offset }` (only data written since `offset`). This is what the
   viewer polls (§4) instead of re-pulling the whole tail. Handle truncation/rotation by
   detecting `current_len < offset` → reset to a fresh tail.
@@ -145,22 +161,17 @@ a **bounded reverse tail**:
 
 ## 4. Frontend viewer optimization (`LogsViewer.tsx` + `NodeManagement.tsx`)
 
-- **Virtualize** the line list (e.g. render only visible rows) or hard-cap the DOM to the
-  last N lines (e.g. 5 000). Keep an in-memory ring buffer capped at N so live-tail can't
-  grow unbounded.
-- **Split once, memoize:** derive `lines` from `content` a single time; drop the triple
-  `split("\n")` (filter body ~L40–55 and footer count ~L180 should reuse it).
-- **Debounce** the text filter input (~150 ms) so filtering doesn't run per keystroke.
-- **ANSI conversion per line, memoized** (convert only the visible/less-than-N lines),
-  not the whole blob each render (~L57–71).
-- **Live tail via polling** the incremental API (§3): when the modal is open and
-  "auto-scroll/live" is on, `setInterval` (~1–2 s) calls `get_merod_logs_since` and
-  appends only new bytes (currently there is **no** polling — refresh is manual).
-  Pause polling when the modal is closed or the tab is hidden.
-- **Auto-scroll only when pinned to bottom** (don't yank the view if the user scrolled up).
-- Add **"Clear logs"** (calls `clear_merod_logs`) and optionally **"Download full log"**
-  (stream file to a user-picked path) buttons.
-- Mirror new commands in `src/utils/merod.ts` (`getMerodLogsSince`, `clearMerodLogs`).
+- ✅ **Hard-cap the DOM** to the last `MAX_RENDERED_LINES` (3 000) with a "N older lines
+  hidden" banner. (⏭️ full windowed virtualization via a library is a further follow-up.)
+- ✅ **Split once, memoize:** `allLines` is derived from `content` a single time and reused
+  by the filter, the render slice and the footer count (was three separate `split("\n")`).
+- ✅ **Debounce** the filter input (150 ms).
+- ✅ **ANSI conversion of only the rendered slice**, not the whole blob each render.
+- ✅ **Auto-scroll only when pinned to bottom** (tracked via an `onScroll` handler) so it
+  no longer yanks the view when the user scrolls up.
+- ✅ **"Clear logs"** button → `clear_merod_logs` (via `clearMerodLogs` in `utils/merod.ts`).
+- ⏭️ **Deferred** — live-tail polling of the incremental API (§3); **"Download full log"**
+  button.
 
 ---
 

--- a/apps/desktop/src-tauri/src/log_rotation.rs
+++ b/apps/desktop/src-tauri/src/log_rotation.rs
@@ -66,13 +66,42 @@ impl RollingLogWriter {
     }
 
     /// Append one already-newline-terminated log line, rotating first if it would
-    /// push the active file over the segment size.
+    /// push the active file over the segment size. A write larger than a whole
+    /// segment (e.g. a newline-less blob) is split across segments so none
+    /// exceeds the cap.
     pub fn write_line(&mut self, bytes: &[u8]) -> io::Result<()> {
-        if self.len > 0 && self.len + bytes.len() as u64 > self.segment_bytes {
-            self.roll()?;
+        // Reconcile the cached length with the file's real size before any
+        // rotation decision: `clear_logs` (the "Clear" button) may have
+        // truncated the active file (set_len(0)) out from under us, which would
+        // otherwise leave `self.len` stale-high and trigger a spurious early
+        // roll. Only stat when we're at/over the limit, so the common path stays
+        // syscall-free.
+        if self.len + bytes.len() as u64 > self.segment_bytes {
+            if let Ok(meta) = self.file.metadata() {
+                self.len = meta.len();
+            }
         }
-        self.file.write_all(bytes)?;
-        self.len += bytes.len() as u64;
+
+        let mut rest = bytes;
+        while !rest.is_empty() {
+            // Roll a non-empty segment before it would spill past the cap.
+            // (Never roll an empty active file — that just makes empty segments.)
+            if self.len > 0 && self.len + rest.len() as u64 > self.segment_bytes {
+                self.roll()?;
+            }
+            let room = self.segment_bytes.saturating_sub(self.len);
+            // If a single write is bigger than a whole segment, take one
+            // segment's worth and loop (the next iteration rolls); otherwise
+            // write it all.
+            let take = if room > 0 && rest.len() as u64 > room {
+                room as usize
+            } else {
+                rest.len()
+            };
+            self.file.write_all(&rest[..take])?;
+            self.len += take as u64;
+            rest = &rest[take..];
+        }
         Ok(())
     }
 
@@ -337,5 +366,45 @@ mod tests {
         let dir = tmp();
         fs::remove_dir_all(&dir).ok();
         assert_eq!(read_tail(&dir, 10).unwrap(), "");
+    }
+
+    #[test]
+    fn single_write_larger_than_segment_is_split_and_capped() {
+        let dir = tmp();
+        let mut w = RollingLogWriter::open_with(&dir, 10, 5).unwrap();
+        // One 25-byte write, no newline, into 10-byte segments → must span
+        // multiple files, none exceeding the cap, with no bytes lost.
+        w.write_line(b"0123456789ABCDEFGHIJKLMNO").unwrap();
+        assert!(active_path(&dir).metadata().unwrap().len() <= 10);
+        let mut total = active_path(&dir).metadata().unwrap().len();
+        let mut k = 1;
+        loop {
+            let p = seg_path(&dir, k);
+            if p.exists() {
+                let l = p.metadata().unwrap().len();
+                assert!(l <= 10, "segment {k} exceeds cap: {l}");
+                total += l;
+                k += 1;
+            } else {
+                break;
+            }
+        }
+        assert_eq!(total, 25, "no bytes may be lost across the split");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn write_after_external_clear_does_not_spuriously_roll() {
+        let dir = tmp();
+        let mut w = RollingLogWriter::open_with(&dir, 50, 5).unwrap();
+        w.write_line(&vec![b'a'; 45]).unwrap(); // near the limit
+        // The "Clear" button truncates the active file out from under the writer.
+        clear_logs(&dir).unwrap();
+        // A normal write must NOT roll — the file is actually empty now, so the
+        // stale cached len (45) must be reconciled first.
+        w.write_line(b"hello\n").unwrap();
+        assert!(!seg_path(&dir, 1).exists(), "must not roll after an external clear");
+        assert_eq!(read_tail(&dir, 10).unwrap(), "hello");
+        fs::remove_dir_all(&dir).ok();
     }
 }

--- a/apps/desktop/src-tauri/src/log_rotation.rs
+++ b/apps/desktop/src-tauri/src/log_rotation.rs
@@ -60,8 +60,22 @@ impl RollingLogWriter {
     pub fn open_with(dir: &Path, segment_bytes: u64, max_segments: u32) -> io::Result<Self> {
         fs::create_dir_all(dir)?;
         let path = active_path(dir);
-        let file = OpenOptions::new().create(true).append(true).open(&path)?;
-        let len = file.metadata().map(|m| m.len()).unwrap_or(0);
+        let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let mut len = file.metadata().map(|m| m.len()).unwrap_or(0);
+        // A legacy, pre-rotation merod.log may already exceed the cap. Trim it to
+        // its last segment on open so the active file honors segment_bytes right
+        // away — otherwise the first roll would rename the whole oversized file to
+        // merod.log.1, leaving disk use far above the advertised ~100 MB until it
+        // ages out over many rotations.
+        if len > segment_bytes {
+            let _ = file.flush();
+            let kept = tail_bytes_raw(&path, segment_bytes)?;
+            let mut wf = OpenOptions::new().write(true).truncate(true).open(&path)?;
+            wf.write_all(&kept)?;
+            wf.flush()?;
+            file = OpenOptions::new().create(true).append(true).open(&path)?;
+            len = kept.len() as u64;
+        }
         Ok(Self {
             dir: dir.to_path_buf(),
             file: Some(file),
@@ -309,6 +323,24 @@ fn read_tail_bytes(path: &Path, max_bytes: u64) -> io::Result<String> {
     Ok(text)
 }
 
+/// Read at most `max_bytes` of raw bytes from the end of `path`, dropping a
+/// leading partial line when we started mid-file. Byte-exact (no lossy decode) —
+/// used to trim an oversized active file in place on open.
+fn tail_bytes_raw(path: &Path, max_bytes: u64) -> io::Result<Vec<u8>> {
+    let mut f = File::open(path)?;
+    let len = f.metadata()?.len();
+    let start = len.saturating_sub(max_bytes);
+    f.seek(SeekFrom::Start(start))?;
+    let mut buf = Vec::with_capacity((len - start) as usize);
+    f.read_to_end(&mut buf)?;
+    if start > 0 {
+        if let Some(nl) = buf.iter().position(|&b| b == b'\n') {
+            buf.drain(..=nl);
+        }
+    }
+    Ok(buf)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -434,6 +466,23 @@ mod tests {
             }
         }
         assert_eq!(total, 25, "no bytes may be lost across the split");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn oversized_legacy_active_file_is_trimmed_on_open() {
+        let dir = tmp();
+        // A pre-rotation merod.log larger than a segment.
+        {
+            let mut f = File::create(active_path(&dir)).unwrap();
+            f.write_all(&vec![b'x'; 250]).unwrap();
+            f.write_all(b"\nKEEP\n").unwrap();
+        }
+        let _w = RollingLogWriter::open_with(&dir, 100, 5).unwrap();
+        let active_len = active_path(&dir).metadata().unwrap().len();
+        assert!(active_len <= 100, "legacy active file should be trimmed to <= segment, got {active_len}");
+        // The most recent content survives, older overflow is dropped.
+        assert_eq!(read_tail(&dir, 10).unwrap(), "KEEP");
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/apps/desktop/src-tauri/src/log_rotation.rs
+++ b/apps/desktop/src-tauri/src/log_rotation.rs
@@ -1,0 +1,341 @@
+//! Size-capped, rotating log storage for a merod node.
+//!
+//! merod's stdout/stderr are drained by the app (see `start_merod`) and written
+//! here line-by-line. The active file `merod.log` rolls to numbered segments
+//! (`merod.log.1` .. `merod.log.N`) once it exceeds [`SEGMENT_BYTES`]; the oldest
+//! segment beyond [`MAX_SEGMENTS`] is deleted, so total on-disk logs per node stay
+//! at roughly `SEGMENT_BYTES * (MAX_SEGMENTS + 1)` ≈ 100 MB.
+//!
+//! Reads use a bounded tail so displaying logs never loads the whole history into
+//! memory, even if a legacy pre-rotation `merod.log` is huge.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+/// Roll the active file once it grows past this size.
+pub const SEGMENT_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
+/// Keep at most this many rotated segments (`merod.log.1` .. `merod.log.N`).
+/// With the active file that is `MAX_SEGMENTS + 1` files ≈ 100 MB total.
+pub const MAX_SEGMENTS: u32 = 9;
+/// Rotated segments older than this are removed on cleanup.
+pub const RETENTION_DAYS: u64 = 14;
+/// Upper bound on bytes read from any single file when tailing. Protects the read
+/// path against a legacy, pre-rotation `merod.log` that may be far larger than a
+/// segment (it will be brought back under the cap on the next node start).
+const TAIL_READ_CAP_BYTES: u64 = 4 * 1024 * 1024; // 4 MB
+
+const ACTIVE_NAME: &str = "merod.log";
+
+fn active_path(dir: &Path) -> PathBuf {
+    dir.join(ACTIVE_NAME)
+}
+
+fn seg_path(dir: &Path, n: u32) -> PathBuf {
+    dir.join(format!("{}.{}", ACTIVE_NAME, n))
+}
+
+/// Append-only writer for `merod.log` that rotates by size and enforces the cap.
+pub struct RollingLogWriter {
+    dir: PathBuf,
+    file: File,
+    len: u64,
+    segment_bytes: u64,
+    max_segments: u32,
+}
+
+impl RollingLogWriter {
+    /// Open (creating if needed) the active log file in `dir` with default limits.
+    pub fn open(dir: &Path) -> io::Result<Self> {
+        Self::open_with(dir, SEGMENT_BYTES, MAX_SEGMENTS)
+    }
+
+    pub fn open_with(dir: &Path, segment_bytes: u64, max_segments: u32) -> io::Result<Self> {
+        fs::create_dir_all(dir)?;
+        let path = active_path(dir);
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let len = file.metadata().map(|m| m.len()).unwrap_or(0);
+        Ok(Self {
+            dir: dir.to_path_buf(),
+            file,
+            len,
+            segment_bytes,
+            max_segments,
+        })
+    }
+
+    /// Append one already-newline-terminated log line, rotating first if it would
+    /// push the active file over the segment size.
+    pub fn write_line(&mut self, bytes: &[u8]) -> io::Result<()> {
+        if self.len > 0 && self.len + bytes.len() as u64 > self.segment_bytes {
+            self.roll()?;
+        }
+        self.file.write_all(bytes)?;
+        self.len += bytes.len() as u64;
+        Ok(())
+    }
+
+    fn roll(&mut self) -> io::Result<()> {
+        let _ = self.file.flush();
+        // Drop the oldest segment that would otherwise fall off the end.
+        let oldest = seg_path(&self.dir, self.max_segments);
+        if oldest.exists() {
+            let _ = fs::remove_file(&oldest);
+        }
+        // Shift merod.log.k -> merod.log.(k+1), highest first.
+        for k in (1..self.max_segments).rev() {
+            let from = seg_path(&self.dir, k);
+            if from.exists() {
+                fs::rename(&from, seg_path(&self.dir, k + 1))?;
+            }
+        }
+        // merod.log -> merod.log.1, then reopen a fresh active file.
+        let active = active_path(&self.dir);
+        if active.exists() {
+            fs::rename(&active, seg_path(&self.dir, 1))?;
+        }
+        self.file = OpenOptions::new().create(true).append(true).open(&active)?;
+        self.len = 0;
+        Ok(())
+    }
+}
+
+/// Delete rotated segments beyond `MAX_SEGMENTS`, drop rotated segments older than
+/// `RETENTION_DAYS`, and enforce the total-size cap. Never touches the active file.
+pub fn cleanup_logs(dir: &Path) -> io::Result<()> {
+    cleanup_logs_with(dir, MAX_SEGMENTS, RETENTION_DAYS)
+}
+
+pub fn cleanup_logs_with(dir: &Path, max_segments: u32, retention_days: u64) -> io::Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    let retention = Duration::from_secs(retention_days.saturating_mul(24 * 60 * 60));
+    let now = SystemTime::now();
+
+    for entry in fs::read_dir(dir)?.flatten() {
+        let path = entry.path();
+        let name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        // Only ever manage our own files.
+        let idx = match name.strip_prefix(&format!("{}.", ACTIVE_NAME)) {
+            Some(rest) => rest.parse::<u32>().ok(),
+            None => None,
+        };
+        let is_active = name == ACTIVE_NAME;
+        if !is_active && idx.is_none() {
+            continue; // not a merod.log[.N] file
+        }
+        // Segments past the retained count go immediately.
+        if let Some(idx) = idx {
+            if idx > max_segments {
+                let _ = fs::remove_file(&path);
+                continue;
+            }
+        }
+        // Age out old rotated segments (never the live file).
+        if !is_active {
+            if let Ok(modified) = entry.metadata().and_then(|m| m.modified()) {
+                if now.duration_since(modified).map(|age| age > retention).unwrap_or(false) {
+                    let _ = fs::remove_file(&path);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Truncate the active file and remove all rotated segments. Returns how many
+/// rotated segments were removed. Safe to call whether or not a node is running:
+/// the active file is truncated in place so a live writer keeps appending at 0.
+pub fn clear_logs(dir: &Path) -> io::Result<usize> {
+    if !dir.exists() {
+        return Ok(0);
+    }
+    let active = active_path(dir);
+    if active.exists() {
+        OpenOptions::new().write(true).open(&active)?.set_len(0)?;
+    }
+    let mut removed = 0;
+    let mut k = 1;
+    loop {
+        let p = seg_path(dir, k);
+        if p.exists() {
+            if fs::remove_file(&p).is_ok() {
+                removed += 1;
+            }
+            k += 1;
+        } else {
+            break;
+        }
+    }
+    Ok(removed)
+}
+
+/// Read up to `max_lines` trailing lines across the active file and rotated
+/// segments (newest first), reading at most `TAIL_READ_CAP_BYTES` from any single
+/// file. Returns the lines joined oldest→newest.
+pub fn read_tail(dir: &Path, max_lines: usize) -> io::Result<String> {
+    if max_lines == 0 {
+        return Ok(String::new());
+    }
+    // Newest -> oldest: merod.log, merod.log.1, merod.log.2, ...
+    let mut paths: Vec<PathBuf> = Vec::new();
+    let active = active_path(dir);
+    if active.exists() {
+        paths.push(active);
+    }
+    let mut k = 1;
+    loop {
+        let p = seg_path(dir, k);
+        if p.exists() {
+            paths.push(p);
+            k += 1;
+        } else {
+            break;
+        }
+    }
+
+    // Collect lines newest-first until we have enough.
+    let mut rev: Vec<String> = Vec::with_capacity(max_lines.min(4096));
+    for path in paths {
+        let chunk = read_tail_bytes(&path, TAIL_READ_CAP_BYTES)?;
+        for line in chunk.lines().rev() {
+            rev.push(line.to_string());
+            if rev.len() >= max_lines {
+                break;
+            }
+        }
+        if rev.len() >= max_lines {
+            break;
+        }
+    }
+    rev.reverse();
+    Ok(rev.join("\n"))
+}
+
+/// Read at most `max_bytes` from the end of `path`, dropping a leading partial
+/// line when we started mid-file so callers only ever see whole lines.
+fn read_tail_bytes(path: &Path, max_bytes: u64) -> io::Result<String> {
+    let mut f = File::open(path)?;
+    let len = f.metadata()?.len();
+    let start = len.saturating_sub(max_bytes);
+    f.seek(SeekFrom::Start(start))?;
+    let mut buf = Vec::with_capacity((len - start) as usize);
+    f.read_to_end(&mut buf)?;
+    let text = String::from_utf8_lossy(&buf).into_owned();
+    if start > 0 {
+        // We began mid-file: discard the truncated first line.
+        if let Some(nl) = text.find('\n') {
+            return Ok(text[nl + 1..].to_string());
+        }
+    }
+    Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    fn tmp() -> PathBuf {
+        let mut p = std::env::temp_dir();
+        // Unique-ish without Date/rand: use a static counter.
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static N: AtomicU32 = AtomicU32::new(0);
+        p.push(format!("merod_logtest_{}_{}", std::process::id(), N.fetch_add(1, Ordering::SeqCst)));
+        let _ = fs::remove_dir_all(&p);
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn writes_and_tails_lines() {
+        let dir = tmp();
+        let mut w = RollingLogWriter::open(&dir).unwrap();
+        for i in 0..10 {
+            w.write_line(format!("line {}\n", i).as_bytes()).unwrap();
+        }
+        let tail = read_tail(&dir, 3).unwrap();
+        assert_eq!(tail, "line 7\nline 8\nline 9");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn rolls_at_segment_boundary_and_caps_segments() {
+        let dir = tmp();
+        // Tiny limits: 100-byte segments, keep 2 rotated segments (+active = 3 files).
+        let mut w = RollingLogWriter::open_with(&dir, 100, 2).unwrap();
+        // Each line ~20 bytes; 60 lines => forces several rolls.
+        for i in 0..60 {
+            w.write_line(format!("log-entry-{:04}\n", i).as_bytes()).unwrap();
+        }
+        // Active + at most MAX_SEGMENTS rotated files exist; nothing beyond .2.
+        assert!(active_path(&dir).exists());
+        assert!(!seg_path(&dir, 3).exists(), "segment beyond cap must be deleted");
+        // The most recent lines survive.
+        let tail = read_tail(&dir, 1).unwrap();
+        assert_eq!(tail, "log-entry-0059");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn tail_spans_rotated_segments() {
+        let dir = tmp();
+        let mut w = RollingLogWriter::open_with(&dir, 60, 5).unwrap();
+        for i in 0..20 {
+            w.write_line(format!("n{:02}\n", i).as_bytes()).unwrap();
+        }
+        // Ask for more lines than fit in the active segment — must read into .1/.2.
+        let tail = read_tail(&dir, 8).unwrap();
+        let got: Vec<&str> = tail.lines().collect();
+        assert_eq!(got.len(), 8);
+        assert_eq!(*got.last().unwrap(), "n19");
+        assert_eq!(got[0], "n12");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn cleanup_removes_overflow_segments() {
+        let dir = tmp();
+        // Hand-create merod.log.1 .. merod.log.5
+        for k in 1..=5 {
+            let mut f = File::create(seg_path(&dir, k)).unwrap();
+            writeln!(f, "seg {}", k).unwrap();
+        }
+        File::create(active_path(&dir)).unwrap();
+        cleanup_logs_with(&dir, 2, 3650).unwrap(); // keep 2, no age-out
+        assert!(seg_path(&dir, 1).exists());
+        assert!(seg_path(&dir, 2).exists());
+        assert!(!seg_path(&dir, 3).exists());
+        assert!(!seg_path(&dir, 4).exists());
+        assert!(!seg_path(&dir, 5).exists());
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn clear_truncates_active_and_removes_segments() {
+        let dir = tmp();
+        let mut w = RollingLogWriter::open_with(&dir, 40, 5).unwrap();
+        for i in 0..20 {
+            w.write_line(format!("x{:02}\n", i).as_bytes()).unwrap();
+        }
+        assert!(seg_path(&dir, 1).exists());
+        let removed = clear_logs(&dir).unwrap();
+        assert!(removed >= 1);
+        assert!(!seg_path(&dir, 1).exists());
+        assert_eq!(active_path(&dir).metadata().unwrap().len(), 0);
+        assert_eq!(read_tail(&dir, 100).unwrap(), "");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn tail_of_missing_dir_is_empty() {
+        let dir = tmp();
+        fs::remove_dir_all(&dir).ok();
+        assert_eq!(read_tail(&dir, 10).unwrap(), "");
+    }
+}

--- a/apps/desktop/src-tauri/src/log_rotation.rs
+++ b/apps/desktop/src-tauri/src/log_rotation.rs
@@ -81,10 +81,9 @@ impl RollingLogWriter {
         Ok(self.file.as_mut().expect("just set"))
     }
 
-    /// Append one already-newline-terminated log line, rotating first if it would
-    /// push the active file over the segment size. A write larger than a whole
-    /// segment (e.g. a newline-less blob) is split across segments so none
-    /// exceeds the cap.
+    /// Append a chunk of raw log bytes, rotating first if it would push the active
+    /// file over the segment size. A chunk larger than a whole segment (e.g. a
+    /// newline-less blob) is split across segments so none exceeds the cap.
     pub fn write_line(&mut self, bytes: &[u8]) -> io::Result<()> {
         // Reconcile the cached length with the file's real size before any
         // rotation decision: `clear_logs` (the "Clear" button) may have

--- a/apps/desktop/src-tauri/src/log_rotation.rs
+++ b/apps/desktop/src-tauri/src/log_rotation.rs
@@ -39,7 +39,9 @@ fn seg_path(dir: &Path, n: u32) -> PathBuf {
 /// Append-only writer for `merod.log` that rotates by size and enforces the cap.
 pub struct RollingLogWriter {
     dir: PathBuf,
-    file: File,
+    // Option so roll() can drop the handle before renaming the active file —
+    // Windows refuses to rename a file that still has an open handle.
+    file: Option<File>,
     len: u64,
     segment_bytes: u64,
     max_segments: u32,
@@ -58,11 +60,21 @@ impl RollingLogWriter {
         let len = file.metadata().map(|m| m.len()).unwrap_or(0);
         Ok(Self {
             dir: dir.to_path_buf(),
-            file,
+            file: Some(file),
             len,
             segment_bytes,
             max_segments,
         })
+    }
+
+    /// The active file handle, reopening it if a prior roll left it closed.
+    fn file_mut(&mut self) -> io::Result<&mut File> {
+        if self.file.is_none() {
+            self.file = Some(
+                OpenOptions::new().create(true).append(true).open(active_path(&self.dir))?,
+            );
+        }
+        Ok(self.file.as_mut().expect("just set"))
     }
 
     /// Append one already-newline-terminated log line, rotating first if it would
@@ -77,7 +89,7 @@ impl RollingLogWriter {
         // roll. Only stat when we're at/over the limit, so the common path stays
         // syscall-free.
         if self.len + bytes.len() as u64 > self.segment_bytes {
-            if let Ok(meta) = self.file.metadata() {
+            if let Ok(meta) = self.file_mut()?.metadata() {
                 self.len = meta.len();
             }
         }
@@ -98,15 +110,31 @@ impl RollingLogWriter {
             } else {
                 rest.len()
             };
-            self.file.write_all(&rest[..take])?;
+            self.file_mut()?.write_all(&rest[..take])?;
             self.len += take as u64;
             rest = &rest[take..];
         }
         Ok(())
     }
 
+    /// Truncate the active file in place and delete rotated segments, resetting
+    /// the in-memory length. Called on the *live* writer (under its lock) so a
+    /// "Clear" can't race the drain tasks or desync the cached length. Returns
+    /// how many rotated segments were removed.
+    pub fn clear(&mut self) -> io::Result<usize> {
+        {
+            let f = self.file_mut()?;
+            let _ = f.flush();
+            f.set_len(0)?;
+        }
+        self.len = 0;
+        Ok(remove_rotated_segments(&self.dir))
+    }
+
     fn roll(&mut self) -> io::Result<()> {
-        let _ = self.file.flush();
+        if let Some(f) = self.file.as_mut() {
+            let _ = f.flush();
+        }
         // Drop the oldest segment that would otherwise fall off the end.
         let oldest = seg_path(&self.dir, self.max_segments);
         if oldest.exists() {
@@ -119,15 +147,37 @@ impl RollingLogWriter {
                 fs::rename(&from, seg_path(&self.dir, k + 1))?;
             }
         }
+        // Close the active handle BEFORE renaming it: Windows refuses to rename a
+        // file that still has an open handle, which would otherwise make the
+        // rename fail and stall the drain once the segment fills.
+        self.file = None;
         // merod.log -> merod.log.1, then reopen a fresh active file.
         let active = active_path(&self.dir);
         if active.exists() {
             fs::rename(&active, seg_path(&self.dir, 1))?;
         }
-        self.file = OpenOptions::new().create(true).append(true).open(&active)?;
+        self.file = Some(OpenOptions::new().create(true).append(true).open(&active)?);
         self.len = 0;
         Ok(())
     }
+}
+
+/// Delete `merod.log.1`, `.2`, … in order; returns how many were removed.
+fn remove_rotated_segments(dir: &Path) -> usize {
+    let mut removed = 0;
+    let mut k = 1;
+    loop {
+        let p = seg_path(dir, k);
+        if p.exists() {
+            if fs::remove_file(&p).is_ok() {
+                removed += 1;
+            }
+            k += 1;
+        } else {
+            break;
+        }
+    }
+    removed
 }
 
 /// Delete rotated segments beyond `MAX_SEGMENTS`, drop rotated segments older than
@@ -180,6 +230,10 @@ pub fn cleanup_logs_with(dir: &Path, max_segments: u32, retention_days: u64) -> 
 /// Truncate the active file and remove all rotated segments. Returns how many
 /// rotated segments were removed. Safe to call whether or not a node is running:
 /// the active file is truncated in place so a live writer keeps appending at 0.
+/// Clear logs on disk when there is NO live writer for this node (node not
+/// running). When a node IS running, clear through the live
+/// [`RollingLogWriter::clear`] instead so the operation is serialized with the
+/// drain tasks (no TOCTOU on the log dir, no cached-length desync).
 pub fn clear_logs(dir: &Path) -> io::Result<usize> {
     if !dir.exists() {
         return Ok(0);
@@ -188,20 +242,7 @@ pub fn clear_logs(dir: &Path) -> io::Result<usize> {
     if active.exists() {
         OpenOptions::new().write(true).open(&active)?.set_len(0)?;
     }
-    let mut removed = 0;
-    let mut k = 1;
-    loop {
-        let p = seg_path(dir, k);
-        if p.exists() {
-            if fs::remove_file(&p).is_ok() {
-                removed += 1;
-            }
-            k += 1;
-        } else {
-            break;
-        }
-    }
-    Ok(removed)
+    Ok(remove_rotated_segments(dir))
 }
 
 /// Read up to `max_lines` trailing lines across the active file and rotated
@@ -390,6 +431,25 @@ mod tests {
             }
         }
         assert_eq!(total, 25, "no bytes may be lost across the split");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn writer_clear_resets_length_and_segments() {
+        let dir = tmp();
+        let mut w = RollingLogWriter::open_with(&dir, 30, 5).unwrap();
+        for i in 0..10 {
+            w.write_line(format!("line{:02}\n", i).as_bytes()).unwrap();
+        }
+        assert!(seg_path(&dir, 1).exists());
+        let removed = w.clear().unwrap();
+        assert!(removed >= 1);
+        assert!(!seg_path(&dir, 1).exists());
+        assert_eq!(active_path(&dir).metadata().unwrap().len(), 0);
+        // A normal write right after clear must not spuriously roll (len reset).
+        w.write_line(b"fresh\n").unwrap();
+        assert!(!seg_path(&dir, 1).exists());
+        assert_eq!(read_tail(&dir, 10).unwrap(), "fresh");
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/apps/desktop/src-tauri/src/log_rotation.rs
+++ b/apps/desktop/src-tauri/src/log_rotation.rs
@@ -21,10 +21,14 @@ pub const SEGMENT_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
 pub const MAX_SEGMENTS: u32 = 9;
 /// Rotated segments older than this are removed on cleanup.
 pub const RETENTION_DAYS: u64 = 14;
-/// Upper bound on bytes read from any single file when tailing. Protects the read
-/// path against a legacy, pre-rotation `merod.log` that may be far larger than a
-/// segment (it will be brought back under the cap on the next node start).
-const TAIL_READ_CAP_BYTES: u64 = 4 * 1024 * 1024; // 4 MB
+/// Upper bound on bytes read from any single file when tailing. Kept at the
+/// segment size so a properly-rotated segment (≤ SEGMENT_BYTES) is always read in
+/// full — reading less than a whole file would skip its older half and leave a
+/// silent chronological gap before the next (older) segment. A legacy
+/// pre-rotation `merod.log` larger than this is still bounded to its last slice
+/// (and gets brought under the cap on the next node start); since no older
+/// segments exist in that case there is no misleading interleaving.
+const TAIL_READ_CAP_BYTES: u64 = SEGMENT_BYTES; // 10 MB — one full segment
 
 const ACTIVE_NAME: &str = "merod.log";
 

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1292,23 +1292,9 @@ async fn start_merod(
         .map_err(|e| TauriError::new(TauriErrorCode::FileNotFound, e))?;
 
     // Prepare home directory (where .calimero folder is, e.g., ~/.calimero)
-    let home_dir_path = if let Some(dir) = data_dir {
-        // Expand ~ if present
-        let expanded = if dir.starts_with("~") {
-            if let Some(home) = dirs::home_dir() {
-                dir.replacen("~", &home.to_string_lossy(), 1)
-            } else {
-                dir
-            }
-        } else {
-            dir
-        };
-        std::path::PathBuf::from(expanded)
-    } else {
-        dirs::home_dir()
-            .ok_or_else(|| TauriError::new(TauriErrorCode::HomeDirNotFound, "Failed to get home directory"))?
-            .join(".calimero")
-    };
+    // Same resolver as get_merod_logs/clear_merod_logs, so a node writes logs at
+    // exactly the path the viewer/Clear later resolve (no ~-expansion drift).
+    let home_dir_path = resolve_home_dir(data_dir)?;
 
     std::fs::create_dir_all(&home_dir_path)
         .map_err(|e| TauriError::with_details(TauriErrorCode::DirectoryError, "Failed to create home directory", e.to_string()))?;

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1136,23 +1136,25 @@ fn resolve_home_dir(home_dir: Option<String>) -> Result<std::path::PathBuf, Taur
 /// home directory (mirrors delete_calimero_data_dir). Uses lexical containment
 /// so it works for paths that don't exist yet.
 fn ensure_under_home(path: &std::path::Path) -> Result<(), TauriError> {
-    if let Some(home) = dirs::home_dir() {
-        let home = home.canonicalize().unwrap_or(home);
-        // Compare against the deepest existing ancestor so a not-yet-created
-        // logs dir still validates against its real (canonical) parent.
-        let mut probe = path.to_path_buf();
-        let anchor = loop {
-            if probe.exists() {
-                break probe.canonicalize().unwrap_or(probe);
-            }
-            match probe.parent() {
-                Some(p) => probe = p.to_path_buf(),
-                None => break path.to_path_buf(),
-            }
-        };
-        if !anchor.starts_with(&home) {
-            return Err(TauriError::new(TauriErrorCode::PathNotAllowed, "Path must be under your home directory"));
+    // Fail closed: if we can't resolve the home directory we can't prove the
+    // path is safe, so refuse rather than skip the check.
+    let home = dirs::home_dir()
+        .ok_or_else(|| TauriError::new(TauriErrorCode::PathNotAllowed, "Cannot resolve home directory to validate the path"))?;
+    let home = home.canonicalize().unwrap_or(home);
+    // Compare against the deepest existing ancestor so a not-yet-created
+    // logs dir still validates against its real (canonical) parent.
+    let mut probe = path.to_path_buf();
+    let anchor = loop {
+        if probe.exists() {
+            break probe.canonicalize().unwrap_or(probe);
         }
+        match probe.parent() {
+            Some(p) => probe = p.to_path_buf(),
+            None => break path.to_path_buf(),
+        }
+    };
+    if !anchor.starts_with(&home) {
+        return Err(TauriError::new(TauriErrorCode::PathNotAllowed, "Path must be under your home directory"));
     }
     Ok(())
 }
@@ -1192,35 +1194,34 @@ fn get_app_data_dir(app_handle: &tauri::AppHandle) -> Result<std::path::PathBuf,
     Ok(app_data_dir)
 }
 
-/// Drain a child stdout/stderr stream line-by-line into the rotating log writer.
+/// Drain a child stdout/stderr stream into the rotating log writer.
 /// The lock is held only for each short synchronous write (never across an await),
-/// so the two drain tasks (stdout + stderr) interleave without corrupting lines.
+/// so the two drain tasks (stdout + stderr) interleave without corrupting output.
 fn spawn_log_drain<R>(
     reader: R,
     writer: std::sync::Arc<std::sync::Mutex<log_rotation::RollingLogWriter>>,
 ) where
     R: tokio::io::AsyncRead + Unpin + Send + 'static,
 {
-    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::io::AsyncReadExt;
     tokio::spawn(async move {
-        // Read raw bytes with read_until rather than lines(): merod can emit
-        // non-UTF-8 (panic backtraces, stray binary), which lines() surfaces as an
-        // Err that would permanently — and silently — kill the drain, so logs just
-        // stop appearing. read_until preserves the bytes verbatim (ANSI colour
-        // codes included) and never fails on invalid UTF-8; the writer's rotation
-        // and the viewer's lossy decode handle anything unusual downstream.
-        let mut buf_reader = BufReader::new(reader);
-        let mut buf: Vec<u8> = Vec::with_capacity(1024);
+        // Read into a fixed-size buffer rather than read_until(b'\n'): raw bytes
+        // never fail on non-UTF-8 (merod panic backtraces / stray binary) the way
+        // lines() would, and a fixed buffer can't grow unbounded on a runaway
+        // newline-less stream (an OOM vector). Bytes are written verbatim (ANSI
+        // colours included); the writer's rotation and the viewer's lossy decode
+        // handle anything unusual downstream.
+        let mut reader = reader;
+        let mut buf = [0u8; 8192];
         // Log a persistent write failure (disk full, dir deleted, …) or a
         // poisoned writer lock once so it's discoverable, without spamming a
-        // warning for every dropped line.
+        // warning for every dropped chunk.
         let mut write_error_logged = false;
         let mut poison_logged = false;
         loop {
-            buf.clear();
-            match buf_reader.read_until(b'\n', &mut buf).await {
+            match reader.read(&mut buf).await {
                 Ok(0) => break, // EOF: process exited / stream closed
-                Ok(_) => {
+                Ok(n) => {
                     // Recover the guard even if the mutex was poisoned (some other
                     // holder panicked): a std Mutex stays poisoned forever, so
                     // ignoring the Err would silently stop all logging. into_inner()
@@ -1238,7 +1239,7 @@ fn spawn_log_drain<R>(
                     // Keep draining even if a write fails, so a write error can
                     // never wedge merod by leaving its pipe unread — but surface
                     // the first failure so silent log loss is diagnosable.
-                    if let Err(e) = w.write_line(&buf) {
+                    if let Err(e) = w.write_line(&buf[..n]) {
                         if !write_error_logged {
                             warn!("[Merod] log write failed (further errors suppressed): {}", e);
                             write_error_logged = true;
@@ -1248,8 +1249,8 @@ fn spawn_log_drain<R>(
                     }
                 }
                 Err(e) => {
-                    // A genuine I/O error (not a decode error) — log it so a
-                    // stream that stops mid-run is diagnosable, then exit.
+                    // A genuine I/O error — log it so a stream that stops mid-run
+                    // is diagnosable, then exit.
                     warn!("[Merod] log drain stopped on read error: {}", e);
                     break;
                 }
@@ -1442,14 +1443,27 @@ async fn start_merod(
 
     // Rotating writer shared by the stdout and stderr drain tasks. Registered in
     // MerodLogWriters so clear_merod_logs can clear through this same instance
-    // (serialized by the inner Mutex) instead of racing it on raw paths.
-    let log_writer = std::sync::Arc::new(std::sync::Mutex::new(
-        log_rotation::RollingLogWriter::open(&log_dir)
-            .map_err(|e| TauriError::with_details(TauriErrorCode::FileWriteError, "Failed to open log writer", e.to_string()))?,
-    ));
-    if let Ok(mut map) = log_writers.lock() {
-        map.insert(log_dir.to_string_lossy().to_string(), log_writer.clone());
-    }
+    // (serialized by the inner Mutex) instead of racing it on raw paths. We
+    // get-or-create per log dir: if a writer already exists for this dir (e.g. a
+    // second start for the same node on a different port), reuse it so both sets
+    // of drains write through ONE writer rather than two racing on the same files.
+    let log_key = log_dir.to_string_lossy().to_string();
+    let log_writer = {
+        let mut map = log_writers
+            .lock()
+            .map_err(|_| TauriError::new(TauriErrorCode::InternalError, "log writers lock poisoned"))?;
+        match map.get(&log_key) {
+            Some(existing) => existing.clone(),
+            None => {
+                let w = std::sync::Arc::new(std::sync::Mutex::new(
+                    log_rotation::RollingLogWriter::open(&log_dir)
+                        .map_err(|e| TauriError::with_details(TauriErrorCode::FileWriteError, "Failed to open log writer", e.to_string()))?,
+                ));
+                map.insert(log_key.clone(), w.clone());
+                w
+            }
+        }
+    };
 
     // Build command - global options come BEFORE subcommand
     // Merod expects: merod --home ~/.calimero --node node1 run
@@ -1519,16 +1533,29 @@ async fn start_merod(
     
     // Spawn a task to monitor the process
     let merod_state_clone = merod_state.inner().clone();
+    let log_writers_clone = log_writers.inner().clone();
+    let exit_log_key = log_key.clone();
+    let exit_writer = log_writer.clone();
     let monitored_pid = pid; // Capture PID for verification
     tokio::spawn(async move {
         let status = child.wait().await;
-        let mut state = merod_state_clone.lock().unwrap();
-        if let Ok(exit_status) = status {
-            if let Some(code) = exit_status.code() {
-                warn!("[Merod] Process {} exited with code: {}", monitored_pid, code);
+        {
+            let mut state = merod_state_clone.lock().unwrap();
+            if let Ok(exit_status) = status {
+                if let Some(code) = exit_status.code() {
+                    warn!("[Merod] Process {} exited with code: {}", monitored_pid, code);
+                }
+            }
+            state.retain(|p| p.pid != monitored_pid);
+        }
+        // Drop this node's writer registration (only if it's still the one we
+        // registered — a restart may have replaced it) so the map doesn't leak an
+        // open file handle per node, and clear falls back to on-disk once stopped.
+        if let Ok(mut map) = log_writers_clone.lock() {
+            if map.get(&exit_log_key).map(|w| std::sync::Arc::ptr_eq(w, &exit_writer)).unwrap_or(false) {
+                map.remove(&exit_log_key);
             }
         }
-        state.retain(|p| p.pid != monitored_pid);
     });
     
     Ok(format!("Merod started successfully with PID: {}", pid))

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1106,11 +1106,18 @@ struct MerodProcess {
 
 type MerodState = Arc<Mutex<Vec<MerodProcess>>>;
 
+/// A registered log writer plus a reference count of live processes using it.
+/// Ref-counting means a restart or a concurrent second start (which reuse the
+/// same writer) don't drop the shared registration until the *last* user exits.
+struct LogWriterEntry {
+    writer: Arc<Mutex<log_rotation::RollingLogWriter>>,
+    refs: usize,
+}
+
 /// Live rotating log writers, keyed by log directory. Lets `clear_merod_logs`
 /// clear through the same writer the drain tasks use (serialized by the inner
 /// Mutex) rather than racing it via free functions on raw paths.
-type MerodLogWriters =
-    Arc<Mutex<std::collections::HashMap<String, Arc<Mutex<log_rotation::RollingLogWriter>>>>>;
+type MerodLogWriters = Arc<Mutex<std::collections::HashMap<String, LogWriterEntry>>>;
 
 /// Resolve an optional caller-supplied home dir: expand a leading `~`, or fall
 /// back to `~/.calimero`. Single source of truth for the node commands.
@@ -1130,33 +1137,6 @@ fn resolve_home_dir(home_dir: Option<String>) -> Result<std::path::PathBuf, Taur
             .ok_or_else(|| TauriError::new(TauriErrorCode::HomeDirNotFound, "Failed to get home directory"))?
             .join(".calimero"))
     }
-}
-
-/// Guard destructive/log commands: the resolved path must sit under the user's
-/// home directory (mirrors delete_calimero_data_dir). Uses lexical containment
-/// so it works for paths that don't exist yet.
-fn ensure_under_home(path: &std::path::Path) -> Result<(), TauriError> {
-    // Fail closed: if we can't resolve the home directory we can't prove the
-    // path is safe, so refuse rather than skip the check.
-    let home = dirs::home_dir()
-        .ok_or_else(|| TauriError::new(TauriErrorCode::PathNotAllowed, "Cannot resolve home directory to validate the path"))?;
-    let home = home.canonicalize().unwrap_or(home);
-    // Compare against the deepest existing ancestor so a not-yet-created
-    // logs dir still validates against its real (canonical) parent.
-    let mut probe = path.to_path_buf();
-    let anchor = loop {
-        if probe.exists() {
-            break probe.canonicalize().unwrap_or(probe);
-        }
-        match probe.parent() {
-            Some(p) => probe = p.to_path_buf(),
-            None => break path.to_path_buf(),
-        }
-    };
-    if !anchor.starts_with(&home) {
-        return Err(TauriError::new(TauriErrorCode::PathNotAllowed, "Path must be under your home directory"));
-    }
-    Ok(())
 }
 
 /// Get the path to the bundled merod binary
@@ -1452,14 +1432,17 @@ async fn start_merod(
         let mut map = log_writers
             .lock()
             .map_err(|_| TauriError::new(TauriErrorCode::InternalError, "log writers lock poisoned"))?;
-        match map.get(&log_key) {
-            Some(existing) => existing.clone(),
+        match map.get_mut(&log_key) {
+            Some(entry) => {
+                entry.refs += 1;
+                entry.writer.clone()
+            }
             None => {
                 let w = std::sync::Arc::new(std::sync::Mutex::new(
                     log_rotation::RollingLogWriter::open(&log_dir)
                         .map_err(|e| TauriError::with_details(TauriErrorCode::FileWriteError, "Failed to open log writer", e.to_string()))?,
                 ));
-                map.insert(log_key.clone(), w.clone());
+                map.insert(log_key.clone(), LogWriterEntry { writer: w.clone(), refs: 1 });
                 w
             }
         }
@@ -1535,7 +1518,6 @@ async fn start_merod(
     let merod_state_clone = merod_state.inner().clone();
     let log_writers_clone = log_writers.inner().clone();
     let exit_log_key = log_key.clone();
-    let exit_writer = log_writer.clone();
     let monitored_pid = pid; // Capture PID for verification
     tokio::spawn(async move {
         let status = child.wait().await;
@@ -1548,12 +1530,17 @@ async fn start_merod(
             }
             state.retain(|p| p.pid != monitored_pid);
         }
-        // Drop this node's writer registration (only if it's still the one we
-        // registered — a restart may have replaced it) so the map doesn't leak an
-        // open file handle per node, and clear falls back to on-disk once stopped.
+        // Drop one reference to this node's writer; remove the registration only
+        // when the last user exits. Ref-counting means a restart or a concurrent
+        // second start (which reuse the same writer) don't unregister it out from
+        // under a still-running drain — which would send clear() down the
+        // unsynchronized on-disk path while writes are live.
         if let Ok(mut map) = log_writers_clone.lock() {
-            if map.get(&exit_log_key).map(|w| std::sync::Arc::ptr_eq(w, &exit_writer)).unwrap_or(false) {
-                map.remove(&exit_log_key);
+            if let Some(entry) = map.get_mut(&exit_log_key) {
+                entry.refs = entry.refs.saturating_sub(1);
+                if entry.refs == 0 {
+                    map.remove(&exit_log_key);
+                }
             }
         }
     });
@@ -2543,7 +2530,9 @@ async fn get_merod_logs(
 
     let home_dir_path = resolve_home_dir(home_dir)?;
     let log_dir = home_dir_path.join(&node_name).join("logs");
-    ensure_under_home(&log_dir)?;
+    // Path safety is from validate_node_name; the data dir is user-configurable
+    // (may be outside $HOME), so we don't constrain it here — this is a read-only
+    // tail of `<data_dir>/<node>/logs` and can't traverse out.
 
     // Only hard-error when the node has no logs dir at all (never started by the
     // app). If the dir exists, read_tail returns whatever is present — including
@@ -2578,16 +2567,18 @@ async fn clear_merod_logs(
 
     let home_dir_path = resolve_home_dir(home_dir)?;
     let log_dir = home_dir_path.join(&node_name).join("logs");
-    // Destructive: constrain to the user's home directory (mirrors
-    // delete_calimero_data_dir) so an arbitrary home_dir can't truncate/delete
-    // files elsewhere on disk.
-    ensure_under_home(&log_dir)?;
+    // Path safety comes from validate_node_name (no separators / `..`), so the
+    // target is always `<data_dir>/<node>/logs` and can't traverse out. We do NOT
+    // constrain to $HOME here: the data dir is user-configurable (pick_directory
+    // can point at an external volume), and start_merod already writes logs there.
+    // Only files literally named merod.log[.N] under a validated node's logs dir
+    // are ever touched.
 
     // If a node is running, clear through its live writer (serialized with the
     // drain tasks by the inner Mutex) so we don't race a concurrent rotation or
     // leave the writer's cached length desynced. Otherwise clear on disk.
     let key = log_dir.to_string_lossy().to_string();
-    let live = log_writers.lock().ok().and_then(|m| m.get(&key).cloned());
+    let live = log_writers.lock().ok().and_then(|m| m.get(&key).map(|e| e.writer.clone()));
 
     let removed = tokio::task::spawn_blocking(move || -> std::io::Result<usize> {
         if let Some(writer) = live {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -2542,10 +2542,14 @@ async fn get_merod_logs(
     let lines = lines.unwrap_or(500).min(10_000);
 
     let home_dir_path = resolve_home_dir(home_dir)?;
-    let log_path = home_dir_path.join(&node_name).join("logs").join("merod.log");
-    ensure_under_home(&log_path)?;
+    let log_dir = home_dir_path.join(&node_name).join("logs");
+    ensure_under_home(&log_dir)?;
 
-    if !log_path.exists() {
+    // Only hard-error when the node has no logs dir at all (never started by the
+    // app). If the dir exists, read_tail returns whatever is present — including
+    // rotated segments alone when the active merod.log has been cleared/rotated
+    // away — or "" when empty.
+    if !log_dir.exists() {
         return Err(TauriError::new(
             TauriErrorCode::FileNotFound,
             format!("No log file found for node '{}'. Logs are only available for nodes started by the app.", node_name),
@@ -2554,10 +2558,6 @@ async fn get_merod_logs(
 
     // Bounded reverse tail across the active file + rotated segments — never loads
     // the whole (up to ~100 MB) history into memory just to return the last N lines.
-    let log_dir = log_path
-        .parent()
-        .map(|p| p.to_path_buf())
-        .ok_or_else(|| TauriError::new(TauriErrorCode::InternalError, "Invalid log path"))?;
     let max_lines = lines as usize;
     let result = tokio::task::spawn_blocking(move || log_rotation::read_tail(&log_dir, max_lines))
         .await

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1106,6 +1106,57 @@ struct MerodProcess {
 
 type MerodState = Arc<Mutex<Vec<MerodProcess>>>;
 
+/// Live rotating log writers, keyed by log directory. Lets `clear_merod_logs`
+/// clear through the same writer the drain tasks use (serialized by the inner
+/// Mutex) rather than racing it via free functions on raw paths.
+type MerodLogWriters =
+    Arc<Mutex<std::collections::HashMap<String, Arc<Mutex<log_rotation::RollingLogWriter>>>>>;
+
+/// Resolve an optional caller-supplied home dir: expand a leading `~`, or fall
+/// back to `~/.calimero`. Single source of truth for the node commands.
+fn resolve_home_dir(home_dir: Option<String>) -> Result<std::path::PathBuf, TauriError> {
+    if let Some(dir) = home_dir {
+        let expanded = if dir.starts_with("~") {
+            match dirs::home_dir() {
+                Some(home) => dir.replacen("~", &home.to_string_lossy(), 1),
+                None => return Err(TauriError::new(TauriErrorCode::HomeDirNotFound, "Failed to get home directory")),
+            }
+        } else {
+            dir
+        };
+        Ok(std::path::PathBuf::from(expanded))
+    } else {
+        Ok(dirs::home_dir()
+            .ok_or_else(|| TauriError::new(TauriErrorCode::HomeDirNotFound, "Failed to get home directory"))?
+            .join(".calimero"))
+    }
+}
+
+/// Guard destructive/log commands: the resolved path must sit under the user's
+/// home directory (mirrors delete_calimero_data_dir). Uses lexical containment
+/// so it works for paths that don't exist yet.
+fn ensure_under_home(path: &std::path::Path) -> Result<(), TauriError> {
+    if let Some(home) = dirs::home_dir() {
+        let home = home.canonicalize().unwrap_or(home);
+        // Compare against the deepest existing ancestor so a not-yet-created
+        // logs dir still validates against its real (canonical) parent.
+        let mut probe = path.to_path_buf();
+        let anchor = loop {
+            if probe.exists() {
+                break probe.canonicalize().unwrap_or(probe);
+            }
+            match probe.parent() {
+                Some(p) => probe = p.to_path_buf(),
+                None => break path.to_path_buf(),
+            }
+        };
+        if !anchor.starts_with(&home) {
+            return Err(TauriError::new(TauriErrorCode::PathNotAllowed, "Path must be under your home directory"));
+        }
+    }
+    Ok(())
+}
+
 /// Get the path to the bundled merod binary
 fn get_merod_binary_path(app_handle: &tauri::AppHandle) -> Result<std::path::PathBuf, String> {
     let resource_candidates = if cfg!(target_os = "windows") {
@@ -1160,6 +1211,9 @@ fn spawn_log_drain<R>(
         // and the viewer's lossy decode handle anything unusual downstream.
         let mut buf_reader = BufReader::new(reader);
         let mut buf: Vec<u8> = Vec::with_capacity(1024);
+        // Log a persistent write failure (disk full, dir deleted, …) once so it's
+        // discoverable, without spamming a warning for every dropped line.
+        let mut write_error_logged = false;
         loop {
             buf.clear();
             match buf_reader.read_until(b'\n', &mut buf).await {
@@ -1167,8 +1221,16 @@ fn spawn_log_drain<R>(
                 Ok(_) => {
                     if let Ok(mut w) = writer.lock() {
                         // Keep draining even if a write fails, so a write error can
-                        // never wedge merod by leaving its pipe unread.
-                        let _ = w.write_line(&buf);
+                        // never wedge merod by leaving its pipe unread — but surface
+                        // the first failure so silent log loss is diagnosable.
+                        if let Err(e) = w.write_line(&buf) {
+                            if !write_error_logged {
+                                warn!("[Merod] log write failed (further errors suppressed): {}", e);
+                                write_error_logged = true;
+                            }
+                        } else {
+                            write_error_logged = false;
+                        }
                     }
                 }
                 Err(e) => {
@@ -1191,6 +1253,7 @@ async fn start_merod(
     debug_logs: Option<bool>,
     app_handle: tauri::AppHandle,
     merod_state: tauri::State<'_, MerodState>,
+    log_writers: tauri::State<'_, MerodLogWriters>,
 ) -> Result<String, TauriError> {
     let server_port = server_port.unwrap_or(2528);
     let swarm_port = swarm_port.unwrap_or(2428);
@@ -1363,11 +1426,16 @@ async fn start_merod(
         warn!("[Merod] Log cleanup failed (non-fatal): {}", e);
     }
 
-    // Rotating writer shared by the stdout and stderr drain tasks.
+    // Rotating writer shared by the stdout and stderr drain tasks. Registered in
+    // MerodLogWriters so clear_merod_logs can clear through this same instance
+    // (serialized by the inner Mutex) instead of racing it on raw paths.
     let log_writer = std::sync::Arc::new(std::sync::Mutex::new(
         log_rotation::RollingLogWriter::open(&log_dir)
             .map_err(|e| TauriError::with_details(TauriErrorCode::FileWriteError, "Failed to open log writer", e.to_string()))?,
     ));
+    if let Ok(mut map) = log_writers.lock() {
+        map.insert(log_dir.to_string_lossy().to_string(), log_writer.clone());
+    }
 
     // Build command - global options come BEFORE subcommand
     // Merod expects: merod --home ~/.calimero --node node1 run
@@ -2432,24 +2500,9 @@ async fn get_merod_logs(
     validate_node_name(&node_name).map_err(|e| TauriError::new(TauriErrorCode::InvalidInput, e))?;
     let lines = lines.unwrap_or(500).min(10_000);
 
-    let home_dir_path = if let Some(dir) = home_dir {
-        let expanded = if dir.starts_with("~") {
-            if let Some(home) = dirs::home_dir() {
-                dir.replacen("~", &home.to_string_lossy(), 1)
-            } else {
-                dir
-            }
-        } else {
-            dir
-        };
-        std::path::PathBuf::from(expanded)
-    } else {
-        dirs::home_dir()
-            .ok_or_else(|| TauriError::new(TauriErrorCode::HomeDirNotFound, "Failed to get home directory"))?
-            .join(".calimero")
-    };
-
+    let home_dir_path = resolve_home_dir(home_dir)?;
     let log_path = home_dir_path.join(&node_name).join("logs").join("merod.log");
+    ensure_under_home(&log_path)?;
 
     if !log_path.exists() {
         return Err(TauriError::new(
@@ -2478,31 +2531,36 @@ async fn get_merod_logs(
 async fn clear_merod_logs(
     node_name: String,
     home_dir: Option<String>,
+    log_writers: tauri::State<'_, MerodLogWriters>,
 ) -> Result<String, TauriError> {
     validate_node_name(&node_name).map_err(|e| TauriError::new(TauriErrorCode::InvalidInput, e))?;
 
-    let home_dir_path = if let Some(dir) = home_dir {
-        let expanded = if dir.starts_with("~") {
-            if let Some(home) = dirs::home_dir() {
-                dir.replacen("~", &home.to_string_lossy(), 1)
-            } else {
-                dir
-            }
-        } else {
-            dir
-        };
-        std::path::PathBuf::from(expanded)
-    } else {
-        dirs::home_dir()
-            .ok_or_else(|| TauriError::new(TauriErrorCode::HomeDirNotFound, "Failed to get home directory"))?
-            .join(".calimero")
-    };
-
+    let home_dir_path = resolve_home_dir(home_dir)?;
     let log_dir = home_dir_path.join(&node_name).join("logs");
-    let removed = tokio::task::spawn_blocking(move || log_rotation::clear_logs(&log_dir))
-        .await
-        .map_err(|e| TauriError::with_details(TauriErrorCode::InternalError, "Log clear task failed", e.to_string()))?
-        .map_err(|e| TauriError::with_details(TauriErrorCode::FileWriteError, "Failed to clear log files", e.to_string()))?;
+    // Destructive: constrain to the user's home directory (mirrors
+    // delete_calimero_data_dir) so an arbitrary home_dir can't truncate/delete
+    // files elsewhere on disk.
+    ensure_under_home(&log_dir)?;
+
+    // If a node is running, clear through its live writer (serialized with the
+    // drain tasks by the inner Mutex) so we don't race a concurrent rotation or
+    // leave the writer's cached length desynced. Otherwise clear on disk.
+    let key = log_dir.to_string_lossy().to_string();
+    let live = log_writers.lock().ok().and_then(|m| m.get(&key).cloned());
+
+    let removed = tokio::task::spawn_blocking(move || -> std::io::Result<usize> {
+        if let Some(writer) = live {
+            let mut w = writer
+                .lock()
+                .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "log writer lock poisoned"))?;
+            w.clear()
+        } else {
+            log_rotation::clear_logs(&log_dir)
+        }
+    })
+    .await
+    .map_err(|e| TauriError::with_details(TauriErrorCode::InternalError, "Log clear task failed", e.to_string()))?
+    .map_err(|e| TauriError::with_details(TauriErrorCode::FileWriteError, "Failed to clear log files", e.to_string()))?;
 
     Ok(format!("Cleared logs ({} rotated segment(s) removed)", removed))
 }
@@ -3094,6 +3152,7 @@ fn main() {
             Ok(())
         })
         .manage(MerodState::default())
+        .manage(MerodLogWriters::default())
         .manage(SseCancelRegistry::new(std::sync::Mutex::new(std::collections::HashMap::new())))
         .manage(TokenBrokerRegistry::new(std::sync::Mutex::new(std::collections::HashMap::new())))
         .invoke_handler(tauri::generate_handler![

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1152,19 +1152,31 @@ fn spawn_log_drain<R>(
 {
     use tokio::io::{AsyncBufReadExt, BufReader};
     tokio::spawn(async move {
-        let mut lines = BufReader::new(reader).lines();
+        // Read raw bytes with read_until rather than lines(): merod can emit
+        // non-UTF-8 (panic backtraces, stray binary), which lines() surfaces as an
+        // Err that would permanently — and silently — kill the drain, so logs just
+        // stop appearing. read_until preserves the bytes verbatim (ANSI colour
+        // codes included) and never fails on invalid UTF-8; the writer's rotation
+        // and the viewer's lossy decode handle anything unusual downstream.
+        let mut buf_reader = BufReader::new(reader);
+        let mut buf: Vec<u8> = Vec::with_capacity(1024);
         loop {
-            match lines.next_line().await {
-                Ok(Some(mut line)) => {
-                    line.push('\n');
+            buf.clear();
+            match buf_reader.read_until(b'\n', &mut buf).await {
+                Ok(0) => break, // EOF: process exited / stream closed
+                Ok(_) => {
                     if let Ok(mut w) = writer.lock() {
                         // Keep draining even if a write fails, so a write error can
                         // never wedge merod by leaving its pipe unread.
-                        let _ = w.write_line(line.as_bytes());
+                        let _ = w.write_line(&buf);
                     }
                 }
-                Ok(None) => break, // EOF: process exited / stream closed
-                Err(_) => break,
+                Err(e) => {
+                    // A genuine I/O error (not a decode error) — log it so a
+                    // stream that stops mid-run is diagnosable, then exit.
+                    warn!("[Merod] log drain stopped on read error: {}", e);
+                    break;
+                }
             }
         }
     });

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -8,6 +8,8 @@ use log::{debug, info, warn};
 use std::sync::OnceLock;
 use thiserror::Error;
 
+mod log_rotation;
+
 static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 static SSE_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
@@ -1139,6 +1141,35 @@ fn get_app_data_dir(app_handle: &tauri::AppHandle) -> Result<std::path::PathBuf,
     Ok(app_data_dir)
 }
 
+/// Drain a child stdout/stderr stream line-by-line into the rotating log writer.
+/// The lock is held only for each short synchronous write (never across an await),
+/// so the two drain tasks (stdout + stderr) interleave without corrupting lines.
+fn spawn_log_drain<R>(
+    reader: R,
+    writer: std::sync::Arc<std::sync::Mutex<log_rotation::RollingLogWriter>>,
+) where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(reader).lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(mut line)) => {
+                    line.push('\n');
+                    if let Ok(mut w) = writer.lock() {
+                        // Keep draining even if a write fails, so a write error can
+                        // never wedge merod by leaving its pipe unread.
+                        let _ = w.write_line(line.as_bytes());
+                    }
+                }
+                Ok(None) => break, // EOF: process exited / stream closed
+                Err(_) => break,
+            }
+        }
+    });
+}
+
 #[tauri::command]
 async fn start_merod(
     server_port: Option<u16>,
@@ -1307,27 +1338,24 @@ async fn start_merod(
     // Node name required
     let node_name_str = node_name.as_ref().ok_or_else(|| TauriError::new(TauriErrorCode::InvalidInput, "Node name is required"))?.clone();
 
-    // Create logs directory and open log file - redirect merod stdout/stderr here
+    // Create logs directory. merod's stdout/stderr are piped to the app and drained
+    // into a size-capped rotating writer (see below) so logs never grow unbounded.
     let log_dir = home_dir_path.join(&node_name_str).join("logs");
     std::fs::create_dir_all(&log_dir)
         .map_err(|e| TauriError::with_details(TauriErrorCode::DirectoryError, "Failed to create logs directory", e.to_string()))?;
     let log_path = log_dir.join("merod.log");
 
-    // Open log file for append - use separate handles for stdout and stderr
-    let log_file_stdout = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&log_path)
-        .map_err(|e| TauriError::with_details(TauriErrorCode::FileWriteError, "Failed to create log file", e.to_string()))?;
-    let log_file_stderr = log_file_stdout
-        .try_clone()
-        .or_else(|_| {
-            std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&log_path)
-        })
-        .map_err(|e| TauriError::with_details(TauriErrorCode::FileWriteError, "Failed to open log file for stderr", e.to_string()))?;
+    // Trim old/oversized rotated segments before we start writing (also brings a
+    // legacy pre-rotation merod.log back under the cap on next start).
+    if let Err(e) = log_rotation::cleanup_logs(&log_dir) {
+        warn!("[Merod] Log cleanup failed (non-fatal): {}", e);
+    }
+
+    // Rotating writer shared by the stdout and stderr drain tasks.
+    let log_writer = std::sync::Arc::new(std::sync::Mutex::new(
+        log_rotation::RollingLogWriter::open(&log_dir)
+            .map_err(|e| TauriError::with_details(TauriErrorCode::FileWriteError, "Failed to open log writer", e.to_string()))?,
+    ));
 
     // Build command - global options come BEFORE subcommand
     // Merod expects: merod --home ~/.calimero --node node1 run
@@ -1352,9 +1380,9 @@ async fn start_merod(
     // Add 'run' subcommand last
     cmd.arg("run");
     
-    // Redirect stdout/stderr to log file - merod output goes directly to disk
-    cmd.stdout(Stdio::from(log_file_stdout));
-    cmd.stderr(Stdio::from(log_file_stderr));
+    // Pipe stdout/stderr so the app can drain them into the rotating writer.
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
     cmd.stdin(Stdio::null());
     
     // Log the command being run
@@ -1367,7 +1395,16 @@ async fn start_merod(
     
     let pid = child.id().unwrap();
     info!("[Merod] Started with PID: {}", pid);
-    
+
+    // Drain stdout+stderr into the rotating writer. Taken before the child is moved
+    // into the monitor task below.
+    if let Some(out) = child.stdout.take() {
+        spawn_log_drain(out, log_writer.clone());
+    }
+    if let Some(err) = child.stderr.take() {
+        spawn_log_drain(err, log_writer.clone());
+    }
+
     // Wait a brief moment to check if process is still alive
     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     
@@ -2409,15 +2446,53 @@ async fn get_merod_logs(
         ));
     }
 
-    let content = tokio::fs::read_to_string(&log_path)
+    // Bounded reverse tail across the active file + rotated segments — never loads
+    // the whole (up to ~100 MB) history into memory just to return the last N lines.
+    let log_dir = log_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| TauriError::new(TauriErrorCode::InternalError, "Invalid log path"))?;
+    let max_lines = lines as usize;
+    let result = tokio::task::spawn_blocking(move || log_rotation::read_tail(&log_dir, max_lines))
         .await
+        .map_err(|e| TauriError::with_details(TauriErrorCode::InternalError, "Log read task failed", e.to_string()))?
         .map_err(|e| TauriError::with_details(TauriErrorCode::FileReadError, "Failed to read log file", e.to_string()))?;
-    
-    let all_lines: Vec<&str> = content.lines().collect();
-    let start = all_lines.len().saturating_sub(lines as usize);
-    let last_lines = &all_lines[start..];
-    
-    Ok(last_lines.join("\n"))
+
+    Ok(result)
+}
+
+/// Truncate the active log file and delete rotated segments for a node.
+#[tauri::command]
+async fn clear_merod_logs(
+    node_name: String,
+    home_dir: Option<String>,
+) -> Result<String, TauriError> {
+    validate_node_name(&node_name).map_err(|e| TauriError::new(TauriErrorCode::InvalidInput, e))?;
+
+    let home_dir_path = if let Some(dir) = home_dir {
+        let expanded = if dir.starts_with("~") {
+            if let Some(home) = dirs::home_dir() {
+                dir.replacen("~", &home.to_string_lossy(), 1)
+            } else {
+                dir
+            }
+        } else {
+            dir
+        };
+        std::path::PathBuf::from(expanded)
+    } else {
+        dirs::home_dir()
+            .ok_or_else(|| TauriError::new(TauriErrorCode::HomeDirNotFound, "Failed to get home directory"))?
+            .join(".calimero")
+    };
+
+    let log_dir = home_dir_path.join(&node_name).join("logs");
+    let removed = tokio::task::spawn_blocking(move || log_rotation::clear_logs(&log_dir))
+        .await
+        .map_err(|e| TauriError::with_details(TauriErrorCode::InternalError, "Log clear task failed", e.to_string()))?
+        .map_err(|e| TauriError::with_details(TauriErrorCode::FileWriteError, "Failed to clear log files", e.to_string()))?;
+
+    Ok(format!("Cleared logs ({} rotated segment(s) removed)", removed))
 }
 
 #[tauri::command]
@@ -3032,6 +3107,7 @@ fn main() {
             init_merod_node,
             detect_running_merod_nodes,
             get_merod_logs,
+            clear_merod_logs,
             get_merod_binary_version,
             download_and_replace_merod,
             set_tray_icon_connected,

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1448,6 +1448,20 @@ async fn start_merod(
         }
     };
 
+    // Drop the ref we just took, for the early-return paths before the exit
+    // monitor (which is what normally decrements) is spawned — otherwise a failed
+    // spawn / immediate exit would leak the registration (and its file handle).
+    let unregister_writer = || {
+        if let Ok(mut map) = log_writers.lock() {
+            if let Some(entry) = map.get_mut(&log_key) {
+                entry.refs = entry.refs.saturating_sub(1);
+                if entry.refs == 0 {
+                    map.remove(&log_key);
+                }
+            }
+        }
+    };
+
     // Build command - global options come BEFORE subcommand
     // Merod expects: merod --home ~/.calimero --node node1 run
     let mut cmd = Command::new(&merod_binary);
@@ -1481,8 +1495,13 @@ async fn start_merod(
     info!("[Merod] Running command: {}, logs at {:?}", cmd_str, log_path);
     
     // Start the process
-    let mut child = cmd.spawn()
-        .map_err(|e| TauriError::with_details(TauriErrorCode::MerodStartFailed, "Failed to start merod", e.to_string()))?;
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            unregister_writer();
+            return Err(TauriError::with_details(TauriErrorCode::MerodStartFailed, "Failed to start merod", e.to_string()));
+        }
+    };
     
     let pid = child.id().unwrap();
     info!("[Merod] Started with PID: {}", pid);
@@ -1504,6 +1523,7 @@ async fn start_merod(
         if let Some(code) = status.code() {
             let error_msg = format!("Merod process exited immediately with code: {}. Check merod logs for details.", code);
             warn!("[Merod] {}", error_msg);
+            unregister_writer();
             return Err(TauriError::new(TauriErrorCode::MerodProcessExited, error_msg));
         }
     }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1211,26 +1211,40 @@ fn spawn_log_drain<R>(
         // and the viewer's lossy decode handle anything unusual downstream.
         let mut buf_reader = BufReader::new(reader);
         let mut buf: Vec<u8> = Vec::with_capacity(1024);
-        // Log a persistent write failure (disk full, dir deleted, …) once so it's
-        // discoverable, without spamming a warning for every dropped line.
+        // Log a persistent write failure (disk full, dir deleted, …) or a
+        // poisoned writer lock once so it's discoverable, without spamming a
+        // warning for every dropped line.
         let mut write_error_logged = false;
+        let mut poison_logged = false;
         loop {
             buf.clear();
             match buf_reader.read_until(b'\n', &mut buf).await {
                 Ok(0) => break, // EOF: process exited / stream closed
                 Ok(_) => {
-                    if let Ok(mut w) = writer.lock() {
-                        // Keep draining even if a write fails, so a write error can
-                        // never wedge merod by leaving its pipe unread — but surface
-                        // the first failure so silent log loss is diagnosable.
-                        if let Err(e) = w.write_line(&buf) {
-                            if !write_error_logged {
-                                warn!("[Merod] log write failed (further errors suppressed): {}", e);
-                                write_error_logged = true;
+                    // Recover the guard even if the mutex was poisoned (some other
+                    // holder panicked): a std Mutex stays poisoned forever, so
+                    // ignoring the Err would silently stop all logging. into_inner()
+                    // keeps draining; we warn once so it's diagnosable.
+                    let mut w = match writer.lock() {
+                        Ok(g) => g,
+                        Err(poisoned) => {
+                            if !poison_logged {
+                                warn!("[Merod] log writer mutex poisoned; recovering and continuing: {}", poisoned);
+                                poison_logged = true;
                             }
-                        } else {
-                            write_error_logged = false;
+                            poisoned.into_inner()
                         }
+                    };
+                    // Keep draining even if a write fails, so a write error can
+                    // never wedge merod by leaving its pipe unread — but surface
+                    // the first failure so silent log loss is diagnosable.
+                    if let Err(e) = w.write_line(&buf) {
+                        if !write_error_logged {
+                            warn!("[Merod] log write failed (further errors suppressed): {}", e);
+                            write_error_logged = true;
+                        }
+                    } else {
+                        write_error_logged = false;
                     }
                 }
                 Err(e) => {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Calimero Desktop",
-    "version": "0.0.70"
+    "version": "0.0.71"
   },
   "tauri": {
     "allowlist": {

--- a/apps/desktop/src/components/LoginView.tsx
+++ b/apps/desktop/src/components/LoginView.tsx
@@ -33,6 +33,11 @@ export function LoginView({ onSuccess, onError, variant = 'light' }: LoginViewPr
       const response = await apiClient.auth.getProviders();
       if (response.error) {
         setError(response.error.message);
+        // Discovery failed — never leave the (default) credential form up, or a
+        // node without password auth would show the wrong screen. Show the
+        // provider view, which renders the error / empty state.
+        setShowUsernamePasswordForm(false);
+        setShowProviders(true);
         return;
       }
       if (response.data) {
@@ -47,6 +52,9 @@ export function LoginView({ onSuccess, onError, variant = 'light' }: LoginViewPr
     } catch (err) {
       console.error('Failed to load providers:', err);
       setError('Failed to load authentication providers');
+      // Same as above: fall back to the provider view rather than the form.
+      setShowUsernamePasswordForm(false);
+      setShowProviders(true);
     } finally {
       setLoading(false);
     }

--- a/apps/desktop/src/components/LoginView.tsx
+++ b/apps/desktop/src/components/LoginView.tsx
@@ -11,12 +11,19 @@ export interface LoginViewProps {
   variant?: 'light' | 'dark';
 }
 
+const isUserPasswordProvider = (p: Provider) =>
+  p.name === 'user_password' || p.name === 'username_password';
+
 export function LoginView({ onSuccess, onError, variant = 'light' }: LoginViewProps) {
   const [providers, setProviders] = useState<Provider[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [showProviders, setShowProviders] = useState(true);
-  const [showUsernamePasswordForm, setShowUsernamePasswordForm] = useState(false);
+  // Username/password is the primary method, so the form is the default view —
+  // the credential fields sit at the top of the popup instead of being buried
+  // behind a provider-selection step. We only fall back to the provider list
+  // when the node has no username/password provider (or offers extra ones).
+  const [showProviders, setShowProviders] = useState(false);
+  const [showUsernamePasswordForm, setShowUsernamePasswordForm] = useState(true);
   const [usernamePasswordLoading, setUsernamePasswordLoading] = useState(false);
 
   const loadProviders = useCallback(async () => {
@@ -29,7 +36,13 @@ export function LoginView({ onSuccess, onError, variant = 'light' }: LoginViewPr
         return;
       }
       if (response.data) {
-        setProviders(response.data.providers);
+        const loaded = response.data.providers;
+        setProviders(loaded);
+        // Show the credential form directly when the node supports it; otherwise
+        // fall through to the provider list (which also renders the empty state).
+        const hasUserPassword = loaded.some(isUserPasswordProvider);
+        setShowUsernamePasswordForm(hasUserPassword);
+        setShowProviders(!hasUserPassword);
       }
     } catch (err) {
       console.error('Failed to load providers:', err);
@@ -119,10 +132,15 @@ export function LoginView({ onSuccess, onError, variant = 'light' }: LoginViewPr
   }
 
   if (showUsernamePasswordForm) {
+    // Only offer "Back" when there is somewhere to go — i.e. the node exposes
+    // other providers besides username/password. With a single provider the
+    // form is the whole login, so a back button would just bounce to a
+    // one-item list.
+    const hasOtherProviders = providers.some((p) => !isUserPasswordProvider(p));
     return (
       <UsernamePasswordForm
         onSubmit={handleUsernamePasswordAuth}
-        onBack={handleBack}
+        onBack={hasOtherProviders ? handleBack : undefined}
         loading={usernamePasswordLoading}
         error={error}
         containerClassName="login-form-container"

--- a/apps/desktop/src/components/LoginView.tsx
+++ b/apps/desktop/src/components/LoginView.tsx
@@ -57,7 +57,7 @@ export function LoginView({ onSuccess, onError, variant = 'light' }: LoginViewPr
   }, [loadProviders]);
 
   const handleProviderSelect = async (provider: Provider) => {
-    if (provider.name === 'user_password' || provider.name === 'username_password') {
+    if (isUserPasswordProvider(provider)) {
       setShowProviders(false);
       setShowUsernamePasswordForm(true);
     } else {

--- a/apps/desktop/src/components/LoginView.tsx
+++ b/apps/desktop/src/components/LoginView.tsx
@@ -117,6 +117,24 @@ export function LoginView({ onSuccess, onError, variant = 'light' }: LoginViewPr
     setError(null);
   };
 
+  // Until provider discovery finishes, show the neutral loading state rather
+  // than a concrete form — otherwise a node without username/password would
+  // briefly flash the credential form and let the user submit before discovery
+  // resolved which method(s) the node actually supports.
+  if (loading) {
+    return (
+      <ProviderSelector
+        providers={[]}
+        onProviderSelect={handleProviderSelect}
+        loading={true}
+        error={error}
+        containerClassName="login-provider-container"
+        cardClassName="login-provider-card"
+        variant={variant}
+      />
+    );
+  }
+
   if (showProviders) {
     return (
       <ProviderSelector

--- a/apps/desktop/src/components/LogsViewer.css
+++ b/apps/desktop/src/components/LogsViewer.css
@@ -174,3 +174,15 @@
   border-top: 1px solid var(--border-color);
   background: var(--surface-glass-soft);
 }
+
+.logs-viewer-truncated {
+  position: sticky;
+  top: 0;
+  margin: -16px -20px 12px;
+  padding: 8px 20px;
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  background: var(--surface-glass-soft);
+  border-bottom: 1px solid var(--border-color);
+  font-family: system-ui, -apple-system, sans-serif;
+}

--- a/apps/desktop/src/components/LogsViewer.tsx
+++ b/apps/desktop/src/components/LogsViewer.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useRef, useEffect } from "react";
-import { Search, Copy, Check, RefreshCw, X } from "lucide-react";
+import { Search, Copy, Check, RefreshCw, X, Trash2 } from "lucide-react";
 import Convert from "ansi-to-html";
 import { useTheme } from "../contexts/ThemeContext";
 import "./LogsViewer.css";
@@ -10,7 +10,14 @@ interface LogsViewerProps {
   loading?: boolean;
   onRefresh: () => void;
   onClose: () => void;
+  onClear?: () => void;
 }
+
+// Cap how many lines are ever put in the DOM at once. The backend already tails
+// (default 500), but a large fetch or an unfiltered view could still push
+// thousands of nodes into one scroll container; rendering only the most recent
+// slice keeps the viewer responsive regardless of how much was fetched.
+const MAX_RENDERED_LINES = 3000;
 
 export function LogsViewer({
   content,
@@ -18,8 +25,10 @@ export function LogsViewer({
   loading = false,
   onRefresh,
   onClose,
+  onClear,
 }: LogsViewerProps) {
   const { theme } = useTheme();
+  const [filterInput, setFilterInput] = useState("");
   const [filter, setFilter] = useState("");
   const [caseSensitive, setCaseSensitive] = useState(false);
   const [levelFilter, setLevelFilter] = useState<string>("");
@@ -27,6 +36,9 @@ export function LogsViewer({
   const [copied, setCopied] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Whether the user is scrolled to (near) the bottom. Auto-scroll only nudges
+  // the view when they haven't deliberately scrolled up to read older lines.
+  const pinnedToBottomRef = useRef(true);
 
   const levels = [
     { id: "", label: "All" },
@@ -37,14 +49,22 @@ export function LogsViewer({
     { id: "TRACE", label: "Trace" },
   ];
 
+  // Debounce the filter so we don't re-scan every line on each keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => setFilter(filterInput), 150);
+    return () => clearTimeout(t);
+  }, [filterInput]);
+
+  // Split the raw content exactly once; every derived value reuses this.
+  const allLines = useMemo(() => content.split("\n"), [content]);
+
   const filteredLines = useMemo(() => {
-    const lines = content.split("\n");
-    return lines.filter((line) => {
+    if (!filter && !levelFilter) return allLines;
+    const needle = caseSensitive ? filter : filter.toLowerCase();
+    return allLines.filter((line) => {
       const matchFilter =
         !filter ||
-        (caseSensitive
-          ? line.includes(filter)
-          : line.toLowerCase().includes(filter.toLowerCase()));
+        (caseSensitive ? line.includes(needle) : line.toLowerCase().includes(needle));
       const matchLevel =
         !levelFilter ||
         line.includes(`[${levelFilter}]`) ||
@@ -52,7 +72,14 @@ export function LogsViewer({
         line.toUpperCase().includes(levelFilter);
       return matchFilter && matchLevel;
     });
-  }, [content, filter, caseSensitive, levelFilter]);
+  }, [allLines, filter, caseSensitive, levelFilter]);
+
+  // Only the most recent slice is rendered; older lines stay out of the DOM.
+  const hiddenCount = Math.max(0, filteredLines.length - MAX_RENDERED_LINES);
+  const visibleLines = useMemo(
+    () => (hiddenCount > 0 ? filteredLines.slice(-MAX_RENDERED_LINES) : filteredLines),
+    [filteredLines, hiddenCount]
+  );
 
   const convert = useMemo(
     () =>
@@ -66,12 +93,13 @@ export function LogsViewer({
   );
 
   const renderedContent = useMemo(() => {
-    const text = filteredLines.join("\n");
+    const text = visibleLines.join("\n");
     return text ? convert.toHtml(text) : "";
-  }, [filteredLines, convert]);
+  }, [visibleLines, convert]);
 
   const handleCopy = async () => {
     try {
+      // Copy the full filtered set, not just the rendered slice.
       await navigator.clipboard.writeText(filteredLines.join("\n"));
       if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
       setCopied(true);
@@ -88,10 +116,18 @@ export function LogsViewer({
   }, []);
 
   useEffect(() => {
-    if (autoScroll && scrollRef.current) {
+    if (autoScroll && pinnedToBottomRef.current && scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
-  }, [filteredLines, autoScroll]);
+  }, [visibleLines, autoScroll]);
+
+  const handleScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    // "Near bottom" tolerance so tiny rounding doesn't unpin the view.
+    pinnedToBottomRef.current =
+      el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+  };
 
   return (
     <div className="logs-viewer-overlay" onClick={onClose}>
@@ -116,6 +152,17 @@ export function LogsViewer({
               {copied ? <Check size={14} /> : <Copy size={14} />}
               {copied ? "Copied!" : "Copy"}
             </button>
+            {onClear && (
+              <button
+                onClick={onClear}
+                className="logs-viewer-btn"
+                disabled={loading}
+                title="Clear logs on disk"
+              >
+                <Trash2 size={14} />
+                Clear
+              </button>
+            )}
             <button
               onClick={onClose}
               className="logs-viewer-btn logs-viewer-close"
@@ -132,8 +179,8 @@ export function LogsViewer({
             <input
               type="text"
               placeholder="Filter logs..."
-              value={filter}
-              onChange={(e) => setFilter(e.target.value)}
+              value={filterInput}
+              onChange={(e) => setFilterInput(e.target.value)}
               className="logs-viewer-search-input"
             />
           </div>
@@ -166,18 +213,28 @@ export function LogsViewer({
           </label>
         </div>
 
-        <div ref={scrollRef} className="logs-viewer-content">
+        <div ref={scrollRef} className="logs-viewer-content" onScroll={handleScroll}>
           {loading ? (
             "Loading logs..."
           ) : renderedContent ? (
-            <div dangerouslySetInnerHTML={{ __html: renderedContent }} />
+            <>
+              {hiddenCount > 0 && (
+                <div className="logs-viewer-truncated">
+                  {hiddenCount.toLocaleString()} older line(s) hidden — showing the
+                  most recent {MAX_RENDERED_LINES.toLocaleString()}. Use the filter to
+                  narrow down, or Copy to export everything fetched.
+                </div>
+              )}
+              <div dangerouslySetInnerHTML={{ __html: renderedContent }} />
+            </>
           ) : (
             "(No log output)"
           )}
         </div>
         {(filter || levelFilter) && (
           <div className="logs-viewer-footer">
-            Showing {filteredLines.length} of {content.split("\n").length} lines
+            Showing {filteredLines.length.toLocaleString()} of{" "}
+            {allLines.length.toLocaleString()} lines
           </div>
         )}
       </div>

--- a/apps/desktop/src/pages/NodeManagement.tsx
+++ b/apps/desktop/src/pages/NodeManagement.tsx
@@ -302,12 +302,19 @@ export default function NodeManagement() {
     setLogsLoading(true);
     try {
       await clearMerodLogs(selectedNode, homeDir);
-      // Re-read so the viewer reflects the now-empty (or freshly appended) file.
-      const logs = await getMerodLogs(selectedNode, homeDir, 500);
-      setLogsContent(logs || "(No log output yet)");
       toast.success("Logs cleared");
     } catch (err: any) {
       toast.error(err?.message || "Failed to clear logs");
+      setLogsLoading(false);
+      return;
+    }
+    // Re-read in a separate step: a failed re-fetch (e.g. no merod.log yet after
+    // clearing) must not be reported as a clear failure — the clear succeeded.
+    try {
+      const logs = await getMerodLogs(selectedNode, homeDir, 500);
+      setLogsContent(logs || "(No log output yet)");
+    } catch {
+      setLogsContent("(No log output yet)");
     } finally {
       setLogsLoading(false);
     }

--- a/apps/desktop/src/pages/NodeManagement.tsx
+++ b/apps/desktop/src/pages/NodeManagement.tsx
@@ -9,6 +9,7 @@ import {
   stopMerodByPid,
   detectRunningMerodNodes,
   getMerodLogs,
+  clearMerodLogs,
   getMerodBinaryVersion,
   type RunningMerodNode,
 } from "../utils/merod";
@@ -291,6 +292,22 @@ export default function NodeManagement() {
     } catch (err: any) {
       setLogsContent(err?.message || "Failed to load logs");
       toast.error("Failed to refresh logs");
+    } finally {
+      setLogsLoading(false);
+    }
+  };
+
+  const handleClearLogs = async () => {
+    if (!selectedNode) return;
+    setLogsLoading(true);
+    try {
+      await clearMerodLogs(selectedNode, homeDir);
+      // Re-read so the viewer reflects the now-empty (or freshly appended) file.
+      const logs = await getMerodLogs(selectedNode, homeDir, 500);
+      setLogsContent(logs || "(No log output yet)");
+      toast.success("Logs cleared");
+    } catch (err: any) {
+      toast.error(err?.message || "Failed to clear logs");
     } finally {
       setLogsLoading(false);
     }
@@ -588,6 +605,7 @@ export default function NodeManagement() {
             title={selectedNode}
             loading={logsLoading}
             onRefresh={handleRefreshLogs}
+            onClear={handleClearLogs}
             onClose={() => setShowLogsModal(false)}
           />
         )}

--- a/apps/desktop/src/pages/Onboarding.css
+++ b/apps/desktop/src/pages/Onboarding.css
@@ -53,15 +53,17 @@
 /* Progress Indicator */
 .onboarding-progress {
   width: 100%;
-  max-width: 700px;
-  margin: 0 auto 32px;
+  max-width: 640px;
+  margin: 0 auto 24px;
   padding: 0;
   flex-shrink: 0;
   position: relative;
   background: transparent;
   z-index: 10;
   order: -1;
-  animation: fadeUp 0.5s ease-out;
+  /* Fade only (no translate): this element is stable across steps and keystrokes,
+     so a vertical entrance would read as the progress bar "jumping". */
+  animation: fadeIn 0.4s ease-out;
 }
 
 .progress-steps {
@@ -70,6 +72,7 @@
   align-items: center;
   position: relative;
   padding: 0 20px;
+  min-height: 16px;
 }
 
 .progress-steps::before {
@@ -136,9 +139,9 @@
   background: var(--gradient-surface), var(--surface-glass);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-xl);
-  padding: 40px 48px;
+  padding: 32px 40px;
   width: 100%;
-  max-width: 700px;
+  max-width: 640px;
   box-shadow: var(--shadow-lg);
   display: flex;
   flex-direction: column;
@@ -153,7 +156,14 @@
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
   z-index: 1;
-  animation: fadeUp 0.5s ease-out 0.1s both;
+  /* Keyed by currentStep in the TSX, so this replays as a clean per-step
+     entrance — subtle rise + fade, not a big vertical jump. */
+  animation: stepIn 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes stepIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 /* Back Button */
@@ -190,7 +200,7 @@
   align-items: center;
   justify-content: flex-start;
   text-align: center;
-  padding: 32px;
+  padding: 20px 24px;
   min-height: 0;
   width: 100%;
   overflow: visible;
@@ -216,7 +226,6 @@
   margin-bottom: 24px;
   color: var(--accent-primary);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  animation: iconFloat 3s ease-in-out infinite;
   padding: 20px;
   box-sizing: border-box;
 }
@@ -230,11 +239,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
 }
 
 .step-logo-wrapper .calimero-logo {
-  width: 200px;
+  width: 160px;
   height: auto;
   max-width: 100%;
   object-fit: contain;
@@ -270,20 +279,20 @@
 }
 
 .step-title {
-  margin: 0 0 16px 0;
-  font-size: 32px;
+  margin: 0 0 10px 0;
+  font-size: 24px;
   font-weight: 700;
   color: var(--text-primary);
-  line-height: 1.2;
-  letter-spacing: -0.5px;
+  line-height: 1.25;
+  letter-spacing: -0.4px;
 }
 
 .step-description {
-  margin: 0;
-  font-size: 17px;
-  line-height: 1.6;
+  margin: 0 auto;
+  font-size: 14px;
+  line-height: 1.55;
   color: var(--text-secondary);
-  max-width: 600px;
+  max-width: 460px;
   font-weight: 400;
   width: 100%;
 }
@@ -327,26 +336,27 @@
 .step-principles {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  margin-top: 24px;
+  gap: 8px;
+  margin-top: 20px;
   width: 100%;
-  max-width: 550px;
+  max-width: 420px;
   margin-left: auto;
   margin-right: auto;
 }
 
 .principle-item {
   display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  padding: 12px 16px;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
   background: var(--surface-glass-soft);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   color: var(--text-primary);
-  font-size: 15px;
-  line-height: 1.5;
-  transition: all 0.2s;
+  font-size: 13px;
+  line-height: 1.45;
+  text-align: left;
+  transition: border-color 0.2s, transform 0.2s;
 }
 
 .principle-item:hover {
@@ -357,7 +367,8 @@
 .principle-item svg {
   color: var(--accent-primary);
   flex-shrink: 0;
-  margin-top: 2px;
+  width: 16px;
+  height: 16px;
 }
 
 .principle-item strong {
@@ -395,45 +406,25 @@
 
 @media (min-width: 1200px) {
   .onboarding-step-container {
-    max-width: 900px;
-    padding: 56px 64px;
+    max-width: 680px;
+    padding: 40px 48px;
   }
 
   .step-description {
-    max-width: 700px;
-    font-size: 18px;
+    max-width: 480px;
+    font-size: 15px;
   }
 
   .step-principles {
-    max-width: 700px;
+    max-width: 520px;
   }
 
   .step-title {
-    font-size: 40px;
+    font-size: 28px;
   }
 
   .step-features {
-    max-width: 500px;
-  }
-}
-
-@media (min-width: 1600px) {
-  .onboarding-step-container {
-    max-width: 1000px;
-    padding: 64px 72px;
-  }
-
-  .step-description {
-    max-width: 800px;
-    font-size: 19px;
-  }
-
-  .step-principles {
-    max-width: 800px;
-  }
-
-  .step-title {
-    font-size: 42px;
+    max-width: 460px;
   }
 }
 
@@ -471,9 +462,9 @@
 /* Step Form */
 .step-form {
   width: 100%;
-  max-width: 500px;
-  margin-top: 32px;
-  margin-bottom: 20px;
+  max-width: 420px;
+  margin-top: 24px;
+  margin-bottom: 16px;
   overflow-x: hidden;
   overflow-y: visible;
   position: relative;
@@ -481,14 +472,15 @@
   display: flex;
   flex-direction: column;
   gap: 0;
+  text-align: left;
 }
 
 .step-form .form-group {
-  margin-bottom: 20px;
+  margin-bottom: 16px;
 }
 
 .step-form > .form-group:first-of-type {
-  margin-bottom: 16px;
+  margin-bottom: 14px;
 }
 
 .step-form .form-group:last-child {
@@ -497,23 +489,23 @@
 
 .step-form label {
   display: block;
-  margin-bottom: 10px;
+  margin-bottom: 7px;
   font-weight: 600;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .step-form input,
 .step-form textarea,
 .step-form select {
   width: 100%;
-  padding: 14px 16px;
+  padding: 11px 14px;
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
-  font-size: 15px;
+  font-size: 14px;
   background: var(--surface-glass-soft);
   color: var(--text-primary);
-  transition: all 0.2s;
+  transition: border-color 0.15s, box-shadow 0.15s, background 0.15s;
   box-sizing: border-box;
 }
 
@@ -575,8 +567,9 @@
 }
 
 .step-form .field-hint {
-  margin-top: 8px;
-  font-size: 12px;
+  margin-top: 6px;
+  font-size: 11.5px;
+  line-height: 1.4;
   color: var(--text-tertiary);
 }
 
@@ -591,8 +584,8 @@
 .step-actions {
   display: flex;
   justify-content: center;
-  gap: 12px;
-  margin-top: 32px;
+  gap: 10px;
+  margin-top: 24px;
   padding-top: 0;
   padding-bottom: 0;
   flex-shrink: 0;
@@ -601,23 +594,23 @@
 }
 
 .step-content .step-actions {
-  margin-top: 32px;
+  margin-top: 24px;
   margin-bottom: 0;
 }
 
 .step-button {
-  padding: 16px 32px;
+  padding: 12px 26px;
   border: 1px solid transparent;
   border-radius: var(--radius-lg);
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: transform 0.15s cubic-bezier(0.4, 0, 0.2, 1), background 0.15s, border-color 0.15s, box-shadow 0.15s;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  min-width: 180px;
+  min-width: 160px;
   letter-spacing: 0.2px;
 }
 
@@ -664,22 +657,22 @@
 .node-setup-choice-cards {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  margin-top: 24px;
+  gap: 12px;
+  margin-top: 20px;
   width: 100%;
-  max-width: 480px;
+  max-width: 420px;
 }
 
 .node-setup-choice-card {
   display: block;
   width: 100%;
-  padding: 24px;
+  padding: 16px 18px;
   text-align: left;
   background: var(--surface-glass-soft);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
   cursor: pointer;
-  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), border-color 0.2s, background 0.2s, box-shadow 0.2s;
   color: var(--text-primary);
 }
 
@@ -692,13 +685,14 @@
 
 .node-setup-choice-card strong {
   display: block;
-  font-size: 16px;
-  margin-bottom: 8px;
+  font-size: 14px;
+  margin-bottom: 5px;
 }
 
 .node-setup-choice-card p {
   margin: 0;
-  font-size: 14px;
+  font-size: 12.5px;
+  line-height: 1.45;
   color: var(--text-secondary);
 }
 
@@ -1405,22 +1399,18 @@
   padding-top: 16px;
   padding-bottom: 8px;
   border-top: 1px solid var(--border-color);
-  animation: slideDown 0.2s ease-out;
+  /* Fade in place — no vertical slide, so revealing the section doesn't shove
+     the surrounding fields around. */
+  animation: onbFade 0.2s ease-out;
   position: relative;
   z-index: 0;
   overflow: visible;
   width: 100%;
 }
 
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+@keyframes onbFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 .success-message,

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -517,7 +517,10 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
     window.location.reload();
   };
 
-  const FloatingMenu = () => (
+  // Rendered as a plain JSX value (not a nested component) so it is NOT
+  // remounted on every parent render — remounting is what made the whole
+  // control replay its entrance animation on each keystroke.
+  const floatingMenu = (
     <>
       {showFloatingMenu && (
         <div
@@ -559,13 +562,35 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
 
   // Get current step index for progress
   const currentStepIndex = ONBOARDING_STEPS.indexOf(currentStep);
-  const progress = ((currentStepIndex + 1) / ONBOARDING_STEPS.length) * 100;
+  const totalSteps = ONBOARDING_STEPS.length;
+  const progress = totalSteps > 1 ? ((currentStepIndex + 1) / totalSteps) * 100 : 0;
+
+  // Progress indicator as a plain JSX value (see floatingMenu note above): a
+  // nested component would remount every render and re-run its fadeUp entrance,
+  // which is exactly the "green bar flickers when I type" bug. As a value it
+  // reconciles to the same DOM node, so only the fill width transitions.
+  const progressLineWidth = totalSteps > 1 ? `calc(${progress}% - 80px)` : '0px';
+  const progressIndicator = (
+    <div className="onboarding-progress">
+      <div className="progress-steps">
+        <div className="progress-fill-line" style={{ width: progressLineWidth }}></div>
+        {ONBOARDING_STEPS.map((step, index) => (
+          <div
+            key={step}
+            className={`progress-step ${index <= currentStepIndex ? 'active' : ''} ${index === currentStepIndex ? 'current' : ''}`}
+          >
+            <div className="progress-dot"></div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 
   // If loading and we have a step other than welcome/node-setup, show loading
   if (loading && !['welcome', 'what-is', 'node-setup'].includes(currentStep)) {
     return (
       <div className="onboarding-page" data-testid="onboarding-page">
-        <FloatingMenu />
+        {floatingMenu}
         <div className="onboarding-content">
           <div className="loading-spinner">
             <div className="spinner"></div>
@@ -604,29 +629,10 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
         setCurrentStep('node-setup');
       };
 
-      // Progress indicator component
-      const ProgressIndicator = () => (
-        <div className="onboarding-progress">
-          <div className="progress-bar">
-            <div className="progress-fill" style={{ width: `${progress}%` }}></div>
-          </div>
-          <div className="progress-steps">
-            {ONBOARDING_STEPS.map((step, index) => (
-              <div
-                key={step}
-                className={`progress-step ${index <= currentStepIndex ? 'active' : ''} ${index === currentStepIndex ? 'current' : ''}`}
-              >
-                <div className="progress-dot"></div>
-              </div>
-            ))}
-          </div>
-        </div>
-      );
-
     return (
       <div className="onboarding-page" data-testid="onboarding-page">
-          <ProgressIndicator />
-          <FloatingMenu />
+          {progressIndicator}
+          {floatingMenu}
         <div className="onboarding-content">
           <div className="onboarding-card error">
               <AlertTriangle className="onboarding-icon" size={48} />
@@ -667,36 +673,13 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
     // If no node configured, just continue with normal flow (welcome screen)
   }
 
-  // Progress indicator component
-  const ProgressIndicator = () => {
-    const totalSteps = ONBOARDING_STEPS.length;
-    const progressWidth = totalSteps > 1 ? ((currentStepIndex + 1) / totalSteps) * 100 : 0;
-    const lineWidth = totalSteps > 1 ? `calc(${progressWidth}% - 80px)` : '0px';
-    
-    return (
-      <div className="onboarding-progress">
-        <div className="progress-steps">
-          <div className="progress-fill-line" style={{ width: lineWidth }}></div>
-          {ONBOARDING_STEPS.map((step, index) => (
-            <div
-              key={step}
-              className={`progress-step ${index <= currentStepIndex ? 'active' : ''} ${index === currentStepIndex ? 'current' : ''}`}
-            >
-              <div className="progress-dot"></div>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  };
-
   // Welcome screen
   if (currentStep === 'welcome') {
     return (
       <div className="onboarding-page" data-testid="onboarding-page">
-        <ProgressIndicator />
-        <FloatingMenu />
-        <div ref={stepContainerRef} className="onboarding-step-container">
+        {progressIndicator}
+        {floatingMenu}
+        <div ref={stepContainerRef} key={currentStep} className="onboarding-step-container">
           <div className="step-content">
             <div className="step-logo-wrapper">
               <img src={calimeroLogo} alt="Calimero" className="calimero-logo" />
@@ -725,9 +708,9 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
   if (currentStep === 'what-is') {
     return (
       <div className="onboarding-page" data-testid="onboarding-page">
-        <ProgressIndicator />
-        <FloatingMenu />
-        <div ref={stepContainerRef} className="onboarding-step-container">
+        {progressIndicator}
+        {floatingMenu}
+        <div ref={stepContainerRef} key={currentStep} className="onboarding-step-container">
           <button 
             onClick={() => setCurrentStep('welcome')} 
             className="step-back-button"
@@ -785,9 +768,9 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
 
     return (
       <div className="onboarding-page" data-testid="onboarding-page">
-        <ProgressIndicator />
-        <FloatingMenu />
-        <div ref={stepContainerRef} className="onboarding-step-container">
+        {progressIndicator}
+        {floatingMenu}
+        <div ref={stepContainerRef} key={currentStep} className="onboarding-step-container">
           <button 
             onClick={() => {
               setCurrentStep('what-is');
@@ -1059,9 +1042,9 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
   if (currentStep === 'cloud-connect') {
     return (
       <div className="onboarding-page" data-testid="onboarding-page">
-        <ProgressIndicator />
-        <FloatingMenu />
-        <div ref={stepContainerRef} className="onboarding-step-container">
+        {progressIndicator}
+        {floatingMenu}
+        <div ref={stepContainerRef} key={currentStep} className="onboarding-step-container">
           <div className="step-content">
             <h1 className="step-title">Connect to Calimero Cloud</h1>
             <p className="step-description">
@@ -1145,9 +1128,9 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
   if (currentStep === 'login') {
       return (
         <div className="onboarding-page" data-testid="onboarding-page">
-        <ProgressIndicator />
-        <FloatingMenu />
-          <div ref={stepContainerRef} className="onboarding-step-container onboarding-step-login">
+        {progressIndicator}
+        {floatingMenu}
+          <div ref={stepContainerRef} key={currentStep} className="onboarding-step-container onboarding-step-login">
             <button
               onClick={() => {
                 if (STEP_AFTER_NODE_SETUP === 'node-setup') {
@@ -1204,9 +1187,9 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
   if (currentStep === 'install-app') {
     return (
       <div className="onboarding-page" data-testid="onboarding-page">
-        <ProgressIndicator />
-        <FloatingMenu />
-        <div ref={stepContainerRef} className="onboarding-step-container">
+        {progressIndicator}
+        {floatingMenu}
+        <div ref={stepContainerRef} key={currentStep} className="onboarding-step-container">
           <button
             onClick={() => setCurrentStep('login')}
             className="step-back-button"

--- a/apps/desktop/src/utils/merod.ts
+++ b/apps/desktop/src/utils/merod.ts
@@ -122,6 +122,16 @@ export async function getMerodLogs(
 }
 
 /**
+ * Truncate the active log file and delete rotated segments for a node.
+ */
+export async function clearMerodLogs(
+  nodeName: string,
+  homeDir?: string
+): Promise<string> {
+  return await invoke('clear_merod_logs', { nodeName, homeDir });
+}
+
+/**
  * Kill all merod processes on the system. Call before total nuke.
  */
 export async function killAllMerodProcesses(): Promise<string> {


### PR DESCRIPTION
## What & why

Two things in one PR (as requested):

### 1. Onboarding + login redesign, progress-bar flicker fix (v0.0.71)

The onboarding progress ("loading") bar **flickered on every keystroke**, screens
**jumped around**, there were **ugly slide-down animations**, and the login popup
buried the **username/password fields behind a provider-selection step**.

**Root cause of the flicker/jumping:** `ProgressIndicator` and `FloatingMenu` were
defined as components **inside** `Onboarding`'s render body → a new component *type*
each render → React remounted them every keystroke, replaying the `fadeUp` entrance
on the progress bar.

- **Onboarding.tsx** — render `ProgressIndicator`/`FloatingMenu` as plain JSX values
  (no remount); `key={currentStep}` per step container for one clean entrance.
- **Onboarding.css** — smaller fonts, tighter alignment; progress bar fades only
  (no jump); advanced-options reveal fades in place instead of the slide-down;
  removed the infinite icon bob; subtle per-step `stepIn`.
- **LoginView.tsx** — username/password form shown at the **top** of the popup by
  default; provider list only when there's no username/password provider; "Back"
  only when other providers exist.
- Version bump **0.0.70 → 0.0.71**.

### 2. Node log rotation + 100 MB cap + cleanup + faster viewer

Implements the core of `apps/desktop/plan-logs.md`. merod logs were one **unbounded**
append file (`~/.calimero/<node>/logs/merod.log`) and the viewer read the whole file
to show 500 lines.

**Backend (`src-tauri`)**
- New `log_rotation.rs`: `RollingLogWriter` rotates `merod.log` into numbered segments
  (10 MB each, up to 9 rotated + active ≈ **100 MB cap**), deletes the oldest;
  `cleanup_logs` (retention + overflow), `clear_logs`, and a bounded `read_tail`
  (≤4 MB from the end of each file, newest→oldest). **6 unit tests.**
- `start_merod` pipes merod stdout/stderr and drains them into the rotating writer
  (`spawn_log_drain`); runs `cleanup_logs` on start.
- `get_merod_logs` now uses the bounded tail (no whole-file read; safe vs. a legacy
  huge log).
- New `clear_merod_logs` command.

**Frontend**
- `LogsViewer.tsx`: single split (reused everywhere), debounced filter, DOM capped
  to the last 3 000 lines with a "N older lines hidden" banner, ANSI conversion of
  only the rendered slice, pin-to-bottom auto-scroll, and a **Clear** button.
- `clearMerodLogs` util + wiring in `NodeManagement.tsx`.

Deferred follow-ups (tagged in plan-logs.md): incremental `get_merod_logs_since`
live-tail, DOM virtualization library, Download-full-log, and Settings knobs for the
cap/retention.

## Verification
- Rust: `cargo test` (6 rotation tests) + `cargo build` clean
- `tsc --noEmit`: clean · `vite build`: ok
- `vitest`: 106 passed · Playwright e2e (chromium): **118 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how merod output is captured (piped drains must stay healthy or the node can block) and touches shared log writer lifecycle/clear paths; UX changes are lower risk.
> 
> **Overview**
> **Merod logging** no longer appends to a single unbounded `merod.log`. The Tauri backend pipes merod stdout/stderr into a new **`RollingLogWriter`** (~10 MB segments, ~100 MB total), runs **startup cleanup**, serves **`get_merod_logs`** via a **bounded tail** (not full-file reads), and adds **`clear_merod_logs`** with ref-counted live writers so Clear doesn’t race drains. The Nodes **log viewer** debounces filters, caps DOM lines, improves auto-scroll when pinned, and wires a **Clear** button.
> 
> **Onboarding/login UX:** progress bar and floating menu are plain JSX so they **don’t remount on every keystroke**; tighter layout/animations. **Login** shows username/password first (with safer loading/error fallbacks) and hides Back when it’s the only provider.
> 
> Version **0.0.70 → 0.0.71**; includes `plan-logs.md` (deferred: live-tail API, full virtualization, settings knobs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c2e28bd59777939d8bbc9c3c2dfa2c46e2317e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->