### PR TITLE
fix(shell): native notifications deliver from per-app launchers (bundle-id attribution)

### DIFF
--- a/apps/desktop/src-tauri/calimero-shell/src/main.rs
+++ b/apps/desktop/src-tauri/calimero-shell/src/main.rs
@@ -17,6 +17,81 @@ mod shell {
     // MUST match BROKERED_REFRESH_TOKEN in src/lib/token-broker.ts + proxy_script.js.
     const BROKERED_REFRESH_TOKEN: &str = "calimero-desktop-brokered-refresh-token";
 
+    /// macOS notification attribution fix.
+    ///
+    /// This shell process runs from a *loose* Mach-O binary
+    /// (`~/Library/Application Support/network.calimero.desktop/shell/CalimeroShell`)
+    /// that a per-app launcher `.app` `exec`s via a bash trampoline. Because the
+    /// running executable has no `.app` wrapper (and no embedded Info.plist),
+    /// `-[NSBundle mainBundle].bundleIdentifier` resolves to `nil`, and both
+    /// `NSUserNotification` and `UNUserNotificationCenter` refuse to deliver a
+    /// notification with no owning bundle — it silently drops.
+    ///
+    /// The launcher `.app` itself *is* LaunchServices-registered at
+    /// `~/Applications/<Name>.app` with `CFBundleIdentifier =
+    /// network.calimero.app.<id>`. So we swizzle `-[NSBundle bundleIdentifier]`
+    /// on the main bundle to claim that registered id (the standard CLI-tool
+    /// trick used by terminal-notifier / node-notifier). After this, macOS
+    /// attributes the notification to the per-app launcher — NOT the host.
+    #[cfg(target_os = "macos")]
+    mod bundle_identity {
+        use cocoa::base::{id, nil};
+        use cocoa::foundation::NSString;
+        use objc::runtime::{Class, Imp, Method, Object, Sel};
+        use objc::{class, msg_send, sel, sel_impl};
+        use std::sync::OnceLock;
+
+        static OVERRIDE_ID: OnceLock<String> = OnceLock::new();
+
+        // Replacement IMP for `-[NSBundle bundleIdentifier]`. Only overrides the
+        // *main* bundle; every other NSBundle keeps its real identifier (which,
+        // after the swizzle, is reachable under `calimeroOriginalBundleIdentifier`).
+        extern "C" fn override_bundle_identifier(this: &Object, _cmd: Sel) -> id {
+            unsafe {
+                let main: id = msg_send![class!(NSBundle), mainBundle];
+                let this_ptr = this as *const Object as id;
+                if this_ptr == main {
+                    if let Some(s) = OVERRIDE_ID.get() {
+                        return NSString::alloc(nil).init_str(s);
+                    }
+                }
+                msg_send![this, calimeroOriginalBundleIdentifier]
+            }
+        }
+
+        /// Install the override. Idempotent-ish: only the first call wins (guarded
+        /// by `OVERRIDE_ID`). Must run before the first notification is posted.
+        pub fn install(bundle_id: &str) {
+            if OVERRIDE_ID.set(bundle_id.to_string()).is_err() {
+                return; // already installed
+            }
+            unsafe {
+                let cls = class!(NSBundle);
+                let cls_mut = cls as *const Class as *mut Class;
+                let alias_sel = sel!(calimeroOriginalBundleIdentifier);
+                let imp: Imp = std::mem::transmute(
+                    override_bundle_identifier as extern "C" fn(&Object, Sel) -> id,
+                );
+                let types = b"@@:\0".as_ptr() as *const std::os::raw::c_char;
+                // Register our IMP under an alias selector, then swap it with the
+                // real `bundleIdentifier`. After the swap: `bundleIdentifier` runs
+                // our IMP; `calimeroOriginalBundleIdentifier` runs the original.
+                let added = objc::runtime::class_addMethod(cls_mut, alias_sel, imp, types);
+                if added == objc::runtime::NO {
+                    return;
+                }
+                let orig = objc::runtime::class_getInstanceMethod(cls, sel!(bundleIdentifier))
+                    as *mut Method;
+                let alias =
+                    objc::runtime::class_getInstanceMethod(cls, alias_sel) as *mut Method;
+                if orig.is_null() || alias.is_null() {
+                    return;
+                }
+                objc::runtime::method_exchangeImplementations(orig, alias);
+            }
+        }
+    }
+
     /// The shell's refresh broker: reads the managed `ShellConfig`, ensures the host
     /// is running, then relays a refresh over the Unix socket. Returns a fresh
     /// access token only — never a refresh token.
@@ -122,6 +197,12 @@ mod shell {
         let cfg = shell_config::parse_app_config_arg(&args)
             .and_then(|p| shell_config::load_shell_config(&p))
             .expect("calimero-shell requires --app-config <app.json>");
+
+        // Claim the per-app launcher's registered bundle id BEFORE any notify, so
+        // macOS attributes native notifications to the launcher `.app` (its icon +
+        // name) and not to nil/host. Mirrors `CFBundleIdentifier` in launcher.rs.
+        #[cfg(target_os = "macos")]
+        bundle_identity::install(&format!("network.calimero.app.{}", cfg.id));
 
         let cfg_for_setup = cfg.clone();
         tauri::Builder::default()


### PR DESCRIPTION
## Problem
Native notifications from a per-app launcher never delivered on a **fresh install**. The launcher `.app` runs a bash trampoline that `exec`s the shared, loose `CalimeroShell` binary, so the running process has **no valid main-bundle identifier** — macOS drops `NSUserNotification` from a process with no owning bundle, and the launcher never even registers in Notification Center.

## Fix
At shell startup, swizzle `-[NSBundle mainBundle].bundleIdentifier` to claim the launcher's LaunchServices-registered id (`network.calimero.app.<id>`, from `ShellConfig.id`) — the standard CLI-notification trick. Only the main bundle is overridden; the original stays reachable under an alias selector. No host-forward, no signing change.

## Result (verified live on macOS 15 Sequoia)
- The fresh launcher bundle now **registers** in Notification Center (it never did before).
- Notifications **deliver a real banner** — confirmed visually + in Notification Center (a screenshot showed two delivered test notifications).
- They're **attributed to the per-app launcher**, showing the app's own icon/name — not the host. (Contradicts the spec's claim that per-app attribution needs signed `.app` bundles.)

## Verification note
Automated log/DB checks are unreliable here: the notification DB is TCC-protected and unified-log strings are redacted `<private>`, so `grep`-for-title reads 0 even on successful delivery. Ground truth is the on-screen banner / Notification Center.

Delivery still requires the app to be **allowed** in System Settings (standard macOS notification permission) — the swizzle is what makes it appear there to be allowed.