### PR TITLE
fix(desktop): nuke actually deletes the app session

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "description": "Calimero Desktop Application",
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/permissions/app-commands.toml
+++ b/apps/desktop/src-tauri/permissions/app-commands.toml
@@ -152,6 +152,16 @@ description = "Enables the delete_calimero_data_dir command."
 commands.allow = ["delete_calimero_data_dir"]
 
 [[permission]]
+identifier = "allow-clear-app-sessions"
+description = "Enables the clear_app_sessions command."
+commands.allow = ["clear_app_sessions"]
+
+[[permission]]
+identifier = "allow-remove-app-launchers"
+description = "Enables the remove_app_launchers command."
+commands.allow = ["remove_app_launchers"]
+
+[[permission]]
 identifier = "allow-kill-all-merod-processes"
 description = "Enables the kill_all_merod_processes command."
 commands.allow = ["kill_all_merod_processes"]
@@ -260,6 +270,8 @@ permissions = [
   "allow-download-and-replace-merod",
   "allow-set-tray-icon-connected",
   "allow-delete-calimero-data-dir",
+  "allow-clear-app-sessions",
+  "allow-remove-app-launchers",
   "allow-kill-all-merod-processes",
   "allow-autostart-enable",
   "allow-autostart-disable",

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1852,6 +1852,38 @@ fn collect_merod_pids(tracked: &[u32]) -> Vec<u32> {
     pids
 }
 
+/// PIDs of running per-app shell processes. Each launcher `.app` trampoline execs
+/// the shared loose shell binary, so the process shows up under the shell's own
+/// name — never as the host. Used by the total nuke: a live shell keeps an
+/// authenticated app webview (and would re-flush its localStorage after a wipe).
+#[cfg(target_os = "macos")]
+fn collect_shell_pids() -> Vec<u32> {
+    // Installed name (extract_shell's dest) plus the cargo binary name used in dev.
+    const SHELL_BINARY_NAMES: [&str; 2] = ["CalimeroShell", "calimero-shell"];
+    let mut pids: Vec<u32> = Vec::new();
+    if let Ok(output) = std::process::Command::new("ps")
+        .args(["ax", "-o", "pid,command"])
+        .output()
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            let mut parts = line.split_whitespace();
+            let (Some(pid_str), Some(exe)) = (parts.next(), parts.next()) else {
+                continue;
+            };
+            let basename = exe.split('/').last().unwrap_or(exe);
+            if SHELL_BINARY_NAMES.contains(&basename) {
+                if let Ok(pid) = pid_str.parse::<u32>() {
+                    if !pids.contains(&pid) {
+                        pids.push(pid);
+                    }
+                }
+            }
+        }
+    }
+    pids
+}
+
 /// Sends SIGTERM to all pids, waits, then force-kills any survivors.
 async fn kill_pids(pids: &[u32]) {
     if pids.is_empty() {
@@ -4078,6 +4110,157 @@ async fn delete_calimero_data_dir(data_dir: String) -> Result<String, TauriError
     Ok(format!("Deleted {}", path_canonical.display()))
 }
 
+/// True if `bundle` is a launcher `.app` we generated and may remove: it must be
+/// a `.app` directory under the user's home. `bundle_path` comes from our own
+/// `caps.json`, but that file is plain JSON on disk — a corrupted or tampered
+/// entry must not turn the nuke into an arbitrary recursive delete.
+fn launcher_bundle_is_removable(bundle: &std::path::Path, home: &std::path::Path) -> bool {
+    bundle.extension().and_then(|e| e.to_str()) == Some("app")
+        && bundle.starts_with(home)
+        && !bundle
+            .components()
+            .any(|c| c.as_os_str() == std::ffi::OsStr::new(".."))
+}
+
+/// Tear down every app session this desktop has handed out. Clearing the
+/// desktop's own `localStorage` was never enough:
+///
+/// - Each app frontend is its own web origin, so the SSO'd access token its
+///   MeroJs persists lands in the webview's shared website-data store
+///   (`~/Library/WebKit/<bundle id>`), which no `localStorage.removeItem` from
+///   the desktop's origin can reach. Reopening an app after a "reset" resumed
+///   the old authenticated session.
+/// - Open app windows and running launcher shells hold live sessions of their
+///   own, and a live webview re-flushes its `localStorage` to disk on close —
+///   so they must go first, or the wipe is undone behind us.
+///
+/// Every step is best-effort except the final website-data wipe, whose failure
+/// is reported so the caller can tell the user their sessions may persist.
+#[tauri::command]
+async fn clear_app_sessions(app_handle: tauri::AppHandle) -> Result<String, TauriError> {
+    let mut done: Vec<String> = Vec::new();
+
+    // 1. Close the in-process app windows.
+    let mut closed = 0;
+    for (label, window) in app_handle.webview_windows() {
+        if label.starts_with("app-") {
+            let _ = window.close();
+            closed += 1;
+        }
+    }
+    if closed > 0 {
+        done.push(format!("{closed} app window(s)"));
+    }
+
+    // 2. Kill the per-app launcher shells, for the same reason.
+    #[cfg(target_os = "macos")]
+    {
+        let pids = collect_shell_pids();
+        if !pids.is_empty() {
+            kill_pids(&pids).await;
+            done.push(format!("{} launcher process(es)", pids.len()));
+        }
+    }
+
+    // 3. The shells are separate processes with their own website-data store,
+    //    which step 4 cannot reach. They are dead by now, so delete it directly.
+    //    Every name is ours: the shell's bundle identifier plus the loose binary
+    //    names WebKit falls back to when the executable has no bundle.
+    #[cfg(target_os = "macos")]
+    if let Some(home) = dirs::home_dir() {
+        for name in ["network.calimero.shell", "CalimeroShell", "calimero-shell"] {
+            let _ = std::fs::remove_dir_all(home.join("Library/WebKit").join(name));
+            let _ = std::fs::remove_dir_all(home.join("Library/HTTPStorages").join(name));
+            let _ = std::fs::remove_file(
+                home.join("Library/HTTPStorages")
+                    .join(format!("{name}.binarycookies")),
+            );
+        }
+        done.push("launcher website data".to_string());
+    }
+
+    // 4. Wipe this process's website data: localStorage, cookies, IndexedDB and
+    //    caches for EVERY origin the host has loaded — which is where the app
+    //    windows' access tokens live. All windows of the process share the one
+    //    default data store, so clearing it through the main window is enough.
+    let main = app_handle.get_webview_window("main").ok_or_else(|| {
+        TauriError::new(
+            TauriErrorCode::WindowOperationFailed,
+            "Main window is gone; webview session data was not cleared",
+        )
+    })?;
+    main.clear_all_browsing_data().map_err(|e| {
+        TauriError::with_details(
+            TauriErrorCode::InternalError,
+            "Failed to clear webview session data — app sessions may persist",
+            e.to_string(),
+        )
+    })?;
+    done.push("webview session data".to_string());
+
+    let summary = format!("Cleared app sessions: {}", done.join(", "));
+    info!("[Reset] {summary}");
+    Ok(summary)
+}
+
+/// Remove the per-app launchers: the generated `.app` bundles, the capability
+/// store that keeps authorizing them (`caps.json` — a launcher built before a
+/// total nuke would otherwise still get tokens brokered over the host socket),
+/// and the extracted shell binary they exec. Total-nuke only: a launcher is a
+/// dock icon the user placed, so the softer "reset settings" leaves them alone.
+///
+/// Best-effort per launcher; a bundle we can't remove is logged, not fatal.
+/// Call `clear_app_sessions` first so no shell is still running out of a bundle.
+#[tauri::command]
+async fn remove_app_launchers(app_handle: tauri::AppHandle) -> Result<String, TauriError> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app_handle;
+        return Ok("No launchers on this platform".to_string());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let store = caps_store_path();
+        let home = dirs::home_dir();
+        let mut removed = 0;
+        for app in app_registry::installed_apps(&store) {
+            let bundle = std::path::PathBuf::from(&app.bundle_path);
+            let removable = home
+                .as_deref()
+                .map_or(false, |h| launcher_bundle_is_removable(&bundle, h));
+            if !removable {
+                if !app.bundle_path.is_empty() {
+                    warn!(
+                        "[Reset] Skipping unexpected launcher path for {}: {}",
+                        app.id, app.bundle_path
+                    );
+                }
+                continue;
+            }
+            match std::fs::remove_dir_all(&bundle) {
+                Ok(()) => removed += 1,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => warn!("[Reset] Failed to remove {}: {}", bundle.display(), e),
+            }
+        }
+
+        let _ = std::fs::remove_file(&store);
+        app_handle
+            .state::<CapRegistry>()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clear();
+        if let Some(shell_dir) = launcher::shell_install_path().parent() {
+            let _ = std::fs::remove_dir_all(shell_dir);
+        }
+
+        let summary = format!("Removed {removed} app launcher(s) and their capabilities");
+        info!("[Reset] {summary}");
+        Ok(summary)
+    }
+}
+
 /// Performs graceful shutdown:
 /// 1. Drain in-flight proxy requests up to REQUEST_DRAIN_TIMEOUT_SECS
 /// 2. SIGTERM all managed (and detected) merod processes
@@ -4462,6 +4645,8 @@ fn main() {
             download_and_replace_merod,
             set_tray_icon_connected,
             delete_calimero_data_dir,
+            clear_app_sessions,
+            remove_app_launchers,
             kill_all_merod_processes,
             autostart_enable,
             autostart_disable,
@@ -4485,10 +4670,39 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::{
-        is_textual_content_type, merod_target_triple, parse_app_deep_link, score_merod_asset,
-        validate_allowed_url,
+        is_textual_content_type, launcher_bundle_is_removable, merod_target_triple,
+        parse_app_deep_link, score_merod_asset, validate_allowed_url,
     };
     use base64::Engine as _;
+    use std::path::Path;
+
+    #[test]
+    fn launcher_bundle_removal_is_confined_to_app_bundles_under_home() {
+        let home = Path::new("/Users/x");
+        assert!(launcher_bundle_is_removable(
+            Path::new("/Users/x/Applications/MeroDrive.app"),
+            home
+        ));
+
+        // Not a .app: a tampered caps.json must not delete a data directory.
+        assert!(!launcher_bundle_is_removable(
+            Path::new("/Users/x/Documents"),
+            home
+        ));
+        // Outside home.
+        assert!(!launcher_bundle_is_removable(
+            Path::new("/Applications/Safari.app"),
+            home
+        ));
+        // Traversal back out of home.
+        assert!(!launcher_bundle_is_removable(
+            Path::new("/Users/x/../../System/Library/CoreServices/Finder.app"),
+            home
+        ));
+        // Empty / relative paths.
+        assert!(!launcher_bundle_is_removable(Path::new(""), home));
+        assert!(!launcher_bundle_is_removable(Path::new("MeroDrive.app"), home));
+    }
 
     #[test]
     fn app_deep_link_custom_scheme() {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -32,7 +32,7 @@
   },
   "productName": "Calimero Desktop",
   "mainBinaryName": "Calimero Desktop",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "identifier": "network.calimero.desktop",
   "plugins": {
     "updater": {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -5,7 +5,13 @@ import { MeroContext, type MeroContextValue } from "@calimero-network/mero-react
 import { LoginView } from "./components/LoginView";
 import { getAccessToken, clearAccessToken, clearRefreshToken } from "./lib/token-storage";
 import { startTokenBroker } from "./lib/token-broker";
-import { getSettings, getAuthUrl, saveSettings } from "./utils/settings";
+import {
+  getSettings,
+  getAuthUrl,
+  saveSettings,
+  DEFAULT_EMBEDDED_NODE_PORT,
+  DEFAULT_EMBEDDED_SWARM_PORT,
+} from "./utils/settings";
 import { clearOnboardingProgress } from "./utils/onboardingProgress";
 import { startMerod, detectRunningMerodNodes, type RunningMerodNode } from "./utils/merod";
 import { useToast } from "./contexts/ToastContext";
@@ -195,8 +201,11 @@ function App() {
           runningNodes.length === 0
         ) {
           const dataDir = settings.embeddedNodeDataDir || '~/.calimero';
-          const serverPort = settings.embeddedNodePort ?? 2528;
-          const swarmPort = 2428; // default swarm port
+          const serverPort = settings.embeddedNodePort ?? DEFAULT_EMBEDDED_NODE_PORT;
+          // Must come from settings: start_merod rewrites config.toml with whatever it
+          // gets, so a hardcoded default here silently reverted a node the user had
+          // created on a different swarm port.
+          const swarmPort = settings.embeddedNodeSwarmPort ?? DEFAULT_EMBEDDED_SWARM_PORT;
           try {
             await startMerod(serverPort, swarmPort, dataDir, settings.embeddedNodeName, settings.debugLogs);
             await new Promise((r) => setTimeout(r, 4000)); // give merod time to start (longer when app launches at login)
@@ -380,8 +389,9 @@ function App() {
     if (settings.embeddedNodeName) {
       try {
         const dataDir = settings.embeddedNodeDataDir || '~/.calimero';
-        const serverPort = settings.embeddedNodePort ?? 2528;
-        await startMerod(serverPort, 2428, dataDir, settings.embeddedNodeName, settings.debugLogs);
+        const serverPort = settings.embeddedNodePort ?? DEFAULT_EMBEDDED_NODE_PORT;
+        const swarmPort = settings.embeddedNodeSwarmPort ?? DEFAULT_EMBEDDED_SWARM_PORT;
+        await startMerod(serverPort, swarmPort, dataDir, settings.embeddedNodeName, settings.debugLogs);
         toast.success("Starting node...");
         await new Promise((r) => setTimeout(r, 3000));
         await checkConnection();

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -2,9 +2,11 @@ import { useState, useEffect, useRef, useMemo } from "react";
 import { checkOnboardingState, getOnboardingMessage, type OnboardingState } from "../utils/onboarding";
 import { apiClient, createClientAsync } from "../lib/mero-client";
 import { LoginView } from "../components/LoginView";
-import { initMerodNode, startMerod, listMerodNodes, detectRunningMerodNodes, waitForNodeHealthy, stopMerod, killAllMerodProcesses, deleteCalimeroDataDir } from "../utils/merod";
+import { initMerodNode, startMerod, listMerodNodes, detectRunningMerodNodes, waitForNodeHealthy } from "../utils/merod";
 import { invoke } from "@tauri-apps/api/core";
-import { saveSettings, getSettings, getAuthUrl, clearAllAppData } from "../utils/settings";
+import { saveSettings, getSettings, getAuthUrl } from "../utils/settings";
+import { hardReset, wipeClientState } from "../utils/hardReset";
+import { parseTauriError } from "../utils/appUtils";
 import { setAccessToken, setRefreshToken, setTokenExpiresAt } from "../lib/token-storage";
 import { saveOnboardingProgress, loadOnboardingProgress } from "../utils/onboardingProgress";
 import { startCloudLogin } from "../utils/cloudAuth";
@@ -599,24 +601,19 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
     setCurrentStep('node-setup');
   };
 
-  // Hard reset: kill all merod processes, delete data dir, wipe all storage, reload
+  // Hard reset: kill all merod processes, delete data dirs, wipe all client state
+  // (this origin's storage, the webview's website data, launchers, cloud session).
   const handleNukeAll = async () => {
     setNuking(true);
     setShowFloatingMenu(false);
-    // 1. Graceful stop then force-kill
-    try { await stopMerod(); } catch { /* not tracked — ok */ }
-    try { await killAllMerodProcesses(); } catch { /* best-effort */ }
-    // 2. Wait for OS to release file handles
-    await new Promise((r) => setTimeout(r, 800));
-    // 3. Delete the data directory (settings path + default ~/.calimero)
-    const settingsDataDir = getSettings().embeddedNodeDataDir || '~/.calimero';
-    const dirsToDelete = [...new Set([settingsDataDir, '~/.calimero'])];
-    for (const dir of dirsToDelete) {
-      try { await deleteCalimeroDataDir(dir); } catch { /* dir may not exist */ }
+    try {
+      await hardReset();
+    } catch (err: unknown) {
+      // A data directory survived. This is the escape hatch from a broken state,
+      // so say what failed but still reset everything we can and come back fresh.
+      toast.error(parseTauriError(err));
+      await wipeClientState();
     }
-    // 4. Wipe all client-side state
-    clearAllAppData();
-    sessionStorage.clear();
     window.location.reload();
   };
 

--- a/apps/desktop/src/pages/Onboarding.tsx
+++ b/apps/desktop/src/pages/Onboarding.tsx
@@ -4,7 +4,13 @@ import { apiClient, createClientAsync } from "../lib/mero-client";
 import { LoginView } from "../components/LoginView";
 import { initMerodNode, startMerod, listMerodNodes, detectRunningMerodNodes, waitForNodeHealthy } from "../utils/merod";
 import { invoke } from "@tauri-apps/api/core";
-import { saveSettings, getSettings, getAuthUrl } from "../utils/settings";
+import {
+  saveSettings,
+  getSettings,
+  getAuthUrl,
+  DEFAULT_EMBEDDED_NODE_PORT,
+  DEFAULT_EMBEDDED_SWARM_PORT,
+} from "../utils/settings";
 import { hardReset, wipeClientState } from "../utils/hardReset";
 import { parseTauriError } from "../utils/appUtils";
 import { setAccessToken, setRefreshToken, setTokenExpiresAt } from "../lib/token-storage";
@@ -102,8 +108,8 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
   const [nodeName, setNodeName] = useState(() => loadOnboardingProgress()?.nodeName ?? "default");
   const [adminUser, setAdminUser] = useState("");
   const [adminPassword, setAdminPassword] = useState("");
-  const [serverPort, setServerPort] = useState(() => loadOnboardingProgress()?.serverPort ?? 2528);
-  const [swarmPort, setSwarmPort] = useState(() => loadOnboardingProgress()?.swarmPort ?? 2428);
+  const [serverPort, setServerPort] = useState(() => loadOnboardingProgress()?.serverPort ?? DEFAULT_EMBEDDED_NODE_PORT);
+  const [swarmPort, setSwarmPort] = useState(() => loadOnboardingProgress()?.swarmPort ?? DEFAULT_EMBEDDED_SWARM_PORT);
       const [creatingNode, setCreatingNode] = useState(false);
       const [nodeError, setNodeError] = useState<string | null>(null);
       const [nodeCreated, setNodeCreated] = useState(false);
@@ -189,6 +195,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
                 embeddedNodeDataDir: dataDir,
                 embeddedNodeName: nodeToUse,
                 embeddedNodePort: alreadyRunning.port,
+                embeddedNodeSwarmPort: alreadyRunning.swarm_port ?? swarmPort,
               });
             } else {
               await startMerod(serverPort, swarmPort, dataDir, nodeToUse, getSettings().debugLogs);
@@ -199,6 +206,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
                 embeddedNodeDataDir: dataDir,
                 embeddedNodeName: nodeToUse,
                 embeddedNodePort: serverPort,
+                embeddedNodeSwarmPort: swarmPort,
               });
             }
             setTheme('dark');
@@ -301,6 +309,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
         embeddedNodeDataDir: dataDir,
         embeddedNodeName: targetNodeName,
         embeddedNodePort: serverPort,
+        embeddedNodeSwarmPort: swarmPort,
       });
       await waitForNodeHealthy(`${nodeUrl}/auth`, 20000);
       const loggedIn = await attemptLogin(nodeUrl, username.trim(), password);
@@ -396,6 +405,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
             embeddedNodeDataDir: dataDir,
             embeddedNodeName: useExistingNode,
             embeddedNodePort: alreadyRunning.port,
+            embeddedNodeSwarmPort: alreadyRunning.swarm_port ?? swarmPort,
           });
           // check_merod_health appends /health — use /auth so it hits /auth/health
           await waitForNodeHealthy(`${nodeUrl}/auth`, 5000);
@@ -415,6 +425,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
           embeddedNodeDataDir: dataDir,
           embeddedNodeName: useExistingNode,
           embeddedNodePort: serverPort,
+          embeddedNodeSwarmPort: swarmPort,
         });
         // check_merod_health appends /health — use /auth so it hits /auth/health
         await waitForNodeHealthy(`${nodeUrl}/auth`, 20000);
@@ -445,6 +456,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
           embeddedNodeDataDir: dataDir,
           embeddedNodeName: targetNodeName,
           embeddedNodePort: serverPort,
+          embeddedNodeSwarmPort: swarmPort,
         });
         // check_merod_health appends /health — use /auth so it hits /auth/health
         await waitForNodeHealthy(`${nodeUrl}/auth`, 20000);
@@ -719,6 +731,7 @@ export default function Onboarding({ onComplete, onSettings }: OnboardingProps) 
           useEmbeddedNode: undefined,
           embeddedNodeName: undefined,
           embeddedNodePort: undefined,
+          embeddedNodeSwarmPort: undefined,
           embeddedNodeDataDir: undefined,
         });
         setState(null);

--- a/apps/desktop/src/pages/Settings.tsx
+++ b/apps/desktop/src/pages/Settings.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
-import { getSettings, saveSettings, clearAllAppData } from "../utils/settings";
+import { getSettings, saveSettings } from "../utils/settings";
 import { parseTauriError } from "../utils/appUtils";
 import { invoke } from "@tauri-apps/api/core";
-import { killAllMerodProcesses, deleteCalimeroDataDir, stopMerod, getMerodStatus } from "../utils/merod";
+import { killAllMerodProcesses, stopMerod } from "../utils/merod";
+import { hardReset, wipeClientState } from "../utils/hardReset";
 import { startCloudLogin, disconnectCloud } from "../utils/cloudAuth";
 import { getCloudSubscription, CloudSessionExpiredError } from "../utils/cloudApi";
 import { isCloudEnabled, notifyCloudEnabledChanged } from "../utils/featureFlags";
@@ -363,7 +364,9 @@ export default function Settings({ onBack }: SettingsProps) {
                           }
                           // Brief settle so OS releases file handles before reload
                           await new Promise((r) => setTimeout(r, 500));
-                          clearAllAppData();
+                          // Wipes this origin's storage AND the webview's website data,
+                          // so app windows don't keep a session the reset just revoked.
+                          await wipeClientState();
                           window.location.reload();
                         }}
                         className="button button-danger"
@@ -421,59 +424,16 @@ export default function Settings({ onBack }: SettingsProps) {
                         onClick={async () => {
                           if (!nukeConfirmed) return;
                           setNuking(true);
-
-                          // Step 1: graceful stop of the embedded node
-                          setNukeStatus('Stopping nodes...');
                           try {
-                            await stopMerod();
-                          } catch {
-                            // not running — ok
-                          }
-
-                          // Step 2: force-kill any remaining merod processes
-                          try {
-                            await killAllMerodProcesses();
+                            await hardReset({ onStatus: setNukeStatus });
                           } catch (err: unknown) {
+                            // A data directory survived; nothing was cleared, so the
+                            // user can read the error and retry from the same state.
                             toast.error(parseTauriError(err));
                             setNuking(false);
                             setNukeStatus('');
                             return;
                           }
-
-                          // Step 3: wait until the embedded node reports stopped (max 10s)
-                          setNukeStatus('Waiting for nodes to stop...');
-                          const deadline = Date.now() + 10_000;
-                          while (Date.now() < deadline) {
-                            try {
-                              const status = await getMerodStatus();
-                              if (!status.running) break;
-                            } catch {
-                              break; // process gone — treat as stopped
-                            }
-                            await new Promise((r) => setTimeout(r, 500));
-                          }
-
-                          // Step 4: brief OS-level settle so file handles are released
-                          await new Promise((r) => setTimeout(r, 500));
-
-                          // Step 5: delete both the settings path and default ~/.calimero.
-                          // After clearAllAppData(), onboarding uses ~/.calimero, so we must remove it.
-                          setNukeStatus('Deleting...');
-                          const settingsDataDir = getSettings().embeddedNodeDataDir || "~/.calimero";
-                          const defaultDataDir = "~/.calimero";
-                          const dirsToDelete = [...new Set([settingsDataDir, defaultDataDir])];
-                          try {
-                            for (const dir of dirsToDelete) {
-                              await deleteCalimeroDataDir(dir);
-                            }
-                          } catch (err: unknown) {
-                            toast.error(parseTauriError(err));
-                            setNuking(false);
-                            setNukeStatus('');
-                            return;
-                          }
-
-                          clearAllAppData();
                           window.location.reload();
                         }}
                         className="button button-danger"

--- a/apps/desktop/src/utils/hardReset.test.ts
+++ b/apps/desktop/src/utils/hardReset.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const invoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
+
+const stopMerod = vi.fn();
+const killAllMerodProcesses = vi.fn();
+const getMerodStatus = vi.fn();
+const deleteCalimeroDataDir = vi.fn();
+vi.mock('./merod', () => ({
+  stopMerod: (...a: unknown[]) => stopMerod(...a),
+  killAllMerodProcesses: (...a: unknown[]) => killAllMerodProcesses(...a),
+  getMerodStatus: (...a: unknown[]) => getMerodStatus(...a),
+  deleteCalimeroDataDir: (...a: unknown[]) => deleteCalimeroDataDir(...a),
+}));
+
+const revokeMdmaSession = vi.fn();
+vi.mock('./cloudAuth', () => ({
+  revokeMdmaSession: (...a: unknown[]) => revokeMdmaSession(...a),
+}));
+
+// getSettings is stubbed, but clearAllAppData is the REAL one: that it clears the
+// whole storage silo (not a stale allowlist of keys) is part of what's under test.
+let settings: Record<string, unknown> = {};
+vi.mock('./settings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./settings')>()),
+  getSettings: () => settings,
+}));
+
+/** Minimal in-memory Storage for the node test environment. */
+function fakeStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    key: (i: number) => [...map.keys()][i] ?? null,
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, String(v)),
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => map.clear(),
+  } as Storage;
+}
+
+import { hardReset, wipeClientState } from './hardReset';
+
+const CLOUD_TOKEN = 'the-mdma-session-token';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  globalThis.localStorage = fakeStorage();
+  globalThis.sessionStorage = fakeStorage();
+  settings = { cloudIdToken: CLOUD_TOKEN, embeddedNodeDataDir: '~/.calimero' };
+  getMerodStatus.mockResolvedValue({ running: false });
+  deleteCalimeroDataDir.mockResolvedValue('Deleted');
+  invoke.mockResolvedValue('ok');
+});
+
+/** Order of the native reset commands the run invoked. */
+function nativeCalls(): string[] {
+  return invoke.mock.calls.map((c) => c[0] as string);
+}
+
+describe('hardReset', () => {
+  it('clears the webview session data, not just the data directory', async () => {
+    await hardReset();
+
+    // The regression: deleting ~/.calimero left every app origin's localStorage
+    // (and its access token) on disk, so reopening an app resumed the session.
+    expect(invoke).toHaveBeenCalledWith('clear_app_sessions');
+  });
+
+  it('removes the launchers, and only after the shells running from them are killed', async () => {
+    await hardReset();
+
+    // The apps the launchers point at lived in the deleted data dir, and their
+    // capability tokens would otherwise keep brokering fresh tokens.
+    expect(nativeCalls()).toEqual(['clear_app_sessions', 'remove_app_launchers']);
+  });
+
+  it('deletes the configured data dir and the default one, deduped', async () => {
+    settings = { embeddedNodeDataDir: '~/custom-node' };
+
+    await hardReset();
+
+    expect(deleteCalimeroDataDir.mock.calls.map((c) => c[0])).toEqual([
+      '~/custom-node',
+      '~/.calimero',
+    ]);
+  });
+
+  it('does not delete the default dir twice when it is the configured one', async () => {
+    await hardReset();
+
+    expect(deleteCalimeroDataDir.mock.calls.map((c) => c[0])).toEqual(['~/.calimero']);
+  });
+
+  it('revokes the cloud session server-side before dropping the token', async () => {
+    await hardReset();
+
+    expect(revokeMdmaSession).toHaveBeenCalledWith(CLOUD_TOKEN);
+  });
+
+  it('wipes every localStorage key, including ones no allowlist knew about', async () => {
+    localStorage.setItem('calimero-desktop-settings', '{}');
+    localStorage.setItem('calimero-context-keys', '{}');
+    localStorage.setItem('calimero_oauth_pending_state', '{}');
+    localStorage.setItem('calimero_access_token', 'at');
+    sessionStorage.setItem('anything', 'x');
+
+    await hardReset();
+
+    expect(localStorage.length).toBe(0);
+    expect(sessionStorage.length).toBe(0);
+  });
+
+  it('keeps going when the node refuses to stop — the delete is the real test', async () => {
+    stopMerod.mockRejectedValue(new Error('not running'));
+    killAllMerodProcesses.mockRejectedValue(new Error('kill failed'));
+
+    await hardReset();
+
+    expect(deleteCalimeroDataDir).toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledWith('clear_app_sessions');
+  });
+
+  it('leaves client state untouched when a data dir survives, so the user can retry', async () => {
+    localStorage.setItem('calimero-desktop-settings', '{}');
+    deleteCalimeroDataDir.mockRejectedValue(new Error('Failed to delete directory'));
+
+    await expect(hardReset()).rejects.toThrow('Failed to delete directory');
+
+    expect(localStorage.getItem('calimero-desktop-settings')).toBe('{}');
+    expect(invoke).not.toHaveBeenCalled();
+    expect(revokeMdmaSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('wipeClientState', () => {
+  it('still clears local storage when the native reset fails', async () => {
+    localStorage.setItem('calimero-desktop-settings', '{}');
+    invoke.mockRejectedValue(new Error('main window is gone'));
+
+    await expect(wipeClientState()).resolves.toBe(false);
+
+    expect(localStorage.length).toBe(0);
+  });
+
+  it('keeps the launchers unless asked to remove them (the softer reset)', async () => {
+    await expect(wipeClientState()).resolves.toBe(true);
+
+    // A launcher is a dock icon the user placed; "reset settings" must not bin it.
+    expect(nativeCalls()).toEqual(['clear_app_sessions']);
+  });
+});

--- a/apps/desktop/src/utils/hardReset.ts
+++ b/apps/desktop/src/utils/hardReset.ts
@@ -1,0 +1,146 @@
+/**
+ * The one implementation of "total nuke": delete everything this desktop owns and
+ * come back up as a fresh install.
+ *
+ * Settings and Onboarding used to carry their own copies of this sequence, which
+ * had already drifted (only one of them cleared sessionStorage) and both stopped
+ * at the merod data directory. Deleting that directory is only half a reset —
+ * the session lives outside it:
+ *
+ * - Every app frontend runs in its own web origin, so the access token handed to
+ *   it in the SSO hash is persisted by its own MeroJs, in the webview's on-disk
+ *   website-data store. The desktop's `localStorage.clear()` cannot touch another
+ *   origin's silo, so reopening an app after a "reset" resumed the old session.
+ *   Clearing that store is what `clear_app_sessions` does natively.
+ * - The Cloud session is a server-side 7-day session; dropping our copy of the
+ *   token leaves it alive and replayable until it expires.
+ * - Per-app launchers keep working (and keep getting tokens brokered) off a
+ *   capability store that outlives the data directory — `remove_app_launchers`.
+ */
+import { invoke } from '@tauri-apps/api/core';
+import {
+  stopMerod,
+  killAllMerodProcesses,
+  getMerodStatus,
+  deleteCalimeroDataDir,
+} from './merod';
+import { getSettings, clearAllAppData } from './settings';
+import { revokeMdmaSession } from './cloudAuth';
+
+const DEFAULT_DATA_DIR = '~/.calimero';
+
+/** How long to wait for the embedded node to report stopped before moving on. */
+const NODE_STOP_TIMEOUT_MS = 10_000;
+const NODE_STOP_POLL_MS = 500;
+/** OS-level settle so merod's file handles are released before the delete. */
+const FILE_HANDLE_SETTLE_MS = 500;
+
+export interface HardResetOptions {
+  /** Progress text for the button label ("Stopping nodes...", "Deleting...", …). */
+  onStatus?: (status: string) => void;
+}
+
+export interface WipeClientStateOptions {
+  /**
+   * Also delete the per-app launchers, their capability store and the extracted
+   * shell binary. Total-nuke only — a launcher is a dock icon the user placed,
+   * so the softer "reset settings" leaves them in place.
+   */
+  removeLaunchers?: boolean;
+}
+
+/**
+ * Wipe client-side state: the Cloud session, this origin's storage, and every app
+ * session (open app windows, running launcher shells, and the webview's on-disk
+ * website data for all app origins).
+ *
+ * Best-effort and never throws — it also runs on the failure path of
+ * `hardReset()`, where the point is to reset as much as possible. Returns false
+ * if a native step failed, which means app sessions may have survived.
+ */
+export async function wipeClientState({
+  removeLaunchers = false,
+}: WipeClientStateOptions = {}): Promise<boolean> {
+  // Revoke the Cloud session while we still hold the token to address it with.
+  // Fire-and-forget by design; see revokeMdmaSession.
+  try {
+    revokeMdmaSession(getSettings().cloudIdToken);
+  } catch (err) {
+    console.warn('[hardReset] cloud session revocation failed:', err);
+  }
+
+  clearAllAppData();
+
+  let ok = true;
+  // Sessions first: this kills the shells that run out of the launcher bundles.
+  try {
+    await invoke<string>('clear_app_sessions');
+  } catch (err) {
+    console.error('[hardReset] clear_app_sessions failed:', err);
+    ok = false;
+  }
+  if (removeLaunchers) {
+    try {
+      await invoke<string>('remove_app_launchers');
+    } catch (err) {
+      console.error('[hardReset] remove_app_launchers failed:', err);
+      ok = false;
+    }
+  }
+  return ok;
+}
+
+/**
+ * Full reset: stop and kill every node, delete the data directories, then wipe
+ * all client state. The caller reloads the window afterwards.
+ *
+ * Throws if a data directory could not be deleted, *before* any client state is
+ * touched — a half-deleted node plus a fresh-looking app is worse than a clean
+ * failure the user can retry. On that path the caller may still call
+ * `wipeClientState()` explicitly. Failing to stop a node is not fatal: the
+ * delete that follows is the real test, and it reports its own failure.
+ */
+export async function hardReset({ onStatus }: HardResetOptions = {}): Promise<void> {
+  // 1. Graceful stop of the embedded node.
+  onStatus?.('Stopping nodes...');
+  try {
+    await stopMerod();
+  } catch {
+    // not running — ok
+  }
+
+  // 2. Force-kill any remaining merod process, so nothing holds the data dir open.
+  try {
+    await killAllMerodProcesses();
+  } catch (err) {
+    console.warn('[hardReset] killAllMerodProcesses failed, continuing:', err);
+  }
+
+  // 3. Wait until the embedded node actually reports stopped.
+  onStatus?.('Waiting for nodes to stop...');
+  const deadline = Date.now() + NODE_STOP_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const status = await getMerodStatus();
+      if (!status.running) break;
+    } catch {
+      break; // process gone — treat as stopped
+    }
+    await new Promise((r) => setTimeout(r, NODE_STOP_POLL_MS));
+  }
+  await new Promise((r) => setTimeout(r, FILE_HANDLE_SETTLE_MS));
+
+  // 4. Delete the configured data dir AND the default one: after the reset,
+  //    onboarding starts from ~/.calimero regardless of what was configured.
+  onStatus?.('Deleting...');
+  const settingsDataDir = getSettings().embeddedNodeDataDir || DEFAULT_DATA_DIR;
+  const dirsToDelete = [...new Set([settingsDataDir, DEFAULT_DATA_DIR])];
+  for (const dir of dirsToDelete) {
+    await deleteCalimeroDataDir(dir);
+  }
+
+  // 5. Only now discard the client state — including the settings that told us
+  //    which directories to delete. The launchers go too: the apps they point at
+  //    lived in the data directory we just deleted.
+  await wipeClientState({ removeLaunchers: true });
+}

--- a/apps/desktop/src/utils/onboardingProgress.ts
+++ b/apps/desktop/src/utils/onboardingProgress.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_EMBEDDED_NODE_PORT, DEFAULT_EMBEDDED_SWARM_PORT } from './settings';
+
 const ONBOARDING_PROGRESS_KEY = 'calimero-onboarding-progress';
 
 export type OnboardingStep = 'welcome' | 'what-is' | 'node-setup' | 'cloud-connect' | 'login' | 'install-app';
@@ -19,8 +21,8 @@ const DEFAULT_PROGRESS: Omit<OnboardingProgress, 'savedAt'> = {
   currentStep: 'welcome',
   dataDir: '~/.calimero',
   nodeName: 'default',
-  serverPort: 2528,
-  swarmPort: 2428,
+  serverPort: DEFAULT_EMBEDDED_NODE_PORT,
+  swarmPort: DEFAULT_EMBEDDED_SWARM_PORT,
   nodeSetupMode: 'choose',
   useExistingNode: null,
 };

--- a/apps/desktop/src/utils/settings.test.ts
+++ b/apps/desktop/src/utils/settings.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+/** Minimal in-memory Storage for the node test environment. */
+function fakeStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    key: (i: number) => [...map.keys()][i] ?? null,
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, String(v)),
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => map.clear(),
+  } as Storage;
+}
+
+beforeEach(() => {
+  globalThis.localStorage = fakeStorage();
+  globalThis.sessionStorage = fakeStorage();
+});
+
+import {
+  getSettings,
+  saveSettings,
+  clearAllAppData,
+  DEFAULT_EMBEDDED_NODE_PORT,
+  DEFAULT_EMBEDDED_SWARM_PORT,
+} from './settings';
+
+describe('embedded node ports', () => {
+  it('round-trips the swarm port so autostart cannot revert it', () => {
+    // The bug: only the server port was persisted, so App.tsx's autostart fell back
+    // to a hardcoded 2428 and start_merod rewrote config.toml with it — silently
+    // undoing a node the user had created on another swarm port.
+    saveSettings({
+      nodeUrl: 'http://localhost:2529',
+      embeddedNodePort: 2529,
+      embeddedNodeSwarmPort: 2429,
+    });
+
+    const settings = getSettings();
+    expect(settings.embeddedNodePort).toBe(2529);
+    expect(settings.embeddedNodeSwarmPort).toBe(2429);
+  });
+
+  it('leaves both ports undefined when unset, so callers apply the shared defaults', () => {
+    saveSettings({ nodeUrl: 'http://localhost:2528' });
+
+    const settings = getSettings();
+    expect(settings.embeddedNodePort).toBeUndefined();
+    expect(settings.embeddedNodeSwarmPort).toBeUndefined();
+    expect(settings.embeddedNodePort ?? DEFAULT_EMBEDDED_NODE_PORT).toBe(2528);
+    expect(settings.embeddedNodeSwarmPort ?? DEFAULT_EMBEDDED_SWARM_PORT).toBe(2428);
+  });
+});
+
+describe('clearAllAppData', () => {
+  it('clears the whole silo, not a fixed list of keys', () => {
+    localStorage.setItem('calimero-desktop-settings', '{}');
+    localStorage.setItem('calimero-context-keys', '{}');
+    localStorage.setItem('calimero_oauth_pending_state', '{}');
+    localStorage.setItem('some-key-added-next-year', 'x');
+    sessionStorage.setItem('anything', 'x');
+
+    clearAllAppData();
+
+    expect(localStorage.length).toBe(0);
+    expect(sessionStorage.length).toBe(0);
+  });
+});

--- a/apps/desktop/src/utils/settings.ts
+++ b/apps/desktop/src/utils/settings.ts
@@ -5,7 +5,8 @@ export interface AppSettings {
   authUrl?: string; // Optional, defaults to nodeUrl if not set
   registries?: string[]; // Array of registry URLs
   useEmbeddedNode?: boolean; // Use embedded merod node
-  embeddedNodePort?: number; // Port for embedded node (default: 2528)
+  embeddedNodePort?: number; // Port for embedded node (default: DEFAULT_EMBEDDED_NODE_PORT)
+  embeddedNodeSwarmPort?: number; // libp2p swarm port for embedded node (default: DEFAULT_EMBEDDED_SWARM_PORT)
   embeddedNodeDataDir?: string; // Data directory for embedded node (default: ~/.calimero)
   embeddedNodeName?: string; // Node name for embedded node
   developerMode?: boolean; // Developer mode - shows advanced features like multiple nodes and contexts
@@ -21,6 +22,14 @@ export interface AppSettings {
 
 const SETTINGS_KEY = 'calimero-desktop-settings';
 const DEFAULT_NODE_URL = 'http://localhost:2528';
+
+/** Embedded-node ports. Both are user-configurable in onboarding and persisted here:
+ *  the swarm port used to be a hardcoded 2428 at every start site, so a node created
+ *  on a different swarm port had its config.toml rewritten back to 2428 on the next
+ *  autostart — and anything else holding 2428 made the node unstartable with no way
+ *  out from the UI. */
+export const DEFAULT_EMBEDDED_NODE_PORT = 2528;
+export const DEFAULT_EMBEDDED_SWARM_PORT = 2428;
 const DEFAULT_REGISTRY_URL = 'https://apps.calimero.network/';
 const OLD_DEFAULT_REGISTRY_URL = 'http://localhost:8080';
 
@@ -83,6 +92,7 @@ export function getSettings(): AppSettings {
         registries: migratedRegistries,
         useEmbeddedNode: rawSettings.useEmbeddedNode,
         embeddedNodePort: rawSettings.embeddedNodePort,
+        embeddedNodeSwarmPort: rawSettings.embeddedNodeSwarmPort,
         embeddedNodeDataDir: rawSettings.embeddedNodeDataDir,
         embeddedNodeName: rawSettings.embeddedNodeName,
         developerMode: rawSettings.developerMode ?? false, // Default to false

--- a/apps/desktop/src/utils/settings.ts
+++ b/apps/desktop/src/utils/settings.ts
@@ -128,27 +128,25 @@ export function clearSettings(): void {
   localStorage.removeItem(SETTINGS_KEY);
 }
 
-const THEME_KEY = 'calimero-desktop-theme';
-
 /**
- * Clear all app data (settings + theme + onboarding progress + cache + session tokens).
+ * Clear all app data for this origin: settings, theme, onboarding progress, caches,
+ * session tokens, context keys, pending OAuth state — everything.
  * Use with stopMerod() for full reset. Caller should reload the app after this.
+ *
+ * Deliberately `clear()` rather than an allowlist of keys: the allowlist version of
+ * this function silently missed every key added after it was written (context keys,
+ * the pending OAuth nonce), so a "reset" kept state it promised to delete. Nothing
+ * in this origin's localStorage is worth preserving across a reset.
  *
  * Note: localStorage is partitioned per web origin, so this only clears the silo of the
  * origin it runs in. Loaded app UIs served from other origins (each node URL is a distinct
- * origin) keep their own tokens — wiping those requires clearing WebsiteData on disk.
+ * origin) keep their own tokens — wiping those needs the `clear_app_sessions` command,
+ * which clears the webview's on-disk website data. See utils/hardReset.ts.
  */
 export function clearAllAppData(): void {
-  localStorage.removeItem(SETTINGS_KEY);
-  localStorage.removeItem(THEME_KEY);
-  localStorage.removeItem('calimero-onboarding-progress');
-  localStorage.removeItem('calimero-autostart-default-applied');
-  localStorage.removeItem('calimero-marketplace-cache');
-  localStorage.removeItem('calimero-error-log');
-  // Session tokens were left behind on reset, so a "reset" still resumed the old
-  // authenticated session against the node. Clear them too.
-  localStorage.removeItem('calimero-auth-tokens');
   clearAllTokens();
+  localStorage.clear();
+  sessionStorage.clear();
 }
 
 


### PR DESCRIPTION
## The bug

"Delete everything and reset" wiped the merod data directory and a hand-written allowlist of `localStorage` keys in the desktop's own origin — and nothing else. The session lives outside both, so a nuke left the user logged in.

- **Every app frontend is its own web origin.** The access token we hand it in the SSO hash (`appUtils.ts`) is persisted by its own MeroJs into the webview's on-disk website-data store (`~/Library/WebKit/network.calimero.desktop/WebsiteData/LocalStorage`). `localStorage.removeItem` from the desktop origin cannot reach another origin's silo, so reopening an app after a "reset" resumed the old authenticated session. Nothing in the codebase cleared that store — only `uninstall-mac.sh` did.
- **Open app windows and running launcher shells** held live sessions of their own. `kill_all_merod_processes` only matched `merod … run`, so the shells survived the nuke and the reload.
- **Per-app launchers survived** with their capability tokens in `caps.json`, so a launcher built before the reset still got tokens brokered over the host socket, and the dock kept icons for apps that no longer existed.
- **The Cloud session** is a 7-day server-side session; dropping our copy of the token left it alive and replayable (`revokeMdmaSession` existed but only `disconnectCloud` called it).
- **The key allowlist had drifted**, silently missing `calimero-context-keys` and `calimero_oauth_pending_state`.

## The fix

Two new native commands do the parts only Rust can:

- **`clear_app_sessions`** — close `app-*` windows → kill the launcher shells → delete their own website-data store → `clear_all_browsing_data()` on the main window, which wipes localStorage, cookies, IndexedDB and caches for *every* origin the host has loaded. Windows and shells go first on purpose: a live webview re-flushes its localStorage on close, which would undo the wipe behind us. Failure is surfaced, not swallowed, so the user learns their sessions may persist.
- **`remove_app_launchers`** — the generated `.app` bundles (guarded to `.app` dirs under `$HOME`, since `caps.json` is plain JSON on disk), `caps.json`, the `CapRegistry`, and the extracted shell binary. Nuke-only: a launcher is a dock icon the user placed, so the softer "reset settings" leaves it alone.

`clearAllAppData()` now clears the whole silo (`localStorage.clear()` + `sessionStorage.clear()`) instead of enumerating keys.

Settings and Onboarding each carried their own copy of the nuke sequence and had already diverged — only one cleared `sessionStorage`. Both now call one `hardReset()` in `utils/hardReset.ts`, which also revokes the Cloud session while the token is still there to address it with. A data directory that can't be deleted still aborts before any client state is touched, so a failed nuke stays retryable.

Also bumps the app to 0.0.75 so this ships (bundled merod stays at 0.11.0-rc.18).

## Test plan

- `cargo test` — 44 pass, including a 5-case test that launcher removal is confined to `.app` bundles under `$HOME` (rejects non-`.app` paths, paths outside home, and `..` traversal).
- `pnpm test:unit` — 120 pass, 10 new in `hardReset.test.ts`: the session wipe happens at all, launchers are removed only after the shells are killed, the cloud session is revoked, every localStorage key goes (including ones no allowlist knew about), the softer reset keeps launchers, and a surviving data dir leaves client state intact.
- `tsc` + `vite build` clean; `cargo check` clean on both binaries.
- **Not yet verified by hand:** that `clear_all_browsing_data()` actually empties `WebsiteData/LocalStorage` in a running build. wry implements it as `WKWebsiteDataStore.removeDataOfTypes(allWebsiteDataTypes, since: epoch)` on the shared default store, so it should clear all origin silos, but worth one manual nuke before tagging: install an app, open it, nuke, reopen the app, confirm it asks for login instead of resuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR: the embedded node's swarm port is now persisted

Found while verifying the nuke on a real build — the node wouldn't start afterwards, and the reason turned out to be a second bug in the same area.

Onboarding lets you pick a swarm port under advanced options, but it was only ever handed to that one `start_merod` call — never saved to settings. Every other start site hardcoded `2428`:

- `App.tsx`'s autostart and `handleRestartNode` both passed a literal `2428`, and `start_merod` **rewrites `config.toml`** with whatever it receives. A node created on 2429 was silently reverted to 2428 on the next launch.
- With anything else holding 2428, the node couldn't start at all and there was no way out from the UI: the server port is configurable, the swarm port wasn't. The symptom is indirect — merod exits 1 with `Address already in use`, and if the squatter accepts TCP connections without serving them (a leaked Docker port-publish, in my case), onboarding's `/auth` health poll hangs rather than reporting a port conflict. That's what "stuck on setup auth" was.

`embeddedNodeSwarmPort` is now part of `AppSettings`, saved at every onboarding site that already saved `embeddedNodePort` (adopting an already-running node takes its reported `swarm_port`), cleared alongside it on "back to node setup", and read by both `App.tsx` start sites. The scattered `2528`/`2428` literals became `DEFAULT_EMBEDDED_NODE_PORT` / `DEFAULT_EMBEDDED_SWARM_PORT` in `settings.ts`, shared with `onboardingProgress` and `Onboarding`.

`Nodes.tsx` / `NodeManagement.tsx` keep their own per-node port inputs — those are developer-mode, multi-node flows and out of scope here.

New `settings.test.ts` covers the swarm-port round-trip, the both-undefined default case, and that `clearAllAppData` clears the whole silo.

## Manual verification (added after review of the first commit)

Ran the real dev build and clicked through the nuke. Both native commands succeeded — `[Reset] Cleared app sessions: launcher website data, webview session data` — and the on-disk store went from **4 origin entries with 2 files containing `calimero_access_token`/`calimero_refresh_token`** to **1 entry with zero token hits**, with the `shell` install dir removed. The session wipe is confirmed on macOS, not just reasoned about.