### PR TITLE
fix(desktop): restore node connectivity for external app windows on Tauri v2

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/capabilities/migrated.json
+++ b/apps/desktop/src-tauri/capabilities/migrated.json
@@ -48,6 +48,7 @@
     "dialog:allow-ask",
     "dialog:allow-confirm",
     "process:allow-restart",
-    "deep-link:default"
+    "deep-link:default",
+    "allow-app-commands"
   ]
 }

--- a/apps/desktop/src-tauri/capabilities/remote.json
+++ b/apps/desktop/src-tauri/capabilities/remote.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "remote-app-windows",
-  "description": "IPC access for dynamically created external app windows (label app-*). Replaces the v1 runtime RemoteDomainAccessScope / ipc_scope().configure_remote_access() calls, which no longer exist in Tauri v2. Grants the injected proxy script and app-hosted pages access to the app's own commands.",
+  "description": "IPC access for dynamically created external app windows (label app-*). Replaces the v1 runtime RemoteDomainAccessScope / ipc_scope().configure_remote_access() calls, which no longer exist in Tauri v2. Grants the injected proxy script and app-hosted pages access to the app's own proxy commands. URLs cover any HTTPS-hosted app (marketplace apps live on assorted origins, e.g. *.vercel.app) plus HTTP localhost for the node's own pages and locally-served apps — matching v1, which allowed whatever domain the desktop opened. Only the desktop opens app-* windows, and the granted proxy commands only reach the local node.",
   "windows": [
     "app-*"
   ],
@@ -9,9 +9,7 @@
     "urls": [
       "http://localhost:*",
       "http://127.0.0.1:*",
-      "https://localhost:*",
-      "https://apps.calimero.network",
-      "https://*.calimero.network"
+      "https://*"
     ]
   },
   "permissions": [
@@ -20,6 +18,10 @@
     "core:window:allow-show",
     "core:window:allow-hide",
     "core:window:allow-close",
-    "core:window:allow-set-focus"
+    "core:window:allow-set-focus",
+    "allow-proxy-http-request",
+    "allow-proxy-sse-stream",
+    "allow-cancel-sse-stream",
+    "allow-broker-token-refresh"
   ]
 }

--- a/apps/desktop/src-tauri/permissions/app-commands.toml
+++ b/apps/desktop/src-tauri/permissions/app-commands.toml
@@ -1,0 +1,254 @@
+# App command permissions for the Tauri v2 ACL.
+#
+# WHY THIS FILE EXISTS:
+# Remote `app-*` windows are deny-by-default and can only call app commands
+# that a capability grants (see capabilities/remote.json for the proxy commands).
+# But the moment ANY app-command permission is defined, Tauri switches out of
+# its implicit "allow every command for local windows" mode: it then only
+# recognises commands that have a permission, and unlisted ones fail with
+# "<cmd> not allowed. Command not found". So every command in main.rs's
+# generate_handler! MUST be declared here, and the main window must be granted
+# them (via the `allow-app-commands` set below, referenced from
+# capabilities/migrated.json). Keep this list in sync with generate_handler!.
+
+[[permission]]
+identifier = "allow-get-pending-open-app"
+description = "Enables the get_pending_open_app command."
+commands.allow = ["get_pending_open_app"]
+
+[[permission]]
+identifier = "allow-clear-pending-open-app"
+description = "Enables the clear_pending_open_app command."
+commands.allow = ["clear_pending_open_app"]
+
+[[permission]]
+identifier = "allow-hide-main-window"
+description = "Enables the hide_main_window command."
+commands.allow = ["hide_main_window"]
+
+[[permission]]
+identifier = "allow-focus-window"
+description = "Enables the focus_window command."
+commands.allow = ["focus_window"]
+
+[[permission]]
+identifier = "allow-create-desktop-shortcut"
+description = "Enables the create_desktop_shortcut command."
+commands.allow = ["create_desktop_shortcut"]
+
+[[permission]]
+identifier = "allow-create-app-window"
+description = "Enables the create_app_window command."
+commands.allow = ["create_app_window"]
+
+[[permission]]
+identifier = "allow-open-devtools"
+description = "Enables the open_devtools command."
+commands.allow = ["open_devtools"]
+
+[[permission]]
+identifier = "allow-proxy-http-request"
+description = "Enables the proxy_http_request command."
+commands.allow = ["proxy_http_request"]
+
+[[permission]]
+identifier = "allow-proxy-sse-stream"
+description = "Enables the proxy_sse_stream command."
+commands.allow = ["proxy_sse_stream"]
+
+[[permission]]
+identifier = "allow-cancel-sse-stream"
+description = "Enables the cancel_sse_stream command."
+commands.allow = ["cancel_sse_stream"]
+
+[[permission]]
+identifier = "allow-broker-token-refresh"
+description = "Enables the broker_token_refresh command."
+commands.allow = ["broker_token_refresh"]
+
+[[permission]]
+identifier = "allow-resolve-token-request"
+description = "Enables the resolve_token_request command."
+commands.allow = ["resolve_token_request"]
+
+[[permission]]
+identifier = "allow-start-merod"
+description = "Enables the start_merod command."
+commands.allow = ["start_merod"]
+
+[[permission]]
+identifier = "allow-stop-merod"
+description = "Enables the stop_merod command."
+commands.allow = ["stop_merod"]
+
+[[permission]]
+identifier = "allow-stop-merod-by-pid-command"
+description = "Enables the stop_merod_by_pid_command command."
+commands.allow = ["stop_merod_by_pid_command"]
+
+[[permission]]
+identifier = "allow-get-merod-status"
+description = "Enables the get_merod_status command."
+commands.allow = ["get_merod_status"]
+
+[[permission]]
+identifier = "allow-list-merod-nodes"
+description = "Enables the list_merod_nodes command."
+commands.allow = ["list_merod_nodes"]
+
+[[permission]]
+identifier = "allow-check-merod-health"
+description = "Enables the check_merod_health command."
+commands.allow = ["check_merod_health"]
+
+[[permission]]
+identifier = "allow-pick-directory"
+description = "Enables the pick_directory command."
+commands.allow = ["pick_directory"]
+
+[[permission]]
+identifier = "allow-init-merod-node"
+description = "Enables the init_merod_node command."
+commands.allow = ["init_merod_node"]
+
+[[permission]]
+identifier = "allow-detect-running-merod-nodes"
+description = "Enables the detect_running_merod_nodes command."
+commands.allow = ["detect_running_merod_nodes"]
+
+[[permission]]
+identifier = "allow-get-merod-logs"
+description = "Enables the get_merod_logs command."
+commands.allow = ["get_merod_logs"]
+
+[[permission]]
+identifier = "allow-clear-merod-logs"
+description = "Enables the clear_merod_logs command."
+commands.allow = ["clear_merod_logs"]
+
+[[permission]]
+identifier = "allow-get-merod-binary-version"
+description = "Enables the get_merod_binary_version command."
+commands.allow = ["get_merod_binary_version"]
+
+[[permission]]
+identifier = "allow-download-and-replace-merod"
+description = "Enables the download_and_replace_merod command."
+commands.allow = ["download_and_replace_merod"]
+
+[[permission]]
+identifier = "allow-set-tray-icon-connected"
+description = "Enables the set_tray_icon_connected command."
+commands.allow = ["set_tray_icon_connected"]
+
+[[permission]]
+identifier = "allow-delete-calimero-data-dir"
+description = "Enables the delete_calimero_data_dir command."
+commands.allow = ["delete_calimero_data_dir"]
+
+[[permission]]
+identifier = "allow-kill-all-merod-processes"
+description = "Enables the kill_all_merod_processes command."
+commands.allow = ["kill_all_merod_processes"]
+
+[[permission]]
+identifier = "allow-autostart-enable"
+description = "Enables the autostart_enable command."
+commands.allow = ["autostart_enable"]
+
+[[permission]]
+identifier = "allow-autostart-disable"
+description = "Enables the autostart_disable command."
+commands.allow = ["autostart_disable"]
+
+[[permission]]
+identifier = "allow-autostart-is-enabled"
+description = "Enables the autostart_is_enabled command."
+commands.allow = ["autostart_is_enabled"]
+
+[[permission]]
+identifier = "allow-close-current-window"
+description = "Enables the close_current_window command."
+commands.allow = ["close_current_window"]
+
+[[permission]]
+identifier = "allow-open-url-in-browser"
+description = "Enables the open_url_in_browser command."
+commands.allow = ["open_url_in_browser"]
+
+[[permission]]
+identifier = "allow-get-ice-servers"
+description = "Enables the get_ice_servers command."
+commands.allow = ["get_ice_servers"]
+
+[[permission]]
+identifier = "allow-secure-store-token"
+description = "Enables the secure_store_token command."
+commands.allow = ["secure_store_token"]
+
+[[permission]]
+identifier = "allow-secure-get-token"
+description = "Enables the secure_get_token command."
+commands.allow = ["secure_get_token"]
+
+[[permission]]
+identifier = "allow-secure-delete-token"
+description = "Enables the secure_delete_token command."
+commands.allow = ["secure_delete_token"]
+
+[[permission]]
+identifier = "allow-get-pending-cloud-auth"
+description = "Enables the get_pending_cloud_auth command."
+commands.allow = ["get_pending_cloud_auth"]
+
+[[permission]]
+identifier = "allow-clear-pending-cloud-auth"
+description = "Enables the clear_pending_cloud_auth command."
+commands.allow = ["clear_pending_cloud_auth"]
+
+# Aggregate set so the main window can be granted every command with a single
+# permission reference instead of enumerating all of them in the capability.
+[[set]]
+identifier = "allow-app-commands"
+description = "All application commands, for trusted local (main) windows."
+permissions = [
+  "allow-get-pending-open-app",
+  "allow-clear-pending-open-app",
+  "allow-hide-main-window",
+  "allow-focus-window",
+  "allow-create-desktop-shortcut",
+  "allow-create-app-window",
+  "allow-open-devtools",
+  "allow-proxy-http-request",
+  "allow-proxy-sse-stream",
+  "allow-cancel-sse-stream",
+  "allow-broker-token-refresh",
+  "allow-resolve-token-request",
+  "allow-start-merod",
+  "allow-stop-merod",
+  "allow-stop-merod-by-pid-command",
+  "allow-get-merod-status",
+  "allow-list-merod-nodes",
+  "allow-check-merod-health",
+  "allow-pick-directory",
+  "allow-init-merod-node",
+  "allow-detect-running-merod-nodes",
+  "allow-get-merod-logs",
+  "allow-clear-merod-logs",
+  "allow-get-merod-binary-version",
+  "allow-download-and-replace-merod",
+  "allow-set-tray-icon-connected",
+  "allow-delete-calimero-data-dir",
+  "allow-kill-all-merod-processes",
+  "allow-autostart-enable",
+  "allow-autostart-disable",
+  "allow-autostart-is-enabled",
+  "allow-close-current-window",
+  "allow-open-url-in-browser",
+  "allow-get-ice-servers",
+  "allow-secure-store-token",
+  "allow-secure-get-token",
+  "allow-secure-delete-token",
+  "allow-get-pending-cloud-auth",
+  "allow-clear-pending-cloud-auth",
+]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
   },
   "productName": "Calimero Desktop",
   "mainBinaryName": "Calimero Desktop",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "identifier": "network.calimero.desktop",
   "plugins": {
     "updater": {

--- a/apps/desktop/src-tauri/tauri.dev.json
+++ b/apps/desktop/src-tauri/tauri.dev.json
@@ -1,11 +1,1 @@
-{
-  "tauri": {
-    "allowlist": {
-      "http": {
-        "all": true,
-        "request": true,
-        "scope": ["http://**", "https://**"]
-      }
-    }
-  }
-}
+{}


### PR DESCRIPTION
## Problem

After the Tauri v2 migration (#153, v0.0.72), **external app windows can no longer connect to the node** — while the main desktop window works fine (node creation, namespaces, etc.). Opening any marketplace app (e.g. MeroDesign) shows *"Failed to connect / No local node found."*

## Root cause

Two gaps in the v2 capability/ACL setup, both in how the `app-*` external webviews reach the node through the injected `proxy_script.js`:

1. **Proxy commands never granted to remote windows.** App windows reach the node by `invoke()`-ing the app's own commands (`proxy_http_request`, `proxy_sse_stream`, `cancel_sse_stream`, `broker_token_refresh`). In Tauri v2, remote (external-URL) webviews are deny-by-default and must be granted each command explicitly. `capabilities/remote.json` granted `core:*` + events but **never these commands**, so every proxied request was rejected by the ACL (console: `proxy_http_request not allowed on window "app-…"`).

   Declaring app-command permissions flips Tauri into explicit-ACL mode, which also drops the implicit *"all commands allowed for local windows"* default — that would break the **main** window too (`init_merod_node ... Command not found` / `not allowed`). So this PR declares the full command set once and grants it to the main window via a set:
   - `permissions/app-commands.toml` — an `allow-*` permission for every `generate_handler!` command plus an aggregate `allow-app-commands` **set**.
   - `capabilities/migrated.json` — grants `allow-app-commands` to the `main` window (one entry).
   - `capabilities/remote.json` — grants **only** the four proxy commands to `app-*` windows (least privilege).

2. **App-hosting domains not allowlisted.** `remote.json`'s `urls` only covered `*.calimero.network`, but marketplace apps are hosted elsewhere (e.g. `mero-design.vercel.app`). Tauri only injects IPC for allowlisted origins, so the proxy never ran and native fetch hit a mixed-content block. Broadened `remote.urls` to **any HTTPS origin** + HTTP localhost, matching v1 behavior (v1 allowed whatever domain the desktop opened, via the now-removed runtime `RemoteDomainAccessScope`). Only the desktop opens `app-*` windows, and the granted proxy commands only reach the local node.

## Also fixed

`tauri.dev.json` still used the v1 `tauri.allowlist` shape, so `tauri dev` failed v2 config validation — `pnpm dev:desktop` was broken on master. Its HTTP-allowlist purpose is obsolete under the reqwest-based proxy, so it's now an empty override.

## Testing

Ran the v2 app from this branch:
- Onboarding created and started a fresh node — `init_merod_node` / `start_merod` succeed (proves the local-window ACL grant).
- Opening the external MeroDesign app window (`mero-design.vercel.app`) now proxies to the node instead of being ACL-blocked.

## Notes / follow-ups

- `permissions/app-commands.toml` must stay in sync with `generate_handler!` in `main.rs` (noted in a comment in the file).
- `https://*` is intentionally broad per request; tighten to specific app-hosting origins later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)