### PR TITLE
fix(desktop): binary-safe HTTP proxy so images work in app windows

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -486,6 +486,7 @@ dependencies = [
 name = "calimero-tauri-app"
 version = "0.1.0"
 dependencies = [
+ "base64 0.21.7",
  "dirs 5.0.1",
  "env_logger",
  "futures-util",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ dirs = "5.0"
 toml = "0.8"
 regex = "1.10"
 thiserror = "1.0"
+base64 = "0.21"
 keyring = "2"
 tauri-plugin-deep-link = "0.1"
 

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -152,15 +152,35 @@ struct HttpResponse {
 /// Whether a response/request body of this content-type is safe to carry as a
 /// UTF-8 string. Anything else (images, octet-stream, video, …) must go over the
 /// IPC boundary as base64 to avoid lossy UTF-8 corruption.
+///
+/// Precise on purpose: a broad `contains("xml")`/`contains("json")` would
+/// misclassify ZIP-based Office Open XML types (`application/vnd.openxmlformats-*`
+/// = docx/xlsx/pptx) as text and corrupt them. Note the asymmetry — treating a
+/// genuinely textual type as binary is harmless (base64 round-trips exactly),
+/// while treating binary as text corrupts, so we bias toward binary.
 fn is_textual_content_type(content_type: &str) -> bool {
-    let ct = content_type.trim().to_ascii_lowercase();
+    // Media type only, ignoring any `; charset=…` parameters.
+    let ct = content_type
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    // Vendor types are overwhelmingly binary containers (OOXML, .xls, …); never
+    // treat them as text even though some contain "xml"/"json" in the name.
+    if ct.starts_with("application/vnd.") {
+        return false;
+    }
     ct.starts_with("text/")
-        || ct.contains("json")
-        || ct.contains("xml")
+        || ct == "application/json"
+        || ct.ends_with("+json")
+        || ct == "application/xml"
+        || ct == "text/xml"
+        || ct.ends_with("+xml")
         || ct.contains("javascript")
         || ct.contains("ecmascript")
-        || ct.contains("x-www-form-urlencoded")
-        || ct.contains("csv")
+        || ct == "application/x-www-form-urlencoded"
+        || ct == "text/csv"
         || ct.starts_with("multipart/") // boundaries + text fields; keep as-is
 }
 
@@ -3397,6 +3417,9 @@ mod tests {
             "application/x-www-form-urlencoded",
             "text/csv",
             "multipart/form-data; boundary=xyz",
+            "image/svg+xml",              // +xml suffix
+            "application/problem+json",   // +json suffix
+            "text/xml",
         ] {
             assert!(is_textual_content_type(ct), "should be textual: {ct}");
         }
@@ -3408,6 +3431,10 @@ mod tests {
             "image/webp",
             "video/mp4",
             "application/pdf",
+            // Office Open XML / vendor types are ZIP binaries despite "xml" in the name.
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.ms-excel",
         ] {
             assert!(!is_textual_content_type(ct), "should be binary: {ct}");
         }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 use log::{debug, info, warn};
 use std::sync::OnceLock;
 use thiserror::Error;
+// Brings `.encode()` / `.decode()` onto the base64 engine used by the HTTP proxy.
+use base64::Engine as _;
 
 static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 static SSE_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
@@ -125,14 +127,41 @@ struct HttpRequest {
     url: String,
     method: String,
     headers: Option<std::collections::HashMap<String, String>>,
+    /// Text bodies (JSON, form-encoded, …) — sent as a UTF-8 string.
     body: Option<String>,
+    /// Binary bodies (image uploads, octet-stream, …) — base64 of the raw bytes.
+    /// Set by the proxy script instead of `body` so bytes survive the IPC hop
+    /// intact; `String(arrayBuffer)`/`.text()` would otherwise mangle them.
+    #[serde(default)]
+    body_base64: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct HttpResponse {
     status: u16,
     headers: std::collections::HashMap<String, String>,
+    /// Text responses — a UTF-8 string (unchanged wire shape for JSON/text).
     body: String,
+    /// Binary responses (images, octet-stream, …) — base64 of the raw bytes.
+    /// When present the proxy script decodes this instead of reading `body`,
+    /// so downloaded blobs are byte-exact rather than UTF-8-lossy corrupted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    body_base64: Option<String>,
+}
+
+/// Whether a response/request body of this content-type is safe to carry as a
+/// UTF-8 string. Anything else (images, octet-stream, video, …) must go over the
+/// IPC boundary as base64 to avoid lossy UTF-8 corruption.
+fn is_textual_content_type(content_type: &str) -> bool {
+    let ct = content_type.trim().to_ascii_lowercase();
+    ct.starts_with("text/")
+        || ct.contains("json")
+        || ct.contains("xml")
+        || ct.contains("javascript")
+        || ct.contains("ecmascript")
+        || ct.contains("x-www-form-urlencoded")
+        || ct.contains("csv")
+        || ct.starts_with("multipart/") // boundaries + text fields; keep as-is
 }
 
 /// Parses --open-app-url, --open-app-name, --open-app-id from CLI args (used when launched from a desktop shortcut).
@@ -426,17 +455,33 @@ async fn proxy_http_request_inner(request: HttpRequest, configured_node_url: Opt
         }
         debug!("[Tauri Proxy] Total headers processed: {}", headers.len());
         
-        // Add default Content-Type if body exists but no Content-Type header
-        if !has_content_type && request.body.is_some() {
-            req_builder = req_builder.header("Content-Type", "application/json");
+        // Add default Content-Type if a body exists but no Content-Type header.
+        // Binary bodies default to octet-stream, text bodies to JSON.
+        if !has_content_type {
+            if request.body_base64.is_some() {
+                req_builder = req_builder.header("Content-Type", "application/octet-stream");
+            } else if request.body.is_some() {
+                req_builder = req_builder.header("Content-Type", "application/json");
+            }
         }
-    } else if request.body.is_some() {
+    } else if request.body.is_some() || request.body_base64.is_some() {
         // No headers provided but body exists - add default Content-Type
-        req_builder = req_builder.header("Content-Type", "application/json");
+        let default_ct = if request.body_base64.is_some() {
+            "application/octet-stream"
+        } else {
+            "application/json"
+        };
+        req_builder = req_builder.header("Content-Type", default_ct);
     }
-    
-    // Add body
-    if let Some(body) = request.body {
+
+    // Add body: a base64 binary body (decoded to raw bytes) wins over the text
+    // body, so image/octet-stream uploads are sent as bytes, not mangled text.
+    if let Some(b64) = request.body_base64 {
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(b64.as_bytes())
+            .map_err(|e| TauriError::with_details(TauriErrorCode::InvalidInput, "Invalid base64 request body", e.to_string()))?;
+        req_builder = req_builder.body(bytes);
+    } else if let Some(body) = request.body {
         req_builder = req_builder.body(body);
     }
     
@@ -463,16 +508,39 @@ async fn proxy_http_request_inner(request: HttpRequest, configured_node_url: Opt
         }
     }
     
-    let body = response.text()
+    // Decide text vs binary from the response Content-Type. Text stays a UTF-8
+    // string (unchanged wire shape for JSON/text); binary (images, octet-stream)
+    // is base64-encoded so the raw bytes reach the webview byte-exact. A missing
+    // content-type is treated as text to preserve prior behavior for plain APIs.
+    let content_type = response_headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+        .map(|(_, v)| v.clone())
+        .unwrap_or_default();
+    let bytes = response.bytes()
         .await
         .map_err(|e| TauriError::with_details(TauriErrorCode::ResponseReadError, format!("Failed to read response from {}", request.url), e.to_string()))?;
-    
-    info!("[Tauri Proxy] Response: {} ({} bytes)", status, body.len());
-    
+
+    let textual = content_type.is_empty() || is_textual_content_type(&content_type);
+    info!(
+        "[Tauri Proxy] Response: {} ({} bytes, content-type: {}, {})",
+        status,
+        bytes.len(),
+        if content_type.is_empty() { "<none>" } else { content_type.as_str() },
+        if textual { "text" } else { "binary/base64" },
+    );
+
+    let (body, body_base64) = if textual {
+        (String::from_utf8_lossy(&bytes).into_owned(), None)
+    } else {
+        (String::new(), Some(base64::engine::general_purpose::STANDARD.encode(&bytes)))
+    };
+
     Ok(HttpResponse {
         status,
         headers: response_headers,
         body,
+        body_base64,
     })
 }
 
@@ -3055,7 +3123,8 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{merod_target_triple, score_merod_asset, validate_allowed_url};
+    use super::{is_textual_content_type, merod_target_triple, score_merod_asset, validate_allowed_url};
+    use base64::Engine as _;
 
     #[test]
     fn test_allowed_localhost_urls() {
@@ -3313,5 +3382,44 @@ mod tests {
         assert_ne!(triple, "unknown", "target triple should be known on supported platforms");
         // Must contain OS and arch info
         assert!(triple.contains('-'), "triple should be dash-separated");
+    }
+
+    #[test]
+    fn test_is_textual_content_type() {
+        // Text — carried as a UTF-8 string.
+        for ct in [
+            "application/json",
+            "application/json; charset=utf-8",
+            "text/plain",
+            "text/html; charset=utf-8",
+            "application/xml",
+            "application/javascript",
+            "application/x-www-form-urlencoded",
+            "text/csv",
+            "multipart/form-data; boundary=xyz",
+        ] {
+            assert!(is_textual_content_type(ct), "should be textual: {ct}");
+        }
+        // Binary — must go over IPC as base64, not lossy UTF-8.
+        for ct in [
+            "application/octet-stream",
+            "image/png",
+            "image/jpeg",
+            "image/webp",
+            "video/mp4",
+            "application/pdf",
+        ] {
+            assert!(!is_textual_content_type(ct), "should be binary: {ct}");
+        }
+    }
+
+    #[test]
+    fn test_base64_roundtrip_preserves_binary() {
+        // Bytes that are NOT valid UTF-8 (a PNG-ish header) — the exact case
+        // response.text() used to corrupt.
+        let raw: Vec<u8> = vec![0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0x00, 0xfe];
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&raw);
+        let decoded = base64::engine::general_purpose::STANDARD.decode(encoded.as_bytes()).unwrap();
+        assert_eq!(raw, decoded, "base64 round-trip must be byte-exact");
     }
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -528,31 +528,35 @@ async fn proxy_http_request_inner(request: HttpRequest, configured_node_url: Opt
         }
     }
     
-    // Decide text vs binary from the response Content-Type. Text stays a UTF-8
-    // string (unchanged wire shape for JSON/text); binary (images, octet-stream)
-    // is base64-encoded so the raw bytes reach the webview byte-exact. A missing
-    // content-type is treated as text to preserve prior behavior for plain APIs.
+    // Decide text vs binary from the response Content-Type BEFORE consuming the
+    // body: textual replies keep the plain-string wire shape (unchanged for
+    // JSON/text); binary (images, octet-stream) is base64 so the raw bytes reach
+    // the webview byte-exact. A missing content-type is treated as text to
+    // preserve prior behavior for plain APIs.
     let content_type = response_headers
         .iter()
         .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
         .map(|(_, v)| v.clone())
         .unwrap_or_default();
-    let bytes = response.bytes()
-        .await
-        .map_err(|e| TauriError::with_details(TauriErrorCode::ResponseReadError, format!("Failed to read response from {}", request.url), e.to_string()))?;
-
     let textual = content_type.is_empty() || is_textual_content_type(&content_type);
     info!(
-        "[Tauri Proxy] Response: {} ({} bytes, content-type: {}, {})",
+        "[Tauri Proxy] Response: {} (content-type: {}, {})",
         status,
-        bytes.len(),
         if content_type.is_empty() { "<none>" } else { content_type.as_str() },
         if textual { "text" } else { "binary/base64" },
     );
 
     let (body, body_base64) = if textual {
-        (String::from_utf8_lossy(&bytes).into_owned(), None)
+        // reqwest's text() honors the Content-Type charset (defaulting to UTF-8),
+        // so a non-UTF-8 text response isn't garbled the way from_utf8_lossy would.
+        let text = response.text().await.map_err(|e| {
+            TauriError::with_details(TauriErrorCode::ResponseReadError, format!("Failed to read response from {}", request.url), e.to_string())
+        })?;
+        (text, None)
     } else {
+        let bytes = response.bytes().await.map_err(|e| {
+            TauriError::with_details(TauriErrorCode::ResponseReadError, format!("Failed to read response from {}", request.url), e.to_string())
+        })?;
         (String::new(), Some(base64::engine::general_purpose::STANDARD.encode(&bytes)))
     };
 

--- a/apps/desktop/src-tauri/src/proxy_script.js
+++ b/apps/desktop/src-tauri/src/proxy_script.js
@@ -246,8 +246,70 @@
         });
     }
 
+    // ─── Binary-safe body helpers ───────────────────────────────────────────
+    // The Tauri proxy carries request/response bodies across IPC. Binary
+    // payloads (image uploads, blob downloads) must travel as base64 or a UTF-8
+    // round-trip corrupts them (String(arrayBuffer) → "[object ArrayBuffer]",
+    // response.text() → mojibake). Text bodies stay plain strings.
+    function bytesToBase64(bytes) {
+        let binary = '';
+        const CHUNK = 0x8000; // avoid arg-count limits in String.fromCharCode
+        for (let i = 0; i < bytes.length; i += CHUNK) {
+            binary += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK));
+        }
+        return btoa(binary);
+    }
+
+    function base64ToBytes(b64) {
+        const binary = atob(b64 || '');
+        const len = binary.length;
+        const out = new Uint8Array(len);
+        for (let i = 0; i < len; i++) out[i] = binary.charCodeAt(i);
+        return out;
+    }
+
+    // A fetch/XHR body is "binary" when it isn't naturally a string. FormData is
+    // deliberately treated as text (its multipart boundary lives in a header we
+    // don't reconstruct here) — same as the previous behavior, not a regression.
+    function isBinaryBody(body) {
+        if (body == null || typeof body === 'string') return false;
+        if (typeof URLSearchParams !== 'undefined' && body instanceof URLSearchParams) return false;
+        if (typeof FormData !== 'undefined' && body instanceof FormData) return false;
+        return true;
+    }
+
+    // Resolve any fetch/XHR body into { body, bodyBase64 } for proxyRequest:
+    // exactly one is non-null (or both null for an empty body).
+    async function encodeBody(body) {
+        if (body == null) return { body: null, bodyBase64: null };
+        if (!isBinaryBody(body)) {
+            if (typeof body === 'string') return { body: body, bodyBase64: null };
+            // URLSearchParams / FormData → serialize to text (unchanged behavior)
+            return { body: await new Response(body).text(), bodyBase64: null };
+        }
+        let bytes;
+        if (body instanceof ArrayBuffer) {
+            bytes = new Uint8Array(body);
+        } else if (ArrayBuffer.isView(body)) {
+            bytes = new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+        } else {
+            // Blob / File
+            bytes = new Uint8Array(await new Response(body).arrayBuffer());
+        }
+        return { body: null, bodyBase64: bytesToBase64(bytes) };
+    }
+
+    // A proxy reply's body → a BodyInit for `new Response(...)`: raw bytes when
+    // the backend flagged it binary (body_base64), else the plain string body.
+    function decodeResponseBody(response) {
+        if (response && typeof response.body_base64 === 'string') {
+            return base64ToBytes(response.body_base64);
+        }
+        return (response && response.body) || '';
+    }
+
     // Helper function to proxy regular HTTP requests through Tauri
-    async function proxyRequest(url, method, headers, body) {
+    async function proxyRequest(url, method, headers, body, bodyBase64) {
         // /auth/refresh is answered by the desktop, never forwarded to the node.
         // Both the fetch and XHR interceptors funnel through here, so this single
         // check covers both.
@@ -267,7 +329,8 @@
                 url: url,
                 method: method || 'GET',
                 headers: headers && Object.keys(headers).length > 0 ? headers : null,
-                body: body
+                body: body != null ? body : null,
+                body_base64: bodyBase64 != null ? bodyBase64 : null
             },
             configured_node_url: nodeUrl
         });
@@ -346,22 +409,17 @@
                     }
                 }
 
-                let bodyStr = null;
-                if (init && init.body) {
-                    if (typeof init.body === 'string') {
-                        bodyStr = init.body;
-                    } else if (init.body instanceof FormData || init.body instanceof Blob) {
-                        bodyStr = await new Response(init.body).text();
-                    } else {
-                        bodyStr = await new Response(init.body).text();
-                    }
-                }
+                // Encode the body binary-safely: strings pass through, binary
+                // (Blob/ArrayBuffer/typed array) becomes base64 so image uploads
+                // survive the IPC hop intact.
+                const { body: reqBody, bodyBase64: reqBodyBase64 } =
+                    init && init.body ? await encodeBody(init.body) : { body: null, bodyBase64: null };
 
                 console.log('[Tauri Proxy] Intercepting fetch:', urlStr, 'method:', init?.method || 'GET');
                 console.log('[Tauri Proxy] Headers being sent:', JSON.stringify(headers, null, 2));
                 console.log('[Tauri Proxy] Has Authorization header?', 'Authorization' in headers || 'authorization' in headers);
 
-                const requestPromise = proxyRequest(urlStr, effectiveMethod, headers, bodyStr);
+                const requestPromise = proxyRequest(urlStr, effectiveMethod, headers, reqBody, reqBodyBase64);
 
                 let response;
                 if (effectiveSignal) {
@@ -381,7 +439,9 @@
 
                 console.log('[Tauri Proxy] Proxy response:', response.status, urlStr);
 
-                return new Response(response.body, {
+                // decodeResponseBody yields raw bytes for binary replies (images,
+                // blobs) so response.blob()/arrayBuffer() are byte-exact.
+                return new Response(decodeResponseBody(response), {
                     status: response.status,
                     statusText: response.status === 200 ? 'OK' : (response.statusText || 'Error'),
                     headers: new Headers(response.headers)
@@ -434,14 +494,37 @@
             if (shouldProxy) {
                 console.log('[Tauri Proxy] XHR intercepted:', xhrMethod, xhrUrl);
 
-                proxyRequest(xhrUrl, xhrMethod, xhrHeaders, body ? String(body) : null)
+                // Encode the request body binary-safely (this is the image-upload
+                // path: axios PUTs an ArrayBuffer, which String(body) used to turn
+                // into the literal "[object ArrayBuffer]").
+                encodeBody(body)
+                    .then(function(enc) {
+                        return proxyRequest(xhrUrl, xhrMethod, xhrHeaders, enc.body, enc.bodyBase64);
+                    })
                     .then(function(response) {
                         console.log('[Tauri Proxy] XHR proxy response:', response.status, xhrUrl);
-                        Object.defineProperty(xhr, 'status', { value: response.status, writable: false });
-                        Object.defineProperty(xhr, 'statusText', { value: response.status === 200 ? 'OK' : 'Error', writable: false });
-                        Object.defineProperty(xhr, 'responseText', { value: response.body || '', writable: false });
-                        Object.defineProperty(xhr, 'response', { value: response.body || '', writable: false });
-                        Object.defineProperty(xhr, 'readyState', { value: 4, writable: false });
+
+                        // Decode the reply for whichever mode the caller reads.
+                        const hasBinary = response && typeof response.body_base64 === 'string';
+                        const bytes = hasBinary ? base64ToBytes(response.body_base64) : null;
+                        const text = hasBinary ? new TextDecoder().decode(bytes) : (response.body || '');
+                        const rt = (xhr.responseType || '').toLowerCase();
+                        let responseValue;
+                        if (rt === 'arraybuffer') {
+                            responseValue = bytes ? bytes.buffer : new TextEncoder().encode(text).buffer;
+                        } else if (rt === 'blob') {
+                            responseValue = bytes ? new Blob([bytes]) : new Blob([text]);
+                        } else if (rt === 'json') {
+                            try { responseValue = JSON.parse(text); } catch (_) { responseValue = null; }
+                        } else {
+                            responseValue = text;
+                        }
+
+                        Object.defineProperty(xhr, 'status', { value: response.status, writable: false, configurable: true });
+                        Object.defineProperty(xhr, 'statusText', { value: response.status === 200 ? 'OK' : 'Error', writable: false, configurable: true });
+                        Object.defineProperty(xhr, 'responseText', { value: text, writable: false, configurable: true });
+                        Object.defineProperty(xhr, 'response', { value: responseValue, writable: false, configurable: true });
+                        Object.defineProperty(xhr, 'readyState', { value: 4, writable: false, configurable: true });
 
                         let headerStr = '';
                         if (response.headers) {

--- a/apps/desktop/src-tauri/src/proxy_script.js
+++ b/apps/desktop/src-tauri/src/proxy_script.js
@@ -509,11 +509,16 @@
                         const bytes = hasBinary ? base64ToBytes(response.body_base64) : null;
                         const text = hasBinary ? new TextDecoder().decode(bytes) : (response.body || '');
                         const rt = (xhr.responseType || '').toLowerCase();
+                        // Content-Type for the Blob's `type` (native XHR sets it from this header).
+                        const contentType = response.headers
+                            ? (response.headers['content-type'] || response.headers['Content-Type'] || '')
+                            : '';
                         let responseValue;
                         if (rt === 'arraybuffer') {
                             responseValue = bytes ? bytes.buffer : new TextEncoder().encode(text).buffer;
                         } else if (rt === 'blob') {
-                            responseValue = bytes ? new Blob([bytes]) : new Blob([text]);
+                            const blobOpts = contentType ? { type: contentType } : undefined;
+                            responseValue = bytes ? new Blob([bytes], blobOpts) : new Blob([text], blobOpts);
                         } else if (rt === 'json') {
                             try { responseValue = JSON.parse(text); } catch (_) { responseValue = null; }
                         } else {

--- a/apps/desktop/src/utils/proxyScript.test.ts
+++ b/apps/desktop/src/utils/proxyScript.test.ts
@@ -325,3 +325,101 @@ describe("proxy_script /auth/refresh brokering", () => {
     expect(JSON.parse(xhr.responseText).data.access_token).toBe("fresh-access-token");
   });
 });
+
+// ─── Binary-safe bodies (image upload/download through the proxy) ────────────
+//
+// The Tauri proxy carries HTTP bodies over IPC. Before this fix everything went
+// as a UTF-8 string: downloads ran response.text() (mojibake) and XHR uploads
+// ran String(arrayBuffer) → "[object ArrayBuffer]". Binary now travels as
+// base64 (body_base64) in both directions; text bodies stay plain strings.
+describe("proxy_script binary bodies", () => {
+  function tauriInvokeWindow(impl: (cmd: string, args: any) => Promise<unknown>) {
+    const mockWindow = makeMockWindow();
+    mockWindow.__TAURI_INVOKE__ = vi.fn(impl);
+    mockWindow.__TAURI__ = { event: { listen: vi.fn(async () => vi.fn()) } };
+    return mockWindow;
+  }
+
+  it("downloads a binary response byte-exact (base64 → bytes)", async () => {
+    // Bytes that are NOT valid UTF-8 — the exact case response.text() corrupted.
+    const raw = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0x00, 0xfe]);
+    const b64 = Buffer.from(raw).toString("base64");
+    const mockWindow = tauriInvokeWindow(async (cmd) =>
+      cmd === "proxy_http_request"
+        ? { status: 200, headers: { "content-type": "image/png" }, body_base64: b64 }
+        : { status: 200, headers: {}, body: "{}" }
+    );
+    injectProxy(mockWindow);
+
+    const res = await mockWindow.fetch("http://localhost:2428/admin-api/blobs/abc?context_id=x");
+    const got = new Uint8Array(await res.arrayBuffer());
+    expect(Array.from(got)).toEqual(Array.from(raw));
+  });
+
+  it("uploads a binary fetch body as base64, not mangled text", async () => {
+    const raw = new Uint8Array([0, 1, 2, 250, 200, 5, 127, 255]);
+    const calls: Array<{ cmd: string; args: any }> = [];
+    const mockWindow = tauriInvokeWindow(async (cmd, args) => {
+      calls.push({ cmd, args });
+      return { status: 200, headers: { "content-type": "application/json" }, body: "{}" };
+    });
+    injectProxy(mockWindow);
+
+    await mockWindow.fetch("http://localhost:2428/admin-api/blobs", {
+      method: "PUT",
+      body: raw,
+      headers: { "Content-Type": "application/octet-stream" },
+    });
+
+    const call = calls.find((c) => c.cmd === "proxy_http_request")!;
+    expect(call).toBeTruthy();
+    expect(call.args.request.body).toBeNull();
+    expect(call.args.request.body_base64).toBe(Buffer.from(raw).toString("base64"));
+  });
+
+  it("uploads a binary XHR body (ArrayBuffer) as base64 — the axios PUT path", async () => {
+    const raw = new Uint8Array([9, 8, 7, 255, 0, 128, 64]);
+    const calls: Array<{ cmd: string; args: any }> = [];
+    const mockWindow = tauriInvokeWindow(async (cmd, args) => {
+      calls.push({ cmd, args });
+      return {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ data: { blob_id: "b1", size: raw.length } }),
+      };
+    });
+    injectProxy(mockWindow);
+
+    const xhr = new mockWindow.XMLHttpRequest();
+    xhr.open("PUT", "http://localhost:2428/admin-api/blobs");
+    const done = new Promise<void>((resolve) => { xhr.onload = () => resolve(); });
+    xhr.send(raw.buffer); // ArrayBuffer, exactly what axios sends for a File.arrayBuffer()
+    await done;
+
+    const call = calls.find((c) => c.cmd === "proxy_http_request")!;
+    expect(call).toBeTruthy();
+    expect(call.args.request.body).toBeNull();
+    expect(call.args.request.body_base64).toBe(Buffer.from(raw).toString("base64"));
+    expect(JSON.parse(xhr.responseText).data.blob_id).toBe("b1");
+  });
+
+  it("keeps a JSON string body as text (no base64)", async () => {
+    const payload = JSON.stringify({ a: 1, b: "two" });
+    const calls: Array<{ cmd: string; args: any }> = [];
+    const mockWindow = tauriInvokeWindow(async (cmd, args) => {
+      calls.push({ cmd, args });
+      return { status: 200, headers: { "content-type": "application/json" }, body: "{}" };
+    });
+    injectProxy(mockWindow);
+
+    await mockWindow.fetch("http://localhost:2428/admin-api/contexts", {
+      method: "POST",
+      body: payload,
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const call = calls.find((c) => c.cmd === "proxy_http_request")!;
+    expect(call.args.request.body).toBe(payload);
+    expect(call.args.request.body_base64).toBeNull();
+  });
+});


### PR DESCRIPTION
## The bug

In mero-chat, images work in a normal browser but break through the desktop app:
- **Viewing in the Tauri webview:** an image sent from anywhere shows nothing (no error in console).
- **Sending from a Tauri window:** the uploaded image is broken **everywhere, including web**.

## Root cause — the Tauri HTTP proxy is binary-unsafe

App windows can't fetch `http://localhost` directly (mixed-content), so `proxy_script.js` intercepts `fetch`/`XHR` and routes them through the `proxy_http_request` Tauri command. That proxy carried **every** body over IPC as a **UTF-8 string**, which destroys binary data:

- **Download** (`downloadBlob` → `fetch` `/admin-api/blobs/<id>` → `res.blob()`): the Rust side did `response.text()` — a lossy UTF-8 decode — so the JPEG/PNG bytes were corrupted and `<img>` silently failed (matches "no errors, not displayed").
- **Upload** (`uploadBlobDirect` → `axios.put(arrayBuffer)` → **XHR**): the XHR interceptor did `String(body)` on the `ArrayBuffer`, producing the literal string `"[object ArrayBuffer]"`. The node stored garbage → broken everywhere, incl. web.

## The fix — carry binary as base64 in both directions

Text/JSON keeps its existing plain-string wire shape (zero behavior change for normal API traffic); only binary is base64-encoded.

**Rust (`main.rs`)**
- `HttpRequest.body_base64` / `HttpResponse.body_base64` (optional fields).
- Response is read with `.bytes()`; if the `Content-Type` isn't textual (`is_textual_content_type`) it's returned as base64, else as a string. A missing content-type is treated as text (preserves prior behavior).
- A base64 request body is decoded to raw bytes before sending.
- `base64 = "0.21"` (already in the lockfile).

**Client (`proxy_script.js`)**
- `bytesToBase64` / `base64ToBytes` helpers.
- `encodeBody()` sends `Blob`/`ArrayBuffer`/typed-array bodies as `body_base64` (strings unchanged).
- Responses carrying `body_base64` are decoded to bytes for the `fetch` `Response` and for XHR `response`/`responseText` (honoring `responseType` `arraybuffer`/`blob`/`json`).

## Tests
- **Rust:** content-type classification + base64 round-trip of non-UTF-8 bytes (the exact case `.text()` corrupted).
- **proxy_script:** binary download is byte-exact; binary `fetch` and XHR uploads go out as `body_base64` (not `"[object ArrayBuffer]"`); JSON stays text.

## Verification
- `cargo test` (main.rs: 20) + `cargo build`: clean
- `vitest`: 110 passed (proxyScript: 14) · `tsc`: clean
- Playwright e2e unaffected — `proxy_script.js` runs only in native app windows, not the web build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all proxied localhost HTTP traffic in app windows; misclassification of Content-Type could still corrupt rare binary types or over-base64 text, but JSON/API paths are explicitly preserved and tests cover the main blob/image cases.
> 
> **Overview**
> Fixes broken images in desktop app windows by making the **Tauri `proxy_http_request` path binary-safe** across IPC. Previously every body was treated as a UTF-8 string, which corrupted PNG/JPEG downloads (`response.text()` on the Rust side) and uploads (`String(ArrayBuffer)` / `"[object ArrayBuffer]"` on the XHR path).
> 
> **Rust (`main.rs`)** adds optional `body_base64` on `HttpRequest` / `HttpResponse`, decodes upload base64 to raw bytes, and classifies responses with `is_textual_content_type` so non-text types are returned as base64 (missing `Content-Type` still uses text for API compatibility). Default `Content-Type` for binary uploads is `application/octet-stream`. Adds `base64` dependency and unit tests for content-type rules and base64 round-trip.
> 
> **`proxy_script.js`** encodes `Blob` / `ArrayBuffer` / typed-array bodies via `encodeBody`, decodes binary replies for `fetch` `Response`, and updates the XHR interceptor to honor `responseType` (`arraybuffer`, `blob`, `json`) when `body_base64` is present.
> 
> **`proxyScript.test.ts`** adds coverage for byte-exact binary download, binary fetch/XHR upload as `body_base64`, and unchanged JSON text bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e8e31db73d8623fd32d068869fc77b436313416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->