### PR TITLE
chore: bump app to 0.0.74, bundled merod to 0.11.0-rc.18

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
   },
   "productName": "Calimero Desktop",
   "mainBinaryName": "Calimero Desktop",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "identifier": "network.calimero.desktop",
   "plugins": {
     "updater": {

--- a/merod-config.json
+++ b/merod-config.json
@@ -1,4 +1,4 @@
 {
     "name": "merod binary",
-    "version": "0.11.0-rc.17"
+    "version": "0.11.0-rc.18"
 }


### PR DESCRIPTION
## Summary
- Bump desktop app version `0.0.73` → `0.0.74` (`apps/desktop/package.json`, `apps/desktop/src-tauri/tauri.conf.json`)
- Pin bundled merod binary `0.11.0-rc.17` → `0.11.0-rc.18` (`merod-config.json`)

Core `0.11.0-rc.18` was published 2026-07-24 and includes the `merod_*` release assets consumed by `prepare-merod.mjs`.

## Release
On merge, tag `v0.0.74` will be pushed to trigger the multi-platform release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)